### PR TITLE
Add specification of the working directory

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -37,13 +37,18 @@ jobs:
           credentials: ${{ secrets.GKE_SERVICE_ACC_KEY }}
     
       - name: Change the service images to most recent ones
+        # Set the working directory
+        working-directory: ./K8s-dev-cluster
         run: |
-          cd K8s-dev-cluster   # Go to directory with kustomization.yaml
           kustomize edit set image context-box:${{ steps.get_persistent_value.outputs.value }}
           kustomize edit set image scheduler:${{ steps.get_persistent_value.outputs.value }}
           kustomize edit set image builder:${{ steps.get_persistent_value.outputs.value }}
           kustomize edit set image terraformer:${{ steps.get_persistent_value.outputs.value }}
           kustomize edit set image wireguardian:${{ steps.get_persistent_value.outputs.value }}
           kustomize edit set image kube-eleven:${{ steps.get_persistent_value.outputs.value }}
+
+          cat kustomization.yaml
       - name: Deploy to the dev cluster via kustomize
+        # Set the working directory
+        working-directory: ./K8s-dev-cluster
         run: kustomize build | kubectl apply -f -


### PR DESCRIPTION
The steps always start in a root directory of the project. Every
step has to specify if the working directory should be different
from the default one. This caused an error in the deployment step
of the workflow. Setting the `working-directory` at the start of the
step should solve this issue.

@MarioUhrik @bernardhalas @samuelstolicny 