### PR TITLE
Feature/rename workflow

### DIFF
--- a/.github/workflows/GCR-cleanup.yml
+++ b/.github/workflows/GCR-cleanup.yml
@@ -19,7 +19,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Clean up the GCR
         run: |
-          SERVICES=( ${{ env.SERVICES }})
+          SERVICES=(${{ env.SERVICES }})
           NUMBER_OF_RETAINED=10
           
           # Loop through the services


### PR DESCRIPTION
This feature branch will fix 2 issues:
- The name of the `GCR-cleanup` workflow was incorrect
- Add `{{$<> }}` to `env.SERVICES` -> the issue was found after the test run, which was possible only on the master branch due to the nature of scheduled workflows.

I apologize for the inconvenience
@MarioUhrik @samuelstolicny @bernardhalas 