### PR TITLE
Issue #31, task 1

### DIFF
--- a/K8s-dev-cluster/builder.yaml
+++ b/K8s-dev-cluster/builder.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: builder
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: builder

--- a/K8s-dev-cluster/kube-eleven.yaml
+++ b/K8s-dev-cluster/kube-eleven.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: kube-eleven
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: kube-eleven

--- a/K8s-dev-cluster/scheduler.yaml
+++ b/K8s-dev-cluster/scheduler.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: scheduler
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: scheduler

--- a/K8s-dev-cluster/terraformer.yaml
+++ b/K8s-dev-cluster/terraformer.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: terraformer
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: terraformer

--- a/K8s-dev-cluster/wireguardian.yaml
+++ b/K8s-dev-cluster/wireguardian.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: wireguardian
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: wireguardian


### PR DESCRIPTION
This feature branch will set a number of replicas to 2 for relevant services. 
The relevant services are `Builder`, `Scheduler`, `Terraformer`, `Wireguardian` and `Kube-eleven`.
@samuelstolicny @bernardhalas @MarioUhrik 