### PR TITLE
Remove logPrint

### DIFF
--- a/healthcheck/healthcheckServer.go
+++ b/healthcheck/healthcheckServer.go
@@ -56,7 +56,7 @@ func (s *ServerHealthChecker) Check(ctx context.Context, req *grpc_health_v1.Hea
 }
 
 func (s *ServerHealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
-	// Unimplemented
+	// Not implemented
 	// The method only returns error/nil - can not reflect ready and liviness respectively
 	return status.Error(codes.Unimplemented, "unimplemented")
 }


### PR DESCRIPTION
This PR removes `gRPC server status: SERVING` print from health checks, which makes it more difficult to debug.