### PR TITLE
Rename env variable configmap from "urls" to "env"

### DIFF
--- a/K8s-dev-cluster/builder.yaml
+++ b/K8s-dev-cluster/builder.yaml
@@ -29,47 +29,47 @@ spec:
         - name: CONTEXT_BOX_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: CONTEXT_BOX_PORT
         - name: CONTEXT_BOX_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: CONTEXT_BOX_HOSTNAME
         - name: TERRAFORMER_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: TERRAFORMER_PORT
         - name: TERRAFORMER_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: TERRAFORMER_HOSTNAME
         - name: WIREGUARDIAN_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: WIREGUARDIAN_PORT
         - name: WIREGUARDIAN_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: WIREGUARDIAN_HOSTNAME
         - name: KUBE_ELEVEN_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: KUBE_ELEVEN_PORT
         - name: KUBE_ELEVEN_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: KUBE_ELEVEN_HOSTNAME
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         readinessProbe:
           httpGet:

--- a/K8s-dev-cluster/context-box.yaml
+++ b/K8s-dev-cluster/context-box.yaml
@@ -29,23 +29,23 @@ spec:
         - name: DATABASE_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: DATABASE_PORT
         - name: DATABASE_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: DATABASE_HOSTNAME
         - name: CONTEXT_BOX_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: CONTEXT_BOX_PORT
          # No hostname needed
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         ports:
         - containerPort: 50055

--- a/K8s-dev-cluster/kube-eleven.yaml
+++ b/K8s-dev-cluster/kube-eleven.yaml
@@ -28,13 +28,13 @@ spec:
         - name: KUBE_ELEVEN_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: KUBE_ELEVEN_PORT
         # No hostname needed
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         ports:
         - containerPort: 50054

--- a/K8s-dev-cluster/kustomization.yaml
+++ b/K8s-dev-cluster/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 configMapGenerator:
 - envs:
   - .env
-  name: urls
+  name: env
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/K8s-dev-cluster/scheduler.yaml
+++ b/K8s-dev-cluster/scheduler.yaml
@@ -29,17 +29,17 @@ spec:
         - name: CONTEXT_BOX_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: CONTEXT_BOX_PORT
         - name: CONTEXT_BOX_HOSTNAME
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: CONTEXT_BOX_HOSTNAME
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         readinessProbe:
           httpGet:

--- a/K8s-dev-cluster/terraformer.yaml
+++ b/K8s-dev-cluster/terraformer.yaml
@@ -29,13 +29,13 @@ spec:
         - name: TERRAFORMER_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: TERRAFORMER_PORT
          # No hostname needed
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         ports:
         - containerPort: 50052

--- a/K8s-dev-cluster/testing-framework.yaml
+++ b/K8s-dev-cluster/testing-framework.yaml
@@ -13,16 +13,16 @@ spec:
             - name: CONTEXT_BOX_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: urls
+                  name: env
                   key: CONTEXT_BOX_PORT
             - name: CONTEXT_BOX_HOSTNAME
               valueFrom:
                 configMapKeyRef:
-                  name: urls
+                  name: env
                   key: CONTEXT_BOX_HOSTNAME
             - name: GOLANG_LOG
               valueFrom:
                 configMapKeyRef:
-                  name: urls
+                  name: env
                   key: GOLANG_LOG
       restartPolicy: OnFailure

--- a/K8s-dev-cluster/wireguardian.yaml
+++ b/K8s-dev-cluster/wireguardian.yaml
@@ -29,13 +29,13 @@ spec:
         - name: WIREGUARDIAN_PORT
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: WIREGUARDIAN_PORT
          # No hostname needed
         - name: GOLANG_LOG
           valueFrom:
             configMapKeyRef:
-              name: urls
+              name: env
               key: GOLANG_LOG
         ports:
         - containerPort: 50053


### PR DESCRIPTION
`urls` was the previous name, when this configmap only held URLs.
Now it's more generic, e.g. it also holds the log verbosity variable.