### PR TITLE
Add the basis for the K8s layer of "Frontend"

### DIFF
--- a/K8s-dev-cluster/frontend.yaml
+++ b/K8s-dev-cluster/frontend.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment 
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      serviceAccountName: k8s-sidecar
+      containers:
+      - name: frontend
+        imagePullPolicy: Always
+        image: nginx # change me please ! After that, uncomment the probes too.
+        resources:
+          requests:
+            cpu: 10m
+            memory: 200Mi
+          limits:
+            cpu: 50m
+            memory: 400Mi
+        env:
+        - name: CONTEXT_BOX_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: env
+              key: CONTEXT_BOX_PORT
+        - name: CONTEXT_BOX_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: env
+              key: CONTEXT_BOX_HOSTNAME
+        - name: GOLANG_LOG
+          valueFrom:
+            configMapKeyRef:
+              name: env
+              key: GOLANG_LOG
+#        readinessProbe:
+#          httpGet:
+#            path: /ready
+#            port: 50051
+#          initialDelaySeconds: 5
+#        livenessProbe:
+#          httpGet:
+#            path: /live
+#            port: 50051
+#          initialDelaySeconds: 10
+        volumeMounts:
+        - name: input-manifests
+          mountPath: /input-manifests/
+      - name: k8s-sidecar
+        imagePullPolicy: Always
+        image: quay.io/kiwigrid/k8s-sidecar:1.15.7
+        resources:
+          requests:
+            cpu: 50m
+            memory: 75Mi
+          limits:
+            cpu: 100m
+            memory: 150Mi
+        env:
+        - name: LABEL
+          value: "claudie.io/input-manifest"
+        - name: FOLDER
+          value: /input-manifests/
+        - name: RESOURCE
+          value: secret
+        volumeMounts:
+        - name: input-manifests
+          mountPath: /input-manifests/
+      volumes:
+      - name: input-manifests
+        emptyDir: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-sidecar
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-sidecar
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-sidecar
+roleRef:
+  kind: Role
+  name: k8s-sidecar
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: k8s-sidecar

--- a/K8s-dev-cluster/input-manifest.yaml
+++ b/K8s-dev-cluster/input-manifest.yaml
@@ -1,0 +1,65 @@
+name: ExampleProject # It would be nice if this example input manifest was a comprehensive representation of features & syntax
+
+providers:
+- name: hetzner
+  credentials: some_creds # fix me please
+- name: gcp
+  credentials: some_creds # fix me please
+
+nodePools:
+  dynamic:
+  - name: hetzner-control
+    provider:
+      hetzner:
+        region: nbg1
+        zone: nbg1-dc3
+    count: 2
+    server_type: cpx11
+    image: ubuntu-20.04
+    disk_size: 50
+  - name: hetzner-compute
+    provider:
+      hetzner:
+        region: nbg1
+        zone: nbg1-dc3
+    count: 2
+    server_type: cpx11
+    image: ubuntu-20.04
+    disk_size: 50
+  - name: gcp-control
+    provider: 
+      gcp:
+        region: europe-west1
+        zone: europe-west1-c
+    count: 2
+    server_type: e2-small
+    image: ubuntu-os-cloud/ubuntu-2004-lts
+    disk_size: 50
+  - name: gcp-compute
+    provider: 
+      gcp:
+        region: europe-west1
+        zone: europe-west1-c
+    count: 2
+    server_type: e2-small
+    image: ubuntu-os-cloud/ubuntu-2004-lts
+    disk_size: 50
+
+kubernetes:
+  clusters:
+    - name: cluster-1
+      version: v1.19.0
+      network: 192.168.2.0/24
+      pools:
+        control:
+        - hetzner-control
+        compute:
+        - hetzner-compute
+    - name: cluster-2
+      version: v1.19.0
+      network: 192.168.2.0/24
+      pools:
+        control:
+        - gcp-control
+        compute:
+        - gcp-compute

--- a/K8s-dev-cluster/kustomization.yaml
+++ b/K8s-dev-cluster/kustomization.yaml
@@ -7,10 +7,19 @@ resources:
 - scheduler.yaml
 - builder.yaml
 - kube-eleven.yaml
+- frontend.yaml
 configMapGenerator:
 - envs:
   - .env
   name: env
+secretGenerator:
+- files:
+  - input-manifest.yaml
+  name: input-manifest
+  options:
+    disableNameSuffixHash: true
+    labels:
+      claudie.io/input-manifest: ""
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:


### PR DESCRIPTION
This PR adds a K8s deployment of Frontend, but for now with just a placeholder "nginx image.
The real value here is the k8s-sidecar.
I've configured the K8s sidecar to watch for secrets with label "claudie.io/input-manifest".
Such secrets will automagically appear in the frontend container at path /input-manifests.
To demonstrate, I'm adding an example inputmanifest secret, which we can maintain
from now for as a showcase.

Helpful for https://github.com/Berops/platform/issues/130