### PR TITLE
Testing framework job: Don't delete pod after failure & only 1 attempt

### DIFF
--- a/K8s-dev-cluster/testing-framework.yaml
+++ b/K8s-dev-cluster/testing-framework.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: testing-framework
 spec:
-  backoffLimit: 1
+  backoffLimit: 0
   template:
     spec:
       containers:
@@ -25,4 +25,4 @@ spec:
                 configMapKeyRef:
                   name: env
                   key: GOLANG_LOG
-      restartPolicy: OnFailure
+      restartPolicy: Never


### PR DESCRIPTION
- `backoffLimit 0` in order to never restart the job
https://stackoverflow.com/questions/39893238/kubernetes-how-to-run-job-only-once

- `Never` restart policy in order for the pod not to be cleaned up right afterwards
This enables us to use kubectl to read the job logs
https://stackoverflow.com/questions/54091659/kubernetes-pods-disappear-after-failed-jobs