### PR TITLE
CI/CD: dump testing-framework logs for both CI & CD

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Monitor E2E test
         run: |
           kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-$GITHUB_SHA
+
+      - name: Dump logs from testing framework
+        if:  ${{ always() }}  
+        run: |
+          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-$GITHUB_SHA""
      
       - name: Delete temporary namespace
         run: |


### PR DESCRIPTION
Looks like CD pipeline was forgotten by accident

@jaskeerat789  @MiroslavRepka 