### PR TITLE
CI/CD: Base image/namespace names on GITHUB_SHA rather than "git rev-parse"

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set short sha output
+        run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+
       - name: install kubectl
         uses: azure/setup-kubectl@v2.0
         with:
@@ -27,14 +30,6 @@ jobs:
         uses: imranismail/setup-kustomize@v1.6.1
         with:
           version: 3.6.1
-
-      # Set output to use short sha of the merge commit HEAD
-      - name: Set short sha output
-        id: sha_short
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
-      - name: Check outputs
-        run: echo ${{ steps.sha_short.outputs.sha_short }}
 
       - name: Login to GCP
         uses: google-github-actions/setup-gcloud@v0.6.0
@@ -56,13 +51,13 @@ jobs:
       # Create a seperate temporary namespace
       - name: Create seperate namespace
         working-directory: ./K8s-dev-cluster
-        run: kubectl create namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+        run: kubectl create namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       # Deploy services to new namespace
       - name: Deploy to new namespace
         working-directory: ./K8s-dev-cluster
         run: |
-          kustomize edit set namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize build | kubectl apply -f - 
 
           cat kustomization.yaml
@@ -75,30 +70,30 @@ jobs:
           echo "${arr[@]}"
           for SERVICE in "${arr[@]}"
           do 
-          kubectl wait deployment -l app=$SERVICE --for=condition=available --timeout=900s --namespace=claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl wait deployment -l app=$SERVICE --for=condition=available --timeout=900s --namespace=claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           done
 
-          kubectl get pods --namespace=claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl get pods --namespace=claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       - name: Start the E2E tests
         working-directory: ./K8s-dev-cluster
         run: |
           TEMP=($(gcloud container images list-tags eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework --sort-by=TIMESTAMP --format="get(tags)"))
           NEWEST_TAG=${TEMP[-1]}
-          kustomize edit set namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize edit add resource testing-framework.yaml
           kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework:$NEWEST_TAG
           kustomize build . | kubectl apply -f -
 
       - name: Monitor E2E test
         run: |
-          kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       - name: Dump logs from testing framework
         if: ${{ always() }}
         run: |
-          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}""
+          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}""
 
       - name: Delete temporary namespace
         run: |
-          kubectl delete namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl delete namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -33,13 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Set output to use short sha of the merge commit HEAD
       - name: Set short sha output
-        id: sha_short
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
-      - name: Check outputs
-        run: echo ${{ steps.sha_short.outputs.sha_short }}
+        run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
 
       # Install the git-crypt and unlock the files
       - name: git-crypt unlock
@@ -93,7 +88,7 @@ jobs:
           for path in "${arr[@]}"
           do
             echo "-----Building $path-----"
-            IMGTAG="eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$path:${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}"
+            IMGTAG="eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$path:${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}"
             DOCKER_BUILDKIT=1 docker build --tag $IMGTAG -f ./services/$path/Dockerfile .
           done
 
@@ -105,7 +100,7 @@ jobs:
 
           for path in "${arr[@]}"
           do
-            docker push eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$path:${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+            docker push eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$path:${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           done
 
     outputs:
@@ -120,10 +115,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      # Set output to use short sha of the merge commit HEAD
       - name: Set short sha output
-        id: sha_short
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: install kustomize
         uses: imranismail/setup-kustomize@v1.6.1
@@ -138,7 +131,7 @@ jobs:
           for SERVICE in "${NEW_SERVICES[@]}"
           do
             echo "Setting a new tag for a $SERVICE"
-            kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$SERVICE:${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+            kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/$SERVICE:${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           done
 
           cat kustomization.yaml
@@ -164,7 +157,6 @@ jobs:
 
     outputs:
       SHA: ${{ steps.sha.outputs.SHA }}
-      SHORT_SHA_RUN_ID: ${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
   #--------------------------------------------------------------------------------------------------
   deploy-and-monitor:
     runs-on: self-hosted
@@ -176,10 +168,8 @@ jobs:
           ref: ${{ needs.edit-kustomization.outputs.SHA }}
           fetch-depth: 0
 
-      # Set output to use short sha of the merge commit HEAD
       - name: Set short sha output
-        id: sha_short
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: install kubectl
         uses: azure/setup-kubectl@v2.0
@@ -211,13 +201,13 @@ jobs:
       # Create a seperate temporary namespace
       - name: Create seperate namespace
         working-directory: ./K8s-dev-cluster
-        run: kubectl create namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+        run: kubectl create namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       # Deploy services to new namespace
       - name: Deploy to new namespace
         working-directory: ./K8s-dev-cluster
         run: |
-          kustomize edit set namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize build | kubectl apply -f - 
 
           cat kustomization.yaml
@@ -230,30 +220,30 @@ jobs:
           echo "${arr[@]}"
           for SERVICE in "${arr[@]}"
           do 
-          kubectl wait deployment -l app=$SERVICE --for=condition=available --timeout=900s --namespace=claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl wait deployment -l app=$SERVICE --for=condition=available --timeout=900s --namespace=claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           done
 
-          kubectl get pods --namespace=claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl get pods --namespace=claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       - name: Start the E2E tests
         working-directory: ./K8s-dev-cluster
         run: |
           TEMP=($(gcloud container images list-tags eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework --sort-by=TIMESTAMP --format="get(tags)"))
           NEWEST_TAG=${TEMP[-1]}
-          kustomize edit set namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize edit add resource testing-framework.yaml
           kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework:$NEWEST_TAG
           kustomize build . | kubectl apply -f -
 
       - name: Monitor E2E test
         run: |
-          kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
       - name: Dump logs from testing framework
         if: ${{ always() }}
         run: |
-          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}""
+          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}""
 
       - name: Delete temporary namespace
         run: |
-          kubectl delete namespace claudie-${{ steps.sha_short.outputs.sha_short }}-${GITHUB_RUN_NUMBER}
+          kubectl delete namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}


### PR DESCRIPTION
GITHUB_SHA is more consistent.
This avoids an issue where "git rev-parse" may be different in each job,
thus leading to docker image tags not matching kustomize imagetags.