### PR TITLE
fix(CI/CD): Don't use latest image tag for testing-framework

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -78,11 +78,8 @@ jobs:
       - name: Start the E2E tests
         working-directory: ./K8s-dev-cluster
         run: |
-          TEMP=($(gcloud container images list-tags eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework --sort-by=TIMESTAMP --format="get(tags)"))
-          NEWEST_TAG=${TEMP[-1]}
           kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize edit add resource testing-framework.yaml
-          kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework:$NEWEST_TAG
           kustomize build . | kubectl apply -f -
 
       - name: Monitor E2E test

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -228,11 +228,8 @@ jobs:
       - name: Start the E2E tests
         working-directory: ./K8s-dev-cluster
         run: |
-          TEMP=($(gcloud container images list-tags eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework --sort-by=TIMESTAMP --format="get(tags)"))
-          NEWEST_TAG=${TEMP[-1]}
           kustomize edit set namespace claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
           kustomize edit add resource testing-framework.yaml
-          kustomize edit set image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/platform/testing-framework:$NEWEST_TAG
           kustomize build . | kubectl apply -f -
 
       - name: Monitor E2E test


### PR DESCRIPTION
# Description
This PR focuses on the issue reported in #137. Previously, we were using the newest image tag for testing-framework, this resulted in using different version of testing-framework in for different branch. We now use the image tag that is present in kustomization.yaml

- [x] Fix CI
- [x] Fix CD