### PR TITLE
Fix the CD error

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   ENV_FILE: .env
-  SERVICES: context-box scheduler builder terraformer wireguardian kube-eleven kuber testing-framework frontend
+  SERVICES: context-box scheduler builder terraformer wireguardian kube-eleven kuber frontend testing-framework
 
 jobs:
   deploy-and-monitor:


### PR DESCRIPTION
The CD is failing after the #166 in the step `Monitor status of the new namespace`. This is because the CD is waiting for the `testing-framework` to be in a ready state, however, it has not been deployed yet. The CD worked before because it was ignoring the last element in the services array, which was previously `testing-framework`, but now it is `frontend`. This PR fixes it by swapping them, so `testing-framework` is last again.
@jaskeerat789 