### PR TITLE
GH Actions: Always start from the head of the source branch

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
       # Install the git-crypt and unlock the files
       - name: git-crypt unlock

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Merge with master branch
         uses: devmasx/merge-branch@1.4.0
@@ -32,6 +34,8 @@ jobs:
     needs: merge-branch
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set short sha output
         run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
@@ -148,15 +152,6 @@ jobs:
           git commit -m "Auto commit - add new kustomization.yaml"
           git push
 
-      - name: Get SHA of auto-commit
-        id: sha
-        run: |
-          sha_new=$(git rev-parse HEAD)
-          echo $sha_new
-          echo "::set-output name=SHA::$sha_new"
-
-    outputs:
-      SHA: ${{ steps.sha.outputs.SHA }}
   #--------------------------------------------------------------------------------------------------
   deploy-and-monitor:
     runs-on: self-hosted
@@ -165,8 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.edit-kustomization.outputs.SHA }}
-          fetch-depth: 0
+          ref: ${{ github.head_ref }}
     
        # Install the git-crypt and unlock the files
       - name: git-crypt unlock


### PR DESCRIPTION
This PR fixes a bug where the `build-and-push` job is ran on an old HEAD, which doesn't include the new contents from the `merge-branch` job. (I.e. the images we built may have been incorrectly lacking changes already present in `master`)

I also rework the way we use `actions/checkout@v2`. 
From now on, we'll just always checkout the head of the source branch every time, for simplicity.

So, the `build-and-push:` change is the actual bugfix, and everything else is refactoring.

---
Here's an example PR where the bug hit us:
https://github.com/Berops/platform/pull/185
Take a deep look at the pipeline logs:
https://github.com/Berops/platform/runs/7353953644?check_suite_focus=true

Notice that `build-and-push` incorrectly starts from `'61b89cb09666335e40c63c4daaa30d1b75f2dba5'`, whereas `edit-kustomization` correctly starts from `'3465a332019cf0cda88e0a537a1061bf6761f455'`.