### PR TITLE
Add namespace-wide network policy

### DIFF
--- a/K8s-dev-cluster/kustomization.yaml
+++ b/K8s-dev-cluster/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - frontend.yaml
 - kuber.yaml
 - minio
+- network-policy.yaml
 # NOTE: when running the testing framework manually in the cluster, you need to specify the namespace in .env file
 # Example: NAMESPACE=foo
 configMapGenerator:

--- a/K8s-dev-cluster/minio/kustomization.yaml
+++ b/K8s-dev-cluster/minio/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - deployment.yaml
   - cm.yaml
   - job.yaml
-  - network-policy.yaml
 secretGenerator:
 - name: minio-secret
   files:

--- a/K8s-dev-cluster/network-policy.yaml
+++ b/K8s-dev-cluster/network-policy.yaml
@@ -1,11 +1,10 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: minio-only-allow-this-namespace
+  name: deny-from-other-namespaces
 spec:
   podSelector:
     matchLabels:
-      app: minio
   ingress:
   - from:
     - podSelector: {}


### PR DESCRIPTION
This PR adds the network policy described in #195. How it works is described [here](https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/04-deny-traffic-from-other-namespaces.md#example). The network policy was tested as follows:
- The Claudie was deployed in the `claudie` namespace
- `nginx` pod with `netcat` was deployed in the `default` namespace
  - When tried to connect to any of the services in the `claudie` namespace, requests were timed out
-  `nginx` pod with `netcat` was deployed in the `claudie` namespace
    - When tried to connect to any of the services in the `claudie` namespace, requests were able to connect