### PR TITLE
Fix/fix gcr cleanup

### DIFF
--- a/.github/workflows/GCR-cleanup.yml
+++ b/.github/workflows/GCR-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v0.6.0
         with:
           service_account_key: ${{ secrets.GCP_DOCKER_REGISTRY_KEY }}
-          project_id: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Clean up the GCR
         run: |
           SERVICES=(${{ env.SERVICES }})


### PR DESCRIPTION
This PR fixes the Clean up the GCR action. The reason why it was failing was the incorrect key in the job spec. This has now been fixed and verified [here](https://github.com/Berops/platform/runs/8094909697?check_suite_focus=true).