### PR TITLE
Feat/GCP-auth

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -15,9 +15,12 @@ env:
 jobs:
   deploy-and-monitor:
     if: github.event.pull_request.draft == false
+    permissions:
+      id-token: write
+      contents: read
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -25,7 +28,7 @@ jobs:
         run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v2.0
+        uses: azure/setup-kubectl@v3.0
         with:
           version: latest
 
@@ -35,16 +38,15 @@ jobs:
           version: 3.6.1
 
       - name: Login to GCP
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/auth@v0.4.0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          service_account_key: ${{ secrets.GCP_DOCKER_REGISTRY_KEY }}
-          export_default_credentials: true
-          cleanup_credentials: true
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          access_token_lifetime: '21600s'
 
       - name: Configure kubectl
-        uses: google-github-actions/get-gke-credentials@v0.3.0
+        uses: google-github-actions/get-gke-credentials@v0.4.0
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
           location: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
           location: ${{ secrets.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SERVICE_ACC_KEY }}
           use_auth_provider: true
 
       # Deploy services to new namespace

--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -115,11 +115,6 @@ jobs:
         run: |
           kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
-      - name: Dump logs from testing framework
-        if: ${{ always() }}
-        run: |
-          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}""
-
       - name: Wait until frontend will clean up the infra from tests
         run: |
           # wait max 5min until the frontend will pick up the change + 10min until everything is destroyed

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Login to GCP
         uses: google-github-actions/auth@v0.4.0
         with:
-          workload_identity_provider: projects/159052430932/locations/global/workloadIdentityPools/github-action-pool/providers/github-action-provider
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Configure kubectl

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -177,7 +177,7 @@ jobs:
         run: echo "SHORT_GITHUB_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v2.0
+        uses: azure/setup-kubectl@v3.0
         with:
           version: latest
 

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -264,11 +264,6 @@ jobs:
         run: |
           kubectl wait --for=condition=complete --timeout=10800s job/testing-framework -n claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
 
-      - name: Dump logs from testing framework
-        if: ${{ always() }}
-        run: |
-          gcloud logging read "resource.labels.container_name = "testing-framework" AND severity >= ERROR AND  resource.labels.namespace_name = "claudie-${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}""
-
       - name: Wait until frontend will clean up the infra from tests
         run: |
           # wait max 5min until the frontend will pick up the change + 10min until everything is destroyed

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -190,7 +190,7 @@ jobs:
         uses: google-github-actions/auth@v0.4.0
         with:
           workload_identity_provider: projects/159052430932/locations/global/workloadIdentityPools/github-action-pool/providers/github-action-provider
-          service_account: docker-registry@platform-infrastructure-316112.iam.gserviceaccount.com
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Configure kubectl
         uses: google-github-actions/get-gke-credentials@v0.4.0

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -192,7 +192,7 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          access_token_lifetime: '3600s'
+          access_token_lifetime: '21600s'
 
       - name: Configure kubectl
         uses: google-github-actions/get-gke-credentials@v0.4.0

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -193,7 +193,7 @@ jobs:
           service_account: docker-registry@platform-infrastructure-316112.iam.gserviceaccount.com
 
       - name: Configure kubectl
-        uses: google-github-actions/get-gke-credentials@v0.3.0
+        uses: google-github-actions/get-gke-credentials@v0.4.0
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
           location: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -66,16 +66,6 @@ jobs:
             fi
           done
           echo ::set-output name=ARRAY_OF_CHANGES::"${arr[@]}"
-
-        # Login to GCP with repository secrets
-      - name: Login to GCP
-        if: ${{ steps.array.outputs.ARRAY_OF_CHANGES != '' }}
-        uses: google-github-actions/setup-gcloud@v0.6.0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          service_account_key: ${{ secrets.GCP_DOCKER_REGISTRY_KEY }}
-
       # Login to Docker Hub
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -194,13 +184,10 @@ jobs:
           version: 3.6.1
 
       - name: Login to GCP
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/auth@v0.4.0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          service_account_key: ${{ secrets.GCP_DOCKER_REGISTRY_KEY }}
-          export_default_credentials: true
-          cleanup_credentials: true
+          workload_identity_provider: projects/159052430932/locations/global/workloadIdentityPools/github-action-pool/providers/githuv-action-provider
+          service_account: docker-registry@platform-infrastructure-316112.iam.gserviceaccount.com
 
       - name: Configure kubectl
         uses: google-github-actions/get-gke-credentials@v0.3.0

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Login to GCP
         uses: google-github-actions/auth@v0.4.0
         with:
-          workload_identity_provider: projects/159052430932/locations/global/workloadIdentityPools/github-action-pool/providers/githuv-action-provider
+          workload_identity_provider: projects/159052430932/locations/global/workloadIdentityPools/github-action-pool/providers/github-action-provider
           service_account: docker-registry@platform-infrastructure-316112.iam.gserviceaccount.com
 
       - name: Configure kubectl

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -197,8 +197,6 @@ jobs:
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
           location: ${{ secrets.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SERVICE_ACC_KEY }}
-          use_auth_provider: true
 
       # Deploy services to new namespace
       - name: Deploy to new namespace

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -189,8 +189,10 @@ jobs:
       - name: Login to GCP
         uses: google-github-actions/auth@v0.4.0
         with:
+          token_format: 'access_token'
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          access_token_lifetime: '3600s'
 
       - name: Configure kubectl
         uses: google-github-actions/get-gke-credentials@v0.4.0

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -166,9 +166,10 @@ jobs:
     needs: [build-and-push, edit-kustomization]
     permissions:
       id-token: write
+      contents: read
     if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES && github.event.pull_request.draft == false }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
           location: ${{ secrets.GKE_ZONE }}
+          use_auth_provider: true
 
       # Deploy services to new namespace
       - name: Deploy to new namespace

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -164,6 +164,8 @@ jobs:
   deploy-and-monitor:
     runs-on: self-hosted
     needs: [build-and-push, edit-kustomization]
+    permissions:
+      id-token: write
     if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES && github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@v2

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -20,18 +20,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/ansibler
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/builder
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/context-box
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/frontend
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/kube-eleven
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/kuber
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/scheduler
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749
 - name: claudieio/terraformer
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -20,18 +20,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/ansibler
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/builder
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/context-box
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/frontend
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/kube-eleven
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/kuber
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/scheduler
-  newTag: 4218b74-780
+  newTag: 0c080c6-748
 - name: claudieio/terraformer
-  newTag: 4218b74-780
+  newTag: 0c080c6-748

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 93d367e-759
+  newTag: 9ad3e38-760

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 749acce-756
+  newTag: e695036-757

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 0c080c6-748
+  newTag: 7554bc1-749

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: ea68409-754
+  newTag: b9743b1-755

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: e695036-757
+  newTag: 93d367e-759

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 1cbbb48-773
+  newTag: 0a2f53f-776

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 75fa667-763
+  newTag: 4d272bc-764

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 9ad3e38-760
+  newTag: 9811053-761

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 4d272bc-764
+  newTag: 6a86378-768

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 6a86378-768
+  newTag: c9c2cc3-769

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 7554bc1-749
+  newTag: 130910d-752

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 0a2f53f-776
+  newTag: 52e4ce3-778

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 3b53ecb-762
+  newTag: 75fa667-763

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 130910d-752
+  newTag: ea68409-754

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: b9743b1-755
+  newTag: 749acce-756

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 0c830af-771
+  newTag: 1cbbb48-773

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 9811053-761
+  newTag: 3b53ecb-762

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: 4218b74-780
+  newTag: 0c080c6-748

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -18,4 +18,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/testing-framework
-  newTag: c9c2cc3-769
+  newTag: 0c830af-771


### PR DESCRIPTION
# Description 
We have been using long-lived service account keys for GCP authentication purposes. GCP recommends that we use [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) [WIF], which provides our CI workflows with short-lived tokens. This PR makes the necessary changes to our CI/CD workflow for using WIF instead of service account keys.