### PR TITLE
return empty config instead of an error

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -24,7 +24,7 @@ images:
 - name: claudieio/builder
   newTag: 7554bc1-749
 - name: claudieio/context-box
-  newTag: 4f7175c-782
+  newTag: 70c5529-783
 - name: claudieio/frontend
   newTag: 7554bc1-749
 - name: claudieio/kube-eleven

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -24,7 +24,7 @@ images:
 - name: claudieio/builder
   newTag: 7554bc1-749
 - name: claudieio/context-box
-  newTag: 7554bc1-749
+  newTag: 4f7175c-782
 - name: claudieio/frontend
   newTag: 7554bc1-749
 - name: claudieio/kube-eleven

--- a/services/context-box/server/server.go
+++ b/services/context-box/server/server.go
@@ -157,7 +157,7 @@ func (*server) GetConfigScheduler(ctx context.Context, req *pb.GetConfigRequest)
 		}
 		return &pb.GetConfigResponse{Config: config}, nil
 	}
-	return nil, fmt.Errorf("empty Scheduler queue")
+	return &pb.GetConfigResponse{Config: nil}, nil
 }
 
 // GetConfigBuilder is a gRPC service: function returns oldest config from the queueBuilder
@@ -171,7 +171,7 @@ func (*server) GetConfigBuilder(ctx context.Context, req *pb.GetConfigRequest) (
 		}
 		return &pb.GetConfigResponse{Config: config}, nil
 	}
-	return nil, fmt.Errorf("empty Builder queue")
+	return &pb.GetConfigResponse{Config: nil}, nil
 }
 
 // GetAllConfigs is a gRPC service: function returns all configs from the DB


### PR DESCRIPTION
# Description

This PR resolves the issue pointed in #281. We don't want to send an error when scheduler/builder tries to get configs from empty queues in c-box. c-box now sends a gRPC response with an `nil` config. 