### PR TITLE
Feat/terminatio grace period

### DIFF
--- a/manifests/claudie/ansibler.yaml
+++ b/manifests/claudie/ansibler.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: ansibler
     spec:
+      terminationGracePeriodSeconds: 1320
       containers:
         - name: ansibler
           imagePullPolicy: Always

--- a/manifests/claudie/builder.yaml
+++ b/manifests/claudie/builder.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: builder
     spec:
+      terminationGracePeriodSeconds: 5400
       containers:
         - name: builder
           imagePullPolicy: Always

--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: context-box
     spec:
+      terminationGracePeriodSeconds: 300
       containers:
         - name: context-box
           imagePullPolicy: Always

--- a/manifests/claudie/frontend.yaml
+++ b/manifests/claudie/frontend.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: frontend
     spec:
+      terminationGracePeriodSeconds: 300
       serviceAccountName: k8s-sidecar
       containers:
         - name: frontend

--- a/manifests/claudie/kube-eleven.yaml
+++ b/manifests/claudie/kube-eleven.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: kube-eleven
     spec:
+      terminationGracePeriodSeconds: 1320
       containers:
         - name: kube-eleven
           imagePullPolicy: Always

--- a/manifests/claudie/kuber.yaml
+++ b/manifests/claudie/kuber.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: kuber
     spec:
+      terminationGracePeriodSeconds: 1320
       containers:
         - name: kuber
           imagePullPolicy: Always

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -20,18 +20,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/ansibler
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/builder
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/context-box
-  newTag: 70c5529-783
+  newTag: ca7b751-787
 - name: claudieio/frontend
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/kube-eleven
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/kuber
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/scheduler
-  newTag: 7554bc1-749
+  newTag: ca7b751-787
 - name: claudieio/terraformer
-  newTag: 7554bc1-749
+  newTag: ca7b751-787

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -24,7 +24,7 @@ images:
 - name: claudieio/builder
   newTag: 7554bc1-749
 - name: claudieio/context-box
-  newTag: 7554bc1-749
+  newTag: 70c5529-783
 - name: claudieio/frontend
   newTag: 7554bc1-749
 - name: claudieio/kube-eleven

--- a/manifests/claudie/scheduler.yaml
+++ b/manifests/claudie/scheduler.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: scheduler
     spec:
+      terminationGracePeriodSeconds: 300
       containers:
         - name: scheduler
           imagePullPolicy: Always

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: terraformer
     spec:
+      terminationGracePeriodSeconds: 1320
       containers:
         - name: terraformer
           imagePullPolicy: Always

--- a/services/ansibler/server/server.go
+++ b/services/ansibler/server/server.go
@@ -156,8 +156,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/builder/builder.go
+++ b/services/builder/builder.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Berops/claudie/internal/envs"
@@ -56,37 +58,75 @@ func healthCheck() error {
 }
 
 func main() {
-	// initialize logger
 	utils.InitLog("builder")
 
-	// Create connection to Context-box
-	cc, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
-	log.Info().Msgf("Dial Context-box: %s", envs.ContextBoxURL)
-	if err != nil {
-		log.Fatal().Msgf("Could not connect to Content-box: %v", err)
+	if err := run(); err != nil {
+		log.Fatal().Msg(err.Error())
 	}
-	defer func() { utils.CloseClientConnection(cc) }()
-	// Creating the client
-	c := pb.NewContextBoxServiceClient(cc)
+}
 
-	// Initialize health probes
-	healthChecker := healthcheck.NewClientHealthChecker(fmt.Sprint(defaultBuilderPort), healthCheck)
-	healthChecker.StartProbes()
+func run() error {
+	conn, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
+	if err != nil {
+		return fmt.Errorf("failed to connect to context-box: %w", err)
+	}
+	defer utils.CloseClientConnection(conn)
 
-	g, ctx := errgroup.WithContext(context.Background())
-	w := worker.NewWorker(ctx, 5*time.Second, configProcessor(c), worker.ErrorLogger)
-	// interrupt catching goroutine
-	g.Go(func() error {
+	log.Info().Msgf("Connected to Context-box: %s", envs.ContextBoxURL)
+
+	healthcheck.NewClientHealthChecker(fmt.Sprint(defaultBuilderPort), healthCheck).StartProbes()
+
+	group, ctx := errgroup.WithContext(context.Background())
+
+	group.Go(func() error {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 		defer signal.Stop(ch)
-		<-ch
-		return errors.New("builder interrupt signal")
+
+		// wait for either the received signal or
+		// check if an error occurred in other
+		// go-routines.
+		var err error
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case sig := <-ch:
+			log.Info().Msgf("Received signal %v", sig)
+			err = errors.New("builder interrupt signal")
+		}
+
+		// Sometimes when the container terminates gRPC logs the following message:
+		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
+		// It does not affect anything as everything will get terminated gracefully
+		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
+		// message in the logs.
+		time.Sleep(1 * time.Second)
+
+		return err
 	})
-	//builder goroutine
-	g.Go(func() error {
-		w.Run()
+
+	group.Go(func() error {
+		client := pb.NewContextBoxServiceClient(conn)
+		group := sync.WaitGroup{}
+
+		worker.NewWorker(
+			ctx,
+			5*time.Second,
+			func() error {
+				return configProcessor(client, &group)
+			},
+			worker.ErrorLogger,
+		).Run()
+
+		log.Info().Msg("Exited worker loop and stopped checking for new configs")
+		log.Info().Msgf("Waiting for spawned go-routines to finish processing their work")
+
+		group.Wait()
+
+		log.Info().Msgf("All spawned go-routines finished")
+
 		return nil
 	})
-	log.Info().Msgf("Stopping Builder: %v", g.Wait())
+
+	return group.Wait()
 }

--- a/services/builder/builder.go
+++ b/services/builder/builder.go
@@ -98,8 +98,7 @@ func run() error {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/context-box/server/server.go
+++ b/services/context-box/server/server.go
@@ -254,8 +254,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/context-box/server/server.go
+++ b/services/context-box/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/Berops/claudie/internal/utils"
@@ -157,7 +158,7 @@ func (*server) GetConfigScheduler(ctx context.Context, req *pb.GetConfigRequest)
 		}
 		return &pb.GetConfigResponse{Config: config}, nil
 	}
-	return nil, fmt.Errorf("empty Scheduler queue")
+	return &pb.GetConfigResponse{Config: nil}, nil
 }
 
 // GetConfigBuilder is a gRPC service: function returns oldest config from the queueBuilder
@@ -171,7 +172,7 @@ func (*server) GetConfigBuilder(ctx context.Context, req *pb.GetConfigRequest) (
 		}
 		return &pb.GetConfigResponse{Config: config}, nil
 	}
-	return nil, fmt.Errorf("empty Builder queue")
+	return &pb.GetConfigResponse{Config: nil}, nil
 }
 
 // GetAllConfigs is a gRPC service: function returns all configs from the DB
@@ -228,28 +229,55 @@ func main() {
 	grpc_health_v1.RegisterHealthServer(s, healthService)
 
 	g, ctx := errgroup.WithContext(context.Background())
-	w := worker.NewWorker(ctx, 10*time.Second, configChecker, worker.ErrorLogger)
+
 	// listen for system interrupts to gracefully shut down
 	g.Go(func() error {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
-		<-ch
-		signal.Stop(ch)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		// wait for either the received signal or
+		// check if an error occurred in other
+		// go-routines.
+		var err error
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case sig := <-ch:
+			log.Info().Msgf("Received signal %v", sig)
+			err = errors.New("context-box interrupt signal")
+		}
+
+		log.Info().Msg("Gracefully shutting down gRPC server")
 		s.GracefulStop()
-		return errors.New("ContextBox interrupt signal")
+
+		// Sometimes when the container terminates gRPC logs the following message:
+		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
+		// It does not affect anything as everything will get terminated gracefully
+		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
+		// message in the logs.
+		time.Sleep(1 * time.Second)
+
+		return err
 	})
+
 	// server goroutine
 	g.Go(func() error {
 		// s.Serve() will create a service goroutine for each connection
 		if err := s.Serve(lis); err != nil {
 			return fmt.Errorf("ContextBox failed to serve: %v", err)
 		}
+		log.Info().Msg("Finished listening for incoming connections")
 		return nil
 	})
+
 	//config checker go routine
 	g.Go(func() error {
+		w := worker.NewWorker(ctx, 10*time.Second, configChecker, worker.ErrorLogger)
 		w.Run()
+		log.Info().Msg("Exited worker loop")
 		return nil
 	})
+
 	log.Info().Msgf("Stopping Context-Box: %v", g.Wait())
 }

--- a/services/kube-eleven/server/server.go
+++ b/services/kube-eleven/server/server.go
@@ -100,8 +100,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/kube-eleven/server/server.go
+++ b/services/kube-eleven/server/server.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/Berops/claudie/internal/healthcheck"
 	"github.com/Berops/claudie/internal/utils"
@@ -72,17 +74,37 @@ func main() {
 	healthService := healthcheck.NewServerHealthChecker(kubeElevenPort, "KUBE_ELEVEN_PORT", nil)
 	grpc_health_v1.RegisterHealthServer(s, healthService)
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(context.Background())
 
 	//goroutine for interrupt
 	g.Go(func() error {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
-		<-ch
-		signal.Stop(ch)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		// wait for either the received signal or
+		// check if an error occurred in other
+		// go-routines.
+		var err error
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case sig := <-ch:
+			log.Info().Msgf("Received signal %v", sig)
+			err = errors.New("kube-eleven interrupt signal")
+		}
+
+		log.Info().Msg("Gracefully shutting down gRPC server")
 		s.GracefulStop()
 
-		return errors.New("KubeEleven interrupt signal")
+		// Sometimes when the container terminates gRPC logs the following message:
+		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
+		// It does not affect anything as everything will get terminated gracefully
+		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
+		// message in the logs.
+		time.Sleep(1 * time.Second)
+
+		return err
 	})
 
 	//server goroutine
@@ -91,7 +113,9 @@ func main() {
 		if err := s.Serve(lis); err != nil {
 			return fmt.Errorf("KubeEleven failed to serve: %w", err)
 		}
+		log.Info().Msg("Finished listening for incoming connections")
 		return nil
 	})
+
 	log.Info().Msgf("Stopping KubeEleven: %s", g.Wait())
 }

--- a/services/kuber/server/server.go
+++ b/services/kuber/server/server.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"syscall"
+	"time"
 
 	"github.com/Berops/claudie/internal/envs"
 	"github.com/Berops/claudie/internal/healthcheck"
@@ -168,18 +170,36 @@ func main() {
 	healthService := healthcheck.NewServerHealthChecker(kuberPort, "KUBER_PORT", nil)
 	grpc_health_v1.RegisterHealthServer(s, healthService)
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(context.Background())
 
 	g.Go(func() error {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 		defer signal.Stop(ch)
-		<-ch
 
-		signal.Stop(ch)
+		// wait for either the received signal or
+		// check if an error occurred in other
+		// go-routines.
+		var err error
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case sig := <-ch:
+			log.Info().Msgf("Received signal %v", sig)
+			err = errors.New("kuber interrupt signal")
+		}
+
+		log.Info().Msg("Gracefully shutting down gRPC server")
 		s.GracefulStop()
 
-		return errors.New("kuber interrupt signal")
+		// Sometimes when the container terminates gRPC logs the following message:
+		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
+		// It does not affect anything as everything will get terminated gracefully
+		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
+		// message in the logs.
+		time.Sleep(1 * time.Second)
+
+		return err
 	})
 
 	g.Go(func() error {
@@ -187,6 +207,7 @@ func main() {
 		if err := s.Serve(lis); err != nil {
 			return fmt.Errorf("kuber failed to serve: %w", err)
 		}
+		log.Info().Msg("Finished listening for incoming connections")
 		return nil
 	})
 

--- a/services/kuber/server/server.go
+++ b/services/kuber/server/server.go
@@ -195,8 +195,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/scheduler/scheduler.go
+++ b/services/scheduler/scheduler.go
@@ -144,8 +144,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/terraformer/server/server.go
+++ b/services/terraformer/server/server.go
@@ -204,8 +204,7 @@ func main() {
 		// Sometimes when the container terminates gRPC logs the following message:
 		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
 		// It does not affect anything as everything will get terminated gracefully
-		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
-		// message in the logs.
+		// this time.Sleep fixes it so that the message won't be logged.
 		time.Sleep(1 * time.Second)
 
 		return err

--- a/services/terraformer/server/server.go
+++ b/services/terraformer/server/server.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/Berops/claudie/internal/envs"
 	"github.com/Berops/claudie/internal/healthcheck"
@@ -18,6 +20,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/rs/zerolog/log"
+
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -176,25 +179,43 @@ func main() {
 	healthService := healthcheck.NewServerHealthChecker(terraformerPort, "TERRAFORMER_PORT", healthCheck)
 	grpc_health_v1.RegisterHealthServer(s, healthService)
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(context.Background())
 
 	g.Go(func() error {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 		defer signal.Stop(ch)
-		<-ch
 
-		signal.Stop(ch)
+		// wait for either the received signal or
+		// check if an error occurred in other
+		// go-routines.
+		var err error
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case sig := <-ch:
+			log.Info().Msgf("Received signal %v", sig)
+			err = errors.New("terraformer interrupt signal")
+		}
+
+		log.Info().Msg("Gracefully shutting down gRPC server")
 		s.GracefulStop()
 
-		return errors.New("terraformer interrupt signal")
+		// Sometimes when the container terminates gRPC logs the following message:
+		// rpc error: code = Unknown desc = Error: No such container: hash of the container...
+		// It does not affect anything as everything will get terminated gracefully
+		// this time.Sleep is more of a 'cosmetic' fix if you will, to not have this
+		// message in the logs.
+		time.Sleep(1 * time.Second)
+
+		return err
 	})
 
 	g.Go(func() error {
-		// s.Serve() will create a service goroutine for each connection
 		if err := s.Serve(lis); err != nil {
 			return fmt.Errorf("terraformer failed to serve: %w", err)
 		}
+		log.Info().Msg("Finished listening for incoming connections")
 		return nil
 	})
 


### PR DESCRIPTION
Closes #283 

- [x] Ensure the SIGTERM signal is passed by shell to all golang processes

    All of our services are started as PID 1 inside the container thus the SIGTERM signal will be propagated to all of them correctly. I've researched why this is the case and it turns out if we use the exec form in the Dockerfile it will get assigned a PID 1, however if the shell form is used it will be spawned as a child process.
    more on this can be found here:
     - https://docs.docker.com/engine/reference/run/#pid-settings---pid
     - https://phoenixnap.com/kb/docker-cmd-vs-entrypoint
     - https://docs.docker.com/engine/reference/commandline/kill/#description
  
- [x] Ensure the kube-proxy properly takes out the pod endpoint from behind the push-based services (e.g. terraformer) so that services become idle before they're terminated

    I've closely followed the iptables in the `kube-proxy` for the specified services when they're terminated. After a `SIGTERM` signal is received by the pod, for example by calling `kubectl delete pod`, The endpoint and also the entries in the iptables will be removed for this particular pod and new entries will be added after the newly spawned pod is assigned an ip address.
    

For example, the following 2 screenshots are made right after `terraformer` received a SIGTERM signal, all of the entries from the iptables and endpoints are removed

<img width="911" alt="deletion_iptable" src="https://user-images.githubusercontent.com/30776544/193052551-f5817942-311c-4ba3-8f95-8b0ad0466fd6.png">

![deletion_pods](https://user-images.githubusercontent.com/30776544/193052584-b0ee0601-9ce4-4c72-9911-db7f7aa322e0.png)

The next 2 picutures are made right after a new pod for `terraformer` was created and assigned an IP. The old pod is still terminating and since the IP tables contains ip address for the new pod it will also receive any new traffic leaving the old one idle until it terminates gracefully

<img width="1033" alt="after_deletion_iptable" src="https://user-images.githubusercontent.com/30776544/193052895-db809fdf-f4c7-4230-8318-a1b0f1ca8397.png">

![after_deletion_pods](https://user-images.githubusercontent.com/30776544/193052929-0f1786b4-205b-4652-80b5-f71bc0b6fda3.png)

- [x] Implement a logic for the pull-based services (e.g. builder) to switch into an idle state upon receiving SIGTERM
- [x] Figure out if a desired behavior for a service that becomes idle after receiving SIGTERM is to terminate. If so, implement this behavior for all our services.

The above 2 points were implemented such that every service, including the builder, performs a graceful shutdown either on SIGTERM or SIGINT, [info regarding signals can be found here](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html), meaning they always finish whatever work they're currently working on and after that they terminate, as leaving them idle until kuberentes issues a SIGKILL would waste resources.

Since the default termination grace period in kubernetes is 30 sec [ref](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) I've changed the timings for each service as 30 seconds simply isn't enough for them to gracefully terminate.
- Builder - 90 mins for graceful shutdown, this is on par with the builderTTL, also including some time for potential retries
- ContextBox - 5 mins for graceful shutdown
- Terraformer - 22 mins for graceful shutdown, also including some time for potential retries
- Kuber - 22 mins for graceful shutdown, also including some time for potential retries
- KubeEleven - 22 mins for graceful shutdown, also including some time for potential retries
- Frontend - 5 mins for graceful shutdown
- Ansibler - 22 mins for graceful shutdown, also including some time for potential retries
- Scheduler - 5 mins for graceful shutdown

I've chosen these numbers to give enough time for each service to gracefully terminate. These numbers may be revisted in the future if they're too short.






    