### PR TITLE
Add dynamodb local development commands to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,15 @@ minio:
 	mkdir -p ~/minio/data/claudie-tf-state-files
 	docker run --rm -p 9000:9000 -p 9001:9001 --name minio -v ~/minio/data:/data quay.io/minio/minio server /data --console-address ":9001"
 
+dynamodb:
+	docker run --rm -p 8000:8000 --name dynamodb-local -v ~/dynamodb:/home/dynamodblocal/data amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -sharedDb -dbPath ./data
+
+dynamodb-create-table:
+	aws dynamodb create-table --attribute-definitions AttributeName=LockID,AttributeType=S --table-name claudie --key-schema AttributeName=LockID,KeyType=HASH --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1  --output json --endpoint-url http://localhost:8000 --no-cli-pager
+
+dynamodb-scan-table:
+	aws dynamodb scan --table-name claudie --endpoint-url http://localhost:8000 --no-cli-pager
+
 # -timeout 0 will disable default timeout
 test:
 	go test -v ./services/testing-framework/... -timeout 0 -count=1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,3 +127,12 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+  dynamodb-local:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:latest"
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    volumes:
+      - "~/dynamodb:/home/dynamodblocal/data"
+    working_dir: /home/dynamodblocal


### PR DESCRIPTION
# Description
This PR adds commands that are necessary for running dynamodb locally for development purposes. the following changes were made:
- add dynamodb to makefile
  - run dynamodb
  - create table
  - scan table to list items stored
- add dynamodb to docker-compose file