### PR TITLE
Add fetch depth needed to access `HEAD^`

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -19,12 +19,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 2
 
       - name: Check the PR for a changes since last commit
         id: change
         run: |
           SERVICES=( ${{ env.SERVICES }} )
           git fetch origin master
+          echo "Files changed since last commit"
+          git diff  --name-only HEAD^ HEAD
           for i in "$(git diff  --name-only HEAD^ HEAD)"
           do
             if [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]] && [[ $i != *".md"* ]]; then


### PR DESCRIPTION
As @MarioUhrik pointed out in last PR #348, `fix it if any bugs appear`.

Well, the first bug in CD appeared, where I forgot to change the fetch depth needed to access `HEAD^`. 
Error: `fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.`
This is now fixed thanks to the [docs](https://github.com/actions/checkout#checkout-head) for `action/checkout`.