### PR TITLE
Remove default http server conf from nginx

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -21,7 +21,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: claudieio/ansibler
-  newTag: 2962f5f-918
+  newTag: f38664f-982
 - name: claudieio/builder
   newTag: ee54904-895
 - name: claudieio/context-box

--- a/services/ansibler/templates/nginx.goyml
+++ b/services/ansibler/templates/nginx.goyml
@@ -19,6 +19,14 @@
         line: "include /etc/nginx/passthrough.conf;"
         insertafter: EOF
       become: yes
+    - name: delete default HTTP server conf (sites-available)
+      file: 
+        path:  "/etc/nginx/sites-available/default"
+        state: absent
+    - name: delete default HTTP server conf (sites-enabled)
+      file: 
+        path:  "/etc/nginx/sites-enabled/default"
+        state: absent
     - name: restart nginx
       service:
         name: nginx


### PR DESCRIPTION
# Description
Fixes #364 
We are deleting default http server conf files in order to prevent spinning up the default http server on port `80`. We only want to use proxy sever from nginx.