### PR TITLE
Increase CPU of context-box and mongodb to help prevent initial crashlooping

### DIFF
--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -21,10 +21,10 @@ spec:
           image: claudieio/context-box
           resources:
             requests:
-              cpu: 5m
+              cpu: 40m
               memory: 50Mi
             limits:
-              cpu: 25m
+              cpu: 80m
               memory: 100Mi
           env:
             - name: DATABASE_PORT

--- a/manifests/claudie/mongo/mongodb.yaml
+++ b/manifests/claudie/mongo/mongodb.yaml
@@ -26,10 +26,10 @@ spec:
         image: mongo:5
         resources:
           requests:
-            cpu: 10m
+            cpu: 40m
             memory: 100Mi
           limits:
-            cpu: 35m
+            cpu: 80m
             memory: 200M
         env:
           - name: MONGO_INITDB_ROOT_USERNAME


### PR DESCRIPTION
We've had some reports of context-box crashlooping forever during startup.
I believe this is a very cheap and quick way to help prevent this.
Jas will open a more proper issue that'll address resource requests/limits of all the pods with more closer attention.

Note that we can check resource usage metrics in the cloud console.