### PR TITLE
Increase initialDelaySeconds for services that wait for other services

### DIFF
--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -67,7 +67,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50055"]
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -77,7 +77,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50052"]
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
initialDelaySeconds is the number of seconds to wait before probes start getting triggered

- Context-box waits for MongoDB
- Terraformer waits for Minio

This is another small improvement that is very likely to help towards smooth startups.
Particularly against context-box crashlooping.