### PR TITLE
Add fix for CI/CD

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -26,19 +26,21 @@ jobs:
         run: |
           SERVICES=( ${{ env.SERVICES }} )
           git fetch origin master
-          echo "Files changed since last commit"
-          git diff  --name-only HEAD^ HEAD
-          for i in "$(git diff  --name-only HEAD^ HEAD)"
+          changes=($(git diff  --name-only HEAD^ HEAD))
+          for i in "${changes[@]}"
           do
-            if [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]] && [[ $i != *".md"* ]]; then
+            if [[ $i == *".md"* ]]; then
+              echo "Skipping document $i"
+              continue
+            elif [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]]; then
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
               break
-            elif [[ $i == *"manifests/"* ]] && [[ $i != *".md"* ]]; then
+            elif [[ $i == *"manifests/"* ]]; then
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
               break
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ $i == *"services/$SERVICE"* ]] && [[ $i != *".md"* ]]; then
+                if [[ $i == *"services/$SERVICE"* ]]; then
                 echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
                 break
                 fi

--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -29,18 +29,15 @@ jobs:
           changes=($(git diff  --name-only HEAD^ HEAD))
           for i in "${changes[@]}"
           do
-            if [[ "$i" == *".md"* ]]; then
+            if [[ "${i}" =~ .*\.md.* ]]; then
               echo "Skipping document "$i""
               continue
-            elif [[ "$i" == *"internal/"* ]] || [[ "$i" == *"proto/"* ]] || [[ "$i" == "go.mod" ]] || [[ "$i" == "go.sum" ]]; then
-              echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
-              break
-            elif [[ "$i" == *"manifests/"* ]]; then
+            elif [[ "${i}" =~ .*(internal|proto|manifests)/.* ]] || [[ "${i}" =~ go\.(mod|sum) ]]; then
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
               break
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ "$i" == *"services/$SERVICE"* ]]; then
+                if [[ "${i}" =~ .*services/${SERVICE}.* ]]; then
                 echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
                 break
                 fi

--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 2
 
-      - name: Check the PR for a changes since last commit
+      - name: Check the PR for changes since the latest commit
         id: change
         run: |
           SERVICES=( ${{ env.SERVICES }} )

--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -29,18 +29,18 @@ jobs:
           changes=($(git diff  --name-only HEAD^ HEAD))
           for i in "${changes[@]}"
           do
-            if [[ $i == *".md"* ]]; then
-              echo "Skipping document $i"
+            if [[ "$i" == *".md"* ]]; then
+              echo "Skipping document "$i""
               continue
-            elif [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]]; then
+            elif [[ "$i" == *"internal/"* ]] || [[ "$i" == *"proto/"* ]] || [[ "$i" == "go.mod" ]] || [[ "$i" == "go.sum" ]]; then
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
               break
-            elif [[ $i == *"manifests/"* ]]; then
+            elif [[ "$i" == *"manifests/"* ]]; then
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
               break
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ $i == *"services/$SERVICE"* ]]; then
+                if [[ "$i" == *"services/$SERVICE"* ]]; then
                 echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
                 break
                 fi

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -47,19 +47,19 @@ jobs:
           changes=($(git diff  --name-only origin/master))
           for i in "${changes[@]}"
           do
-            if [[ "$i" == *".md"* ]]; then
+            if [[ "${i}" =~ .*\.md.* ]]; then
               echo "Skipping document "$i""
               continue
-            elif [[ "$i" == *"internal/"* ]] || [[ "$i" == *"proto/"* ]] || [[ "$i" == "go.mod" ]] || [[ "$i" == "go.sum" ]]; then
+            elif [[ "${i}" =~ .*(internal|proto)/.* ]] || [[ "${i}" =~ go\.(mod|sum) ]]; then
               arr=(${SERVICES[@]})
               echo "All services needs to be built"
               break
-            elif [[ "$i" == *"manifests/"* ]]; then
+            elif [[ "${i}" =~ .*manifests/.* ]]; then
               echo "E2E test will run"
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ "$i" == *"services/$SERVICE"* ]]; then
+                if [[ "${i}" =~ .*services/${SERVICE}.* ]]; then
                 arr+=($SERVICE)
                 echo "Detected change in $SERVICE"
                 fi

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Check the repository for a changes
+      - name: Check the repository for changes
         id: change
         run: |
           arr=()
@@ -52,7 +52,7 @@ jobs:
               continue
             elif [[ "${i}" =~ .*(internal|proto)/.* ]] || [[ "${i}" =~ go\.(mod|sum) ]]; then
               arr=(${SERVICES[@]})
-              echo "All services needs to be built"
+              echo "All services need to be built"
               break
             elif [[ "${i}" =~ .*manifests/.* ]]; then
               echo "E2E test will run"

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -47,19 +47,19 @@ jobs:
           changes=($(git diff  --name-only origin/master))
           for i in "${changes[@]}"
           do
-            if [[ $i == *".md"* ]]; then
-              echo "Skipping document $i"
+            if [[ "$i" == *".md"* ]]; then
+              echo "Skipping document "$i""
               continue
-            elif [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]]; then
+            elif [[ "$i" == *"internal/"* ]] || [[ "$i" == *"proto/"* ]] || [[ "$i" == "go.mod" ]] || [[ "$i" == "go.sum" ]]; then
               arr=(${SERVICES[@]})
               echo "All services needs to be built"
               break
-            elif [[ $i == *"manifests/"* ]]; then
+            elif [[ "$i" == *"manifests/"* ]]; then
               echo "E2E test will run"
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ $i == *"services/$SERVICE"* ]]; then
+                if [[ "$i" == *"services/$SERVICE"* ]]; then
                 arr+=($SERVICE)
                 echo "Detected change in $SERVICE"
                 fi

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -44,18 +44,22 @@ jobs:
           arr=()
           SERVICES=( ${{ env.SERVICES }} )
           git fetch origin master
-          for i in "$(git diff  --name-only origin/master..HEAD)"
+          changes=($(git diff  --name-only origin/master))
+          for i in "${changes[@]}"
           do
-            if [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]] && [[ $i != *".md"* ]]; then
+            if [[ $i == *".md"* ]]; then
+              echo "Skipping document $i"
+              continue
+            elif [[ $i == *"internal/"* ]] || [[ $i == *"proto/"* ]] || [[ $i == "go.mod" ]] || [[ $i == "go.sum" ]]; then
               arr=(${SERVICES[@]})
               echo "All services needs to be built"
               break
-            elif [[ $i == *"manifests/"* ]] && [[ $i != *".md"* ]]; then
+            elif [[ $i == *"manifests/"* ]]; then
               echo "E2E test will run"
               echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
             else
               for SERVICE in "${SERVICES[@]}"; do
-                if [[ $i == *"services/$SERVICE"* ]] && [[ $i != *".md"* ]]; then
+                if [[ $i == *"services/$SERVICE"* ]]; then
                 arr+=($SERVICE)
                 echo "Detected change in $SERVICE"
                 fi


### PR DESCRIPTION
This PR fixes issues reported in #371. For some reason, when adding `[[ $i != *".md"* ]]` the bash interpreted `$i` as the whole array. I changed the condition and array creation, which was tested on #376 and should be fixed now.