### PR TITLE
Fix the job name in `deploy-and-monitor` condition

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -48,7 +48,7 @@ jobs:
       RUN_TESTS: ${{ steps.change.outputs.RUN_TESTS }}
   #--------------------------------------------------------------------------------------------------
   deploy-and-monitor:
-    if: ${{ needs.build-and-push.outputs.RUN_TESTS == 'true' }}
+    if: ${{ needs.check-changes.outputs.RUN_TESTS == 'true' }}
     needs: check-changes
     permissions:
       id-token: write


### PR DESCRIPTION
A small mistake in `deploy-and-monitor` job condition caused outputs to not be checked.

This is now fixed.