### PR TITLE
Fix example inputManifest AMI

### DIFF
--- a/docs/input-manifest/example.yaml
+++ b/docs/input-manifest/example.yaml
@@ -141,9 +141,8 @@ nodePools:
         zone: eu-central-1c
       count: 2
       server_type: t3.medium
-      # ubuntu
       # https://cloud-images.ubuntu.com/query/focal/server/released.current.txt
-      image: ami-01453eb88ba6b047b
+      image: ami-06148e0e81e5187c8
       disk_size: 50
     - name: compute-aws
       providerSpec:
@@ -151,10 +150,9 @@ nodePools:
         region: eu-central-1
         zone: eu-central-1c
       count: 2
-      server_type: t3.medium
-      # ubuntu
+      server_type: t3.medium 
       # https://cloud-images.ubuntu.com/query/focal/server/released.current.txt
-      image: ami-01453eb88ba6b047b
+      image: ami-06148e0e81e5187c8
       disk_size: 50
       # loadbalancer nodes
     - name: loadbalancer-1


### PR DESCRIPTION
It was ARM64, which is clearly wrong.
The new link is AMD64, the same as in E2E pipelines.