### PR TITLE
Docs: clarify requirement of AMD64 Ubuntu

### DIFF
--- a/docs/input-manifest/input-manifest.md
+++ b/docs/input-manifest/input-manifest.md
@@ -185,10 +185,14 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 - `server_type`
   
   Type of the machines in the nodepool.
+  
+  Currently, only AMD64 machines are supported.
 
 - `image`
 
-  OS image of the machine. Currently, Claudie only supports ubuntu images.
+  OS image of the machine. 
+  
+  Currently, only Ubuntu AMD64 images are supported.
 
 - `disk_size`
 


### PR DESCRIPTION
I believe it was worth making it more clear.
Some users have hit "can't run arm64 image on an amd64 machine" errors.