### PR TITLE
Streamline the deployment step

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Claudie comes with a pre-configured storage solution, with ready-to-use Storage 
 Deploy Claudie Kubernetes [manifests/claudie](https://github.com/Berops/claudie/tree/master/manifests/claudie) into a Kubernetes cluster.
 
 ```
-kustomize build manifests/claudie | kubectl apply -f -
+kubectl apply -k manifests/claudie
 ```
 
 Lastly, provide your own manifest via a Kubernetes Secret.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ Claudie comes with a pre-configured storage solution, with ready-to-use Storage 
 Deploy Claudie Kubernetes [manifests/claudie](https://github.com/Berops/claudie/tree/master/manifests/claudie) into a Kubernetes cluster.
 
 ```
-kustomize build | kubectl apply -f -
+kustomize build manifests/claudie | kubectl apply -f -
 ```
-
-> NOTE: Please make sure you are in `/manifests/claudie` directory before running `kustomize build` 
 
 Lastly, provide your own manifest via a Kubernetes Secret.
 

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,5 +1,4 @@
 ## Warning 
-Please make sure you are in `claudie` directory before using `kustomize` to deploy Claudie.
 Running `kustomize` in this directory will deploy `testing-framework` along with the other Claudie components.
 
 `testing-framework` is not part of `claudie` and it is used only for testing the platform itself during development.

--- a/manifests/testing-framework/README.md
+++ b/manifests/testing-framework/README.md
@@ -1,4 +1,6 @@
 ## Testing Framework 
+
 `testing-framework` is a custom service used to run tests by applying some pre-defined manifest and monitor the cluster creation process and their health after successful creation.
 
-Please make sure you use testing framework **only** for development purposes. 
+Please make sure you use the testing framework **only** for development purposes. \
+You almost certainly don't want to deploy the testing framework as a regular user.


### PR DESCRIPTION
`kustomize` can be pointed to any folder in the repo. That makes the `note` superfluous.