### PR TITLE
fix:trim prefix for node names

### DIFF
--- a/internal/templateUtils/templates.go
+++ b/internal/templateUtils/templates.go
@@ -77,6 +77,7 @@ func (tl TemplateLoader) LoadTemplate(tplFile string) (*template.Template, error
 			"getCIDR":                       GetCIDR,
 			"enableAccNet":                  EnableAccNet,
 			"replaceAll":                    strings.ReplaceAll,
+			"trimPrefix":                    strings.TrimPrefix,
 		})
 
 	tpl, err := tpl.ParseFiles(filepath.Join(baseDirectory, tl.Directory, tplFile))

--- a/services/ansibler/server/ansible-playbooks/apiEndpointChange.yml
+++ b/services/ansibler/server/ansible-playbooks/apiEndpointChange.yml
@@ -9,46 +9,51 @@
         name: "{{ item }}"
         state: stopped
       loop:
-      - "kubelet"
-    
+        - "kubelet"
+
     - name: remove old apiserver.crt, apiserver.key
       file:
         path: "{{ item }}"
         state: absent
-      loop: 
-      - "/etc/kubernetes/pki/apiserver.crt"
-      - "/etc/kubernetes/pki/apiserver.key"
+      loop:
+        - "/etc/kubernetes/pki/apiserver.crt"
+        - "/etc/kubernetes/pki/apiserver.key"
 
-    - name: find file that contains the hostname 
+    - name: find file that contains the hostname
       find:
         contains: ".*{{ansible_hostname}}.*"
         path: /root/kubeone/cfg/
       register: file
-    
-    - name: replace endpoint 
+
+    - name: fail if no file was found
+      fail:
+        msg: "No file with {{ansible_hostname}} was found"
+      when: file.files == []
+
+    - name: replace endpoint
       replace:
         path: "{{file.files[0].path}}"
-        regexp: '{{ OldEndpoint}}'
-        replace: '{{ NewEndpoint}}'
-    
+        regexp: '{{ OldEndpoint }}'
+        replace: '{{ NewEndpoint }}'
+
     - name: generate new certs
       shell: "kubeadm init phase certs apiserver --config {{file.files[0].path}}"
-    
+
     - name: remove old /etc/kubernetes/*.conf
       file:
         path: "{{ item }}"
         state: absent
-      loop: 
-      - "/etc/kubernetes/admin.conf"
-      - "/etc/kubernetes/controller-manager.conf"
-      - "/etc/kubernetes/kubelet.conf"
-      - "/etc/kubernetes/scheduler.conf"
-    
-    - name: generate kubeconfig 
+      loop:
+        - "/etc/kubernetes/admin.conf"
+        - "/etc/kubernetes/controller-manager.conf"
+        - "/etc/kubernetes/kubelet.conf"
+        - "/etc/kubernetes/scheduler.conf"
+
+    - name: generate kubeconfig
       shell: "kubeadm init phase kubeconfig all --config {{file.files[0].path}}"
-    
+
     - name: restart kubelet
-      ansible.builtin.service: 
+      ansible.builtin.service:
         name: "{{ item }}"
         state: restarted
       register: serviceDetails
@@ -56,13 +61,13 @@
       retries: 5
       delay: 20
       loop:
-      - "kubelet"
-    
+        - "kubelet"
+
     - name: upload config map
       shell: "kubeadm init phase upload-config all --config {{file.files[0].path}}"
-    
+
     - name: restart containerd and kubelet
-      ansible.builtin.service: 
+      ansible.builtin.service:
         name: "{{ item }}"
         state: restarted
       register: serviceDetails
@@ -70,8 +75,8 @@
       retries: 10
       delay: 20
       loop:
-      - "kubelet"
-      - "containerd"
+        - "kubelet"
+        - "containerd"
 
 - hosts: compute
   gather_facts: true
@@ -79,18 +84,18 @@
   remote_user: root
   tasks:
     - name: stop kubelet
-      ansible.builtin.service: 
+      ansible.builtin.service:
         name: kubelet
         state: stopped
-    
-    - name: replace endpoint 
+
+    - name: replace endpoint
       replace:
         path: "/etc/kubernetes/kubelet.conf"
         regexp: '{{ OldEndpoint}}'
         replace: '{{ NewEndpoint}}'
-    
+
     - name: restart kubelet
-      ansible.builtin.service: 
+      ansible.builtin.service:
         name: kubelet
         state: restarted
       register: serviceDetails

--- a/services/ansibler/server/ansible-playbooks/apiEndpointChange.yml
+++ b/services/ansibler/server/ansible-playbooks/apiEndpointChange.yml
@@ -21,13 +21,13 @@
 
     - name: find file that contains the hostname
       find:
-        contains: ".*{{ansible_hostname}}.*"
+        contains: ".*{{inventory_hostname}}.*"
         path: /root/kubeone/cfg/
       register: file
 
     - name: fail if no file was found
       fail:
-        msg: "No file with {{ansible_hostname}} was found"
+        msg: "No file with {{inventory_hostname}} was found"
       when: file.files == []
 
     - name: replace endpoint

--- a/services/ansibler/server/ansibler.go
+++ b/services/ansibler/server/ansibler.go
@@ -28,6 +28,7 @@ type AllNodesInventoryData struct {
 type LbInventoryData struct {
 	K8sNodepools []*pb.NodePool
 	LBClusters   []*pb.LBcluster
+	ClusterID    string
 }
 
 func generateInventoryFile(inventoryTemplate, directory string, data interface{}) error {

--- a/services/ansibler/server/loadbalancers.go
+++ b/services/ansibler/server/loadbalancers.go
@@ -84,6 +84,8 @@ type (
 		// PreviousAPIEndpointLB holds the endpoint of the previous Load-Balancer endpoint
 		// if there was any to be able to handle the endpoint change.
 		PreviousAPIEndpointLB string
+		// ClusterID contains the ClusterName-Hash- prefix of the kubernetes cluster
+		ClusterID string
 	}
 
 	LBData struct {
@@ -482,7 +484,11 @@ func generateK8sBaseFiles(k8sDirectory string, lbInfo *LBInfo) error {
 		}
 	}
 	//generate inventory
-	err := generateInventoryFile(lbInventoryFile, k8sDirectory, LbInventoryData{K8sNodepools: lbInfo.TargetK8sNodepool, LBClusters: lbSlice})
+	err := generateInventoryFile(lbInventoryFile, k8sDirectory, LbInventoryData{
+		K8sNodepools: lbInfo.TargetK8sNodepool,
+		LBClusters:   lbSlice,
+		ClusterID:    lbInfo.ClusterID,
+	})
 	if err != nil {
 		return fmt.Errorf("error while generating inventory file for %s : %w", k8sDirectory, err)
 	}

--- a/services/ansibler/server/server.go
+++ b/services/ansibler/server/server.go
@@ -78,12 +78,14 @@ func (*server) TeardownLoadBalancers(ctx context.Context, req *pb.TeardownLBRequ
 		attached        = make(map[string]bool)           // [k8sClusterName]Bool
 		k8sNodepools    = make(map[string][]*pb.NodePool) //[k8sClusterName][]nodepools
 		k8sNodepoolsKey = make(map[string]string)         //[k8sClusterName]keys
+		clusterIDs      = make(map[string]string)         //[k8sClusterName]prefix (clusterName + hash)
 	)
 
 	// Collect all NodePools that will exist after the deletion
 	for _, k8s := range req.CurrentState.Clusters {
 		k8sNodepools[k8s.ClusterInfo.Name] = k8s.ClusterInfo.NodePools
 		k8sNodepoolsKey[k8s.ClusterInfo.Name] = k8s.ClusterInfo.PrivateKey
+		clusterIDs[k8s.ClusterInfo.Name] = fmt.Sprintf("%s-%s", k8s.ClusterInfo.Name, k8s.ClusterInfo.Hash)
 	}
 
 	// Look for newly attached LoadBalancers.
@@ -97,7 +99,7 @@ func (*server) TeardownLoadBalancers(ctx context.Context, req *pb.TeardownLBRequ
 	for _, lb := range req.DeletedState.LoadBalancerClusters {
 		np, ok := k8sNodepools[lb.TargetedK8S]
 		if !ok {
-			log.Error().Msgf("LoadBalancer %s has not found a target k8s cluster %s", lb.ClusterInfo.Name, lb.TargetedK8S)
+			log.Info().Msgf("LoadBalancer %s has not found a target k8s cluster %s", lb.ClusterInfo.Name, lb.TargetedK8S)
 			continue
 		}
 
@@ -107,6 +109,7 @@ func (*server) TeardownLoadBalancers(ctx context.Context, req *pb.TeardownLBRequ
 				LbClusters:           make([]*LBData, 0),
 				TargetK8sNodepool:    np,
 				TargetK8sNodepoolKey: k8sNodepoolsKey[lb.TargetedK8S],
+				ClusterID:            clusterIDs[lb.TargetedK8S],
 			}
 		}
 
@@ -139,6 +142,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 		lbInfos         = make(map[string]*LBInfo)        //[k8sClusterName]lbInfo
 		k8sNodepools    = make(map[string][]*pb.NodePool) //[k8sClusterName][]nodepools
 		k8sNodepoolsKey = make(map[string]string)         //[k8sClusterName]keys
+		clusterIDs      = make(map[string]string)         //[k8sClusterName]prefix (clusterName + hash)
 		currentLBs      = make(map[string]*pb.LBcluster)  //[lbClusterName]CurrentStateLB
 	)
 
@@ -146,6 +150,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 	for _, k8s := range req.DesiredState.Clusters {
 		k8sNodepools[k8s.ClusterInfo.Name] = k8s.ClusterInfo.NodePools
 		k8sNodepoolsKey[k8s.ClusterInfo.Name] = k8s.ClusterInfo.PrivateKey
+		clusterIDs[k8s.ClusterInfo.Name] = fmt.Sprintf("%s-%s", k8s.ClusterInfo.Name, k8s.ClusterInfo.Hash)
 	}
 
 	//get current dns so we can detect a possible change in configuration
@@ -156,7 +161,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 	for _, lb := range req.DesiredState.LoadBalancerClusters {
 		np, ok := k8sNodepools[lb.TargetedK8S]
 		if !ok {
-			log.Error().Msgf("Loadbalancer %s has not found a target k8s cluster (%s)", lb.ClusterInfo.Name, lb.TargetedK8S)
+			log.Info().Msgf("Loadbalancer %s has not found a target k8s cluster (%s)", lb.ClusterInfo.Name, lb.TargetedK8S)
 			continue
 		}
 
@@ -168,6 +173,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 				LbClusters:            make([]*LBData, 0),
 				TargetK8sNodepoolKey:  k8sNodepoolsKey[lb.TargetedK8S],
 				PreviousAPIEndpointLB: req.OldApiEndpoints[lb.TargetedK8S],
+				ClusterID:             clusterIDs[lb.TargetedK8S],
 			}
 		}
 

--- a/services/ansibler/server/server.go
+++ b/services/ansibler/server/server.go
@@ -78,7 +78,7 @@ func (*server) TeardownLoadBalancers(ctx context.Context, req *pb.TeardownLBRequ
 		attached        = make(map[string]bool)           // [k8sClusterName]Bool
 		k8sNodepools    = make(map[string][]*pb.NodePool) //[k8sClusterName][]nodepools
 		k8sNodepoolsKey = make(map[string]string)         //[k8sClusterName]keys
-		clusterIDs      = make(map[string]string)         //[k8sClusterName]prefix (clusterName + hash)
+		clusterIDs      = make(map[string]string)         //[k8sClusterName]clusterID (<clusterName>-<hash>)
 	)
 
 	// Collect all NodePools that will exist after the deletion
@@ -99,7 +99,7 @@ func (*server) TeardownLoadBalancers(ctx context.Context, req *pb.TeardownLBRequ
 	for _, lb := range req.DeletedState.LoadBalancerClusters {
 		np, ok := k8sNodepools[lb.TargetedK8S]
 		if !ok {
-			log.Info().Msgf("LoadBalancer %s has not found a target k8s cluster %s", lb.ClusterInfo.Name, lb.TargetedK8S)
+			log.Error().Msgf("LoadBalancer %s has not found a target k8s cluster %s", lb.ClusterInfo.Name, lb.TargetedK8S)
 			continue
 		}
 
@@ -142,7 +142,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 		lbInfos         = make(map[string]*LBInfo)        //[k8sClusterName]lbInfo
 		k8sNodepools    = make(map[string][]*pb.NodePool) //[k8sClusterName][]nodepools
 		k8sNodepoolsKey = make(map[string]string)         //[k8sClusterName]keys
-		clusterIDs      = make(map[string]string)         //[k8sClusterName]prefix (clusterName + hash)
+		clusterIDs      = make(map[string]string)         //[k8sClusterName]clusterID (<clusterName>-<hash>)
 		currentLBs      = make(map[string]*pb.LBcluster)  //[lbClusterName]CurrentStateLB
 	)
 
@@ -161,7 +161,7 @@ func (*server) SetUpLoadbalancers(_ context.Context, req *pb.SetUpLBRequest) (*p
 	for _, lb := range req.DesiredState.LoadBalancerClusters {
 		np, ok := k8sNodepools[lb.TargetedK8S]
 		if !ok {
-			log.Info().Msgf("Loadbalancer %s has not found a target k8s cluster (%s)", lb.ClusterInfo.Name, lb.TargetedK8S)
+			log.Error().Msgf("Loadbalancer %s has not found a target k8s cluster (%s)", lb.ClusterInfo.Name, lb.TargetedK8S)
 			continue
 		}
 

--- a/services/ansibler/templates/all-node-inventory.goini
+++ b/services/ansibler/templates/all-node-inventory.goini
@@ -2,7 +2,7 @@
 {{- range $nodepoolInfo := .NodepoolInfos }}
     {{- range $nodepool := $nodepoolInfo.Nodepools }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepoolInfo.ID }}.pem
+{{ trimPrefix $node.Name (printf "%s-" $nodepoolInfo.ID) }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepoolInfo.ID }}.pem
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/lb-inventory.goini
+++ b/services/ansibler/templates/lb-inventory.goini
@@ -3,7 +3,7 @@
 {{- range $nodepool := .K8sNodepools }}
     {{- if $nodepool.IsControl }}       
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file=k8s.pem
+{{ trimPrefix $node.Name (printf "%s-" $.ClusterID) }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file=k8s.pem
         {{- end }}
     {{- end }}
 {{- end }}
@@ -12,7 +12,7 @@
 {{- range $nodepool := .K8sNodepools }}
     {{- if not $nodepool.IsControl }}       
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file=k8s.pem
+{{ trimPrefix $node.Name (printf "%s-" $.ClusterID) }} ansible_host={{ $node.Public }} private_ip={{ $node.Private }} ansible_ssh_private_key_file=k8s.pem
         {{- end }}
     {{- end }}
 {{- end }}
@@ -23,7 +23,7 @@
     {{- range $lbNodepool := $lbCluster.ClusterInfo.NodePools }}
         {{- range $lbNode :=  $lbNodepool.Nodes }}
 {{/*key.pem is taken from a directory where ansible-playbook is called, thus it does not need to specify path relative to inventory.ini*/}}
-{{ $lbNode.Name }} ansible_host={{ $lbNode.Public }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file=key.pem
+{{ trimPrefix $lbNode.Name (printf "%s-%s-" $lbCluster.ClusterInfo.Name $lbCluster.ClusterInfo.Hash) }} ansible_host={{ $lbNode.Public }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file=key.pem
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes the issue where when the changeApiEndpoint playbook would reference the old node names with the prefix clusterName + clusterHash.