### PR TITLE
fix:use auth

### DIFF
--- a/.github/workflows/CD-pipeline-dev.yml
+++ b/.github/workflows/CD-pipeline-dev.yml
@@ -80,11 +80,16 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
           access_token_lifetime: "21600s"
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Configure kubectl
-        uses: google-github-actions/get-gke-credentials@v1.0.1
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GKE_ZONE }}
+        env:
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+        run: |-
+          gcloud components install gke-gcloud-auth-plugin
+          gke-gcloud-auth-plugin --version
+          gcloud container clusters get-credentials ${{ secrets.GKE_CLUSTER_NAME }} --zone ${{ secrets.GKE_ZONE }}
 
       # Deploy services to new namespace
       - name: Deploy to new namespace

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -217,11 +217,16 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
           access_token_lifetime: "21600s"
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Configure kubectl
-        uses: google-github-actions/get-gke-credentials@v1.0.1
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GKE_ZONE }}
+        env:
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+        run: |-
+          gcloud components install gke-gcloud-auth-plugin
+          gke-gcloud-auth-plugin --version
+          gcloud container clusters get-credentials ${{ secrets.GKE_CLUSTER_NAME }} --zone ${{ secrets.GKE_ZONE }}
 
       - name: Get PR labels
         id: pr-labels

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -27,7 +27,7 @@ images:
 - name: claudieio/context-box
   newTag: e29a83d-1218
 - name: claudieio/frontend
-  newTag: e29a83d-1218
+  newTag: 2d44fa8-1249
 - name: claudieio/kube-eleven
   newTag: e29a83d-1218
 - name: claudieio/kuber

--- a/services/frontend/server.go
+++ b/services/frontend/server.go
@@ -10,15 +10,15 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/Berops/claudie/proto/pb"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type server struct {


### PR DESCRIPTION
Closes #467 by using gcloud to fetch the kubeconfig for the dev cluster. gcloud will use the token genereted by the `google-github-actions/auth@v1.0.0` to authenticate