### PR TITLE
feat/increase-requests

### DIFF
--- a/manifests/claudie/ansibler.yaml
+++ b/manifests/claudie/ansibler.yaml
@@ -21,11 +21,11 @@ spec:
           image: claudieio/ansibler
           resources:
             requests:
-              cpu: 500m
-              memory: 700Mi
+              cpu: 700m
+              memory: 768Mi
             limits:
-              cpu: 750m
-              memory: 900Mi
+              cpu: 1024m
+              memory: 1248Mi
           env:
             - name: ANSIBLER_PORT
               valueFrom:
@@ -44,10 +44,12 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50053"]
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50053"]
             initialDelaySeconds: 10
+            periodSeconds: 30
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/claudie/builder.yaml
+++ b/manifests/claudie/builder.yaml
@@ -21,10 +21,10 @@ spec:
           image: claudieio/builder
           resources:
             requests:
-              cpu: 25m
+              cpu: 80m
               memory: 200Mi
             limits:
-              cpu: 75m
+              cpu: 160m
               memory: 400Mi
           env:
             - name: CONTEXT_BOX_PORT
@@ -87,8 +87,10 @@ spec:
               path: /ready
               port: 50051
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             httpGet:
               path: /live
               port: 50051
             initialDelaySeconds: 10
+            periodSeconds: 30

--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -21,10 +21,10 @@ spec:
           image: claudieio/context-box
           resources:
             requests:
-              cpu: 40m
+              cpu: 80m
               memory: 50Mi
             limits:
-              cpu: 80m
+              cpu: 160m
               memory: 100Mi
           env:
             - name: DATABASE_PORT
@@ -64,10 +64,12 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50055"]
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50055"]
             initialDelaySeconds: 120
+            periodSeconds: 30
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/claudie/frontend.yaml
+++ b/manifests/claudie/frontend.yaml
@@ -50,11 +50,13 @@ spec:
               path: /ready
               port: 50058
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             httpGet:
               path: /live
               port: 50058
             initialDelaySeconds: 10
+            periodSeconds: 30
           volumeMounts:
             - name: input-manifests
               mountPath: /input-manifests/

--- a/manifests/claudie/kube-eleven.yaml
+++ b/manifests/claudie/kube-eleven.yaml
@@ -44,10 +44,12 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50054"]
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50054"]
             initialDelaySeconds: 10
+            periodSeconds: 30
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/claudie/kuber.yaml
+++ b/manifests/claudie/kuber.yaml
@@ -47,10 +47,12 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50057"]
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50057"]
             initialDelaySeconds: 10
+            periodSeconds: 30
       serviceAccountName: kuber
 ---
 kind: Service

--- a/manifests/claudie/scheduler.yaml
+++ b/manifests/claudie/scheduler.yaml
@@ -21,10 +21,10 @@ spec:
           image: claudieio/scheduler
           resources:
             requests:
-              cpu: 30m
+              cpu: 45m
               memory: 50Mi
             limits:
-              cpu: 80m
+              cpu: 100m
               memory: 100Mi
           env:
             - name: CONTEXT_BOX_PORT
@@ -47,8 +47,10 @@ spec:
               path: /ready
               port: 50056
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             httpGet:
               path: /live
               port: 50056
             initialDelaySeconds: 10
+            periodSeconds: 30

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -21,11 +21,11 @@ spec:
           image: claudieio/terraformer
           resources:
             requests:
-              cpu: 500m
+              cpu: 700m
               memory: 768Mi
             limits:
-              cpu: 700m
-              memory: 1024Mi
+              cpu: 1024m
+              memory: 1248Mi
           env:
             - name: TERRAFORMER_PORT
               valueFrom:
@@ -96,10 +96,12 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50052"]
             initialDelaySeconds: 5
+            periodSeconds: 30
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe-Liveness", "-addr=:50052"]
             initialDelaySeconds: 30
+            periodSeconds: 30
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
#369 

Increase the limits for terraformer, ansibler, context-box and builder, also increase the interval in which the healthcheck is called to 30 seconds (instead of 10s the default value)