### PR TITLE
Disable apt fix

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -21,7 +21,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 69fb5b3-1339
+  newTag: af6519f-1341
 - name: ghcr.io/berops/claudie/builder
   newTag: 69fb5b3-1339
 - name: ghcr.io/berops/claudie/context-box

--- a/services/ansibler/server/ansible-playbooks/wireguard/tasks/main.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- include_tasks: kill_unattended_upgrades.yml
-  tags: install
-
 - include_tasks: install.yml
   tags: install
 


### PR DESCRIPTION
This PR disables the playbook added in PR #538. The playbook does not work due to errors like `'ansible_distribution' is undefined`. I tried to simply enable `gather_facts`, however, the errors were still present. 

 cc @wULLSnpAXbWZGYDYyhWTKKspEQoaYxXyhoisqHf 