### PR TITLE
make connection attemps more readable

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -23,7 +23,7 @@ images:
 - name: ghcr.io/berops/claudie/ansibler
   newTag: d630d0f-1402
 - name: ghcr.io/berops/claudie/builder
-  newTag: c7f8a92-1392
+  newTag: 985d6da-1401
 - name: ghcr.io/berops/claudie/context-box
   newTag: c7f8a92-1392
 - name: ghcr.io/berops/claudie/frontend
@@ -33,6 +33,6 @@ images:
 - name: ghcr.io/berops/claudie/kuber
   newTag: 381614f-1400
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: c7f8a92-1392
+  newTag: 985d6da-1401
 - name: ghcr.io/berops/claudie/terraformer
   newTag: c7f8a92-1392


### PR DESCRIPTION
closes #528 

Example of the changes when the connection is unhealthy:

```
#initial start of the service

11:37AM INF internal/utils/log.go:37 > Using log with the level "debug" module=builder
11:37AM INF services/builder/builder.go:77 > Initiated connection Context-box: localhost:50055, waiting for connection to be in state: READY module=builder
11:37AM WRN services/builder/builder.go:124 > connection to Context-box is not READY module=builder
11:37AM DBG services/builder/builder.go:125 > connection to Context-box is IDLE, waiting for the service to be reachable module=builder
11:37AM WRN services/builder/builder.go:124 > connection to Context-box is not READY module=builder
11:37AM DBG services/builder/builder.go:125 > connection to Context-box is IDLE, waiting for the service to be reachable module=builder
11:37AM WRN services/builder/builder.go:124 > connection to Context-box is not READY module=builder
11:37AM DBG services/builder/builder.go:125 > connection to Context-box is IDLE, waiting for the service to be reachable module=builder
11:37AM INF services/builder/builder.go:120 > connection to Context-box is READY module=builder


# make contextbox fail again

11:38AM WRN services/builder/builder.go:124 > connection to Context-box is not READY module=builder
11:38AM DBG services/builder/builder.go:125 > connection to Context-box is IDLE, waiting for the service to be reachable module=builder
11:38AM WRN services/builder/builder.go:124 > connection to Context-box is not READY module=builder
11:38AM DBG services/builder/builder.go:125 > connection to Context-box is IDLE, waiting for the service to be reachable module=builder
11:38AM INF services/builder/builder.go:120 > connection to Context-box is READY module=builder
```