### PR TITLE
Fix retries in Wireguard playbook

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -21,7 +21,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 6cf8a87-1567
+  newTag: 7be3757-1569
 - name: ghcr.io/berops/claudie/builder
   newTag: 6cf8a87-1567
 - name: ghcr.io/berops/claudie/context-box

--- a/services/ansibler/server/ansible-playbooks/wireguard.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard.yml
@@ -1,13 +1,17 @@
 ---
 - hosts: nodes
   remote_user: root
-  gather_facts: true
+  gather_facts: false
   become: yes
 
   pre_tasks:
     - name: Wait 300 seconds for target connection to become reachable/usable
       wait_for_connection:
         timeout: 300
+
+    # Gather facts manually after we made sure, VMs are accessible
+    - name: Gather facts from nodes
+      ansible.builtin.setup:
 
   # abort playbook on any fatal error, the golang code will trigger a retry
   any_errors_fatal: true


### PR DESCRIPTION
Fixes #646 

Verified by running a simple input manifest. 
Logs from Ansibler:
```
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     PLAY [nodes] *******************************************************************
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     TASK [Wait 300 seconds for target connection to become reachable/usable] *******
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-1]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-3]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-2]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-2]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-1]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-3]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     TASK [Gather facts from nodes] *************************************************
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-2]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-1]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-compute-3]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-3]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-1]
VPN - services/ansibler/server/clusters/miro-cluster-hvwkuvd     ok: [gcp-control-2]
```
After this, the playbook ran as normal without any unnecessary retries.