### PR TITLE
Replace OS label with ID

### DIFF
--- a/docs/input-manifest/example.yaml
+++ b/docs/input-manifest/example.yaml
@@ -145,7 +145,7 @@ nodePools:
         zone: hel1-dc2
       count: 3
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: compute-hetzner
@@ -155,7 +155,7 @@ nodePools:
         zone: hel1-dc2
       count: 2
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: compute-hetzner-autoscaled
@@ -164,7 +164,7 @@ nodePools:
         region: hel1
         zone: hel1-dc2
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
       autoscalerConf:
         min: 1

--- a/docs/input-manifest/providers/examples/hetzner-input-manifest.md
+++ b/docs/input-manifest/providers/examples/hetzner-input-manifest.md
@@ -24,8 +24,8 @@ nodePools:
       count: 1
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
     - name: compute-1-hetzner
@@ -39,8 +39,8 @@ nodePools:
       count: 2
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
     - name: compute-2-hetzner
@@ -54,8 +54,8 @@ nodePools:
       count: 2
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
 kubernetes:
@@ -99,8 +99,8 @@ nodePools:
       count: 1
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
     - name: control-hetzner-2
@@ -114,8 +114,8 @@ nodePools:
       count: 2
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
     - name: compute-hetzner-1
@@ -129,8 +129,8 @@ nodePools:
       count: 2
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
     - name: compute-hetzner-2
@@ -144,8 +144,8 @@ nodePools:
       count: 2
       # Machine type name.
       serverType: cpx11
-      # OS image name.
-      image: ubuntu-22.04
+      # OS image ID for ubuntu-22.04.
+      image: "67794396"
       diskSize: 50
 
 kubernetes:

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -35,7 +35,7 @@ func (s *ClientHealthChecker) StartProbes() {
 
 func writeMsg(w http.ResponseWriter, msg string) {
 	if _, err := w.Write([]byte(msg)); err != nil {
-		log.Debug().Msgf("HealthCheckClient write error: ", err)
+		log.Debug().Msgf("HealthCheckClient write error: %v", err)
 	}
 }
 

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: gcp-control

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 2
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: gcp-control

--- a/manifests/testing-framework/test-sets/test-set1/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/3.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: hel1-dc2
       count: 2
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: gcp-control

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control
@@ -89,7 +89,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-lb

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control
@@ -89,7 +89,7 @@ nodePools:
         zone: nbg1-dc3
       count: 2
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-lb

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control
@@ -89,7 +89,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-lb

--- a/manifests/testing-framework/test-sets/test-set3/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/1.yaml
@@ -36,7 +36,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -45,7 +45,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control

--- a/manifests/testing-framework/test-sets/test-set3/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/2.yaml
@@ -26,7 +26,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -35,7 +35,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control

--- a/manifests/testing-framework/test-sets/test-set3/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/3.yaml
@@ -33,7 +33,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -42,7 +42,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control

--- a/manifests/testing-framework/test-sets/test-set3/4.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/4.yaml
@@ -33,7 +33,7 @@ nodePools:
         zone: nbg1-dc3
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
     - name: hetzner-compute
       providerSpec:
@@ -42,7 +42,7 @@ nodePools:
         zone: hel1-dc2
       count: 1
       serverType: cpx11
-      image: ubuntu-22.04
+      image: "67794396"
       diskSize: 50
 
     - name: oci-control


### PR DESCRIPTION
As described in Slack, the Hetzner OS image registry now contains two versions of `ubuntu-22.04`. This PR replaces this, with the correct ID of the same image.