### PR TITLE
missing param in example input manifest

### DIFF
--- a/docs/autoscaling/autoscaling.md
+++ b/docs/autoscaling/autoscaling.md
@@ -1,6 +1,6 @@
 # Autoscaling in Claudie
 
-Claudie supports autoscaling by installing [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) for Claudie-made clusters, with a custom implementation of `external gRPC cloud provider`, in Claudie context called `autoscaler-adapter`. This, together with Cluster Autoscaler is automatically managed by Claudie, for any clusters, which have at least one node pool defined with `autoscalerConf`. Whats more, you can change the node pool specification freely from autoscaler configuration to static count or vice versa. Claudie will seamlessly configure Cluster Autoscaler, or even remove it when it is no longer needed.
+Claudie supports autoscaling by installing [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) for Claudie-made clusters, with a custom implementation of `external gRPC cloud provider`, in Claudie context called `autoscaler-adapter`. This, together with Cluster Autoscaler is automatically managed by Claudie, for any clusters, which have at least one node pool defined with `autoscaler` field. Whats more, you can change the node pool specification freely from autoscaler configuration to static count or vice versa. Claudie will seamlessly configure Cluster Autoscaler, or even remove it when it is no longer needed.
 
 ## What triggers a scale up
 

--- a/docs/input-manifest/example.yaml
+++ b/docs/input-manifest/example.yaml
@@ -162,6 +162,7 @@ nodePools:
         name: hetzner-1
         region: hel1
         zone: hel1-dc2
+      count: 2
       serverType: cpx11
       image: ubuntu-22.04
       storageDiskSize: 50

--- a/docs/input-manifest/example.yaml
+++ b/docs/input-manifest/example.yaml
@@ -132,7 +132,7 @@ nodePools:
   #     serverType:       # Machine type of the nodes in this nodepool.
   #     image:            # OS image of the nodes in the nodepool.
   #     storageDiskSize:  # Disk size of the storage disk for compute nodepool.
-  #     autoscalerConf:   # Autoscaler configuration. Mutually exclusive with Count.
+  #     autoscaler:       # Autoscaler configuration. Mutually exclusive with Count.
   #       min:            # Minimum number of nodes in nodepool.
   #       max:            # Maximum number of nodes in nodepool.
   #

--- a/docs/input-manifest/example.yaml
+++ b/docs/input-manifest/example.yaml
@@ -162,11 +162,10 @@ nodePools:
         name: hetzner-1
         region: hel1
         zone: hel1-dc2
-      count: 2
       serverType: cpx11
       image: ubuntu-22.04
       storageDiskSize: 50
-      autoscalerConf:
+      autoscaler:
         min: 1
         max: 5
 

--- a/docs/input-manifest/input-manifest.md
+++ b/docs/input-manifest/input-manifest.md
@@ -222,7 +222,7 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 
 - `count`
 
-  Number of the nodes in the nodepool. Mutually exclusive with `autoscalerConf`.
+  Number of the nodes in the nodepool. Mutually exclusive with `autoscaler`.
 
 - `serverType`
   
@@ -244,7 +244,7 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 
   This field is optional, however, if compute nodepool does not define it, default value is used for creation of storage disk. Control nodepools and Loadbalancer nodepools ignore this field.
 
-- `autoscalerConf` [Autoscaler Configuration](#autoscaler-configuration)
+- `autoscaler` [Autoscaler Configuration](#autoscaler-configuration)
   
   Autoscaler configuration for this nodepool. Mutually exclusive with `count`.
 


### PR DESCRIPTION
ERR Skipping over file /input-manifests/manifest.yaml due to processing error : failed to validate nodepools section inside manifest: failed to validate DynamicNodePool "compute-hetzner-autoscaled": Key: 'DynamicNodePool.Count' Error:Field validation for 'Count' failed on the 'required_without' tag module=frontend