### PR TITLE
Feat/volume replication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ dynamodb:
 # -timeout 0 will disable default timeout
 # Successful test will end with infrastructure being destroyed
 test:
-	AUTO_CLEAN_UP=TRUE go test -v ./services/testing-framework -timeout 0 -count=1 -run TestClaudie
+	AUTO_CLEAN_UP=TRUE GOLANG_LOG=debug go test -v ./services/testing-framework -timeout 0 -count=1 -run TestClaudie
 
 # Run the golang linter
 lint:

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -21,18 +21,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: d801197-1787
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/builder
-  newTag: d801197-1787
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/context-box
-  newTag: d801197-1787
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/frontend
-  newTag: 834a4ac-1752
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 834a4ac-1752
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/kuber
-  newTag: d801197-1787
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 834a4ac-1752
+  newTag: c59989d-1807
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: d801197-1787
+  newTag: c59989d-1807

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -25,4 +25,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: d801197-1787
+  newTag: c59989d-1807

--- a/services/kuber/server/nodes/delete.go
+++ b/services/kuber/server/nodes/delete.go
@@ -223,7 +223,7 @@ func (d *Deleter) assureReplication(kc kubectl.Kubectl, worker string) error {
 				time.Sleep(newReplicaCreationTimeout)
 
 				// Verify all current replicas are running correctly
-				if err := verifyAllReplicasSetUp(r, v.Metadata.Name, kc); err != nil {
+				if err := verifyAllReplicasSetUp(v.Metadata.Name, kc); err != nil {
 					return fmt.Errorf("error while checking if all longhorn replicas for volume %s are running : %w", v.Metadata.Name, err)
 				}
 				log.Info().Msgf("Replication for volume %s has been set up", v.Metadata.Name)

--- a/services/kuber/server/nodes/delete.go
+++ b/services/kuber/server/nodes/delete.go
@@ -101,12 +101,8 @@ func (d *Deleter) DeleteNodes() (*pb.K8Scluster, error) {
 		if err := d.deleteNodesByName(kubectl, worker, realNodeNames); err != nil {
 			return nil, fmt.Errorf("error while deleting nodes from worker nodes for %s : %w", d.clusterPrefix, err)
 		}
-		// NOTE: Might need to verify if the volume got detached. The issue is still being discussed in #longhorn channel in CNCF slack workspace.
-		// https://cloud-native.slack.com/archives/CNVPEL9U3/p1683744899327089
-		// Issue seen, when once the node is deleted, some volumes might be still attached to the already deleted node, even though all replicas
-		// have moved to other nodes in cluster. Once manually detaching the volume from already deleted node (via UI), it attached again to a new node
-		// with no issues. Since there is no easy way how to verify and detach volume in some CLI way (due to longhorn policy of  doing everything via UI
-		// in ClickOps), leaving this note until discussion with longhorn maintainers concludes.
+		// NOTE: Might need to manually verify if the volume got detached.
+		// https://github.com/berops/claudie/issues/784
 	}
 
 	// Update the current cluster

--- a/services/kuber/server/nodes/pvc_replication_utils.go
+++ b/services/kuber/server/nodes/pvc_replication_utils.go
@@ -52,7 +52,7 @@ const (
 	pvcReplicationTimeout = 5 * time.Minute
 )
 
-// getVolumes returns a map of volumes currently in the cluster.
+// getVolumes returns a map[volume name]volume of volumes currently in the cluster.
 func getVolumes(kc kubectl.Kubectl) (map[string]LonghornVolume, error) {
 	out, err := kc.KubectlGet(volumes, "-n", longhornNamespace, "-o", "yaml")
 	if err != nil {

--- a/services/kuber/server/nodes/pvc_replication_utils.go
+++ b/services/kuber/server/nodes/pvc_replication_utils.go
@@ -40,6 +40,7 @@ type VolumeSpec struct {
 type Status struct {
 	OwnerID      string `yaml:"ownerID"`
 	CurrentState string `yaml:"currentState"`
+	Started      bool   `yaml:"started"`
 }
 
 const (
@@ -141,7 +142,7 @@ func verifyAllReplicasRunning(r LonghornReplica, volumeName string, kc kubectl.K
 	for _, r := range replicaList.Items {
 		if r.Spec.VolumeName == volumeName {
 			// Current state not running, return false.
-			if r.Status.CurrentState != runningState {
+			if !(r.Status.CurrentState == runningState && r.Status.Started) {
 				return false, nil
 			}
 		}

--- a/services/kuber/server/nodes/pvc_replication_utils.go
+++ b/services/kuber/server/nodes/pvc_replication_utils.go
@@ -98,7 +98,7 @@ func verifyAllReplicasSetUp(r LonghornReplica, volumeName string, kc kubectl.Kub
 				if ok {
 					return nil
 				} else {
-					log.Info().Msgf("Volume replication is not ready yet, retrying check for replication status of %s volume", volumeName)
+					log.Debug().Msgf("Volume replication is not ready yet, retrying check for replication status of %s volume", volumeName)
 				}
 			}
 		case <-ctx.Done():

--- a/services/kuber/server/nodes/pvc_replication_utils.go
+++ b/services/kuber/server/nodes/pvc_replication_utils.go
@@ -1,9 +1,12 @@
 package nodes
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/berops/claudie/internal/kubectl"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,13 +38,17 @@ type VolumeSpec struct {
 }
 
 type Status struct {
-	OwnerID string `yaml:"ownerID"`
+	OwnerID      string `yaml:"ownerID"`
+	CurrentState string `yaml:"currentState"`
 }
 
 const (
 	replicas              = "replicas.longhorn.io"
 	volumes               = "volumes.longhorn.io"
 	patchNumberOfReplicas = "{\"spec\":{\"numberOfReplicas\":%d}}"
+	runningState          = "running"
+	replicaRunningCheck   = 5 * time.Second
+	pvcReplicationTimeout = 5 * time.Minute
 )
 
 // getVolumes returns a map of volumes currently in the cluster.
@@ -63,21 +70,40 @@ func getVolumes(kc kubectl.Kubectl) (map[string]LonghornVolume, error) {
 }
 
 // getReplicas returns a map of nodes and slice of replicas they contain.
-func getReplicas(kc kubectl.Kubectl) (map[string][]LonghornReplica, error) {
-	out, err := kc.KubectlGet(replicas, "-n", longhornNamespace, "-o", "yaml")
+func getReplicasMap(kc kubectl.Kubectl) (map[string][]LonghornReplica, error) {
+	replicaList, err := getReplicas(kc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all replicas : %w", err)
+		return nil, err
 	}
-	var replicaList K8sList[LonghornReplica]
-	if err := yaml.Unmarshal(out, &replicaList); err != nil {
-		return nil, fmt.Errorf("failed unmarshal kubectl output : %w", err)
-	}
-
 	m := make(map[string][]LonghornReplica, len(replicaList.Items))
 	for _, r := range replicaList.Items {
 		m[r.Status.OwnerID] = append(m[r.Status.OwnerID], r)
 	}
 	return m, nil
+}
+
+func verifyAllReplicasSetUp(r LonghornReplica, volumeName string, kc kubectl.Kubectl) error {
+	ticker := time.NewTicker(replicaRunningCheck)
+	ctx, cancel := context.WithTimeout(context.Background(), pvcReplicationTimeout)
+	defer cancel()
+	// Check for the replication status
+	for {
+		select {
+		case <-ticker.C:
+			if ok, err := verifyAllReplicasRunning(r, volumeName, kc); err != nil {
+				log.Warn().Msgf("Got error while checking for replication status of %s volume : %v", volumeName, err)
+				log.Info().Msgf("Retrying check for replication status of %s volume", volumeName)
+			} else {
+				if ok {
+					return nil
+				} else {
+					log.Info().Msgf("Volume replication is not ready yet, retrying check for replication status of %s volume", volumeName)
+				}
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("error while checking the status of volume %s replication : %w", volumeName, ctx.Err())
+		}
+	}
 }
 
 // deleteReplica deletes a replica from a node.
@@ -93,4 +119,33 @@ func increaseReplicaCount(v LonghornVolume, kc kubectl.Kubectl) error {
 // revertReplicaCount sets the number of replicas for longhorn volume to the original value, taken from the v, via kubectl patch
 func revertReplicaCount(v LonghornVolume, kc kubectl.Kubectl) error {
 	return kc.KubectlPatch(volumes, v.Metadata.Name, fmt.Sprintf(patchNumberOfReplicas, v.Spec.NumberOfReplicas), "-n", longhornNamespace, "--type", "merge")
+}
+
+func getReplicas(kc kubectl.Kubectl) (K8sList[LonghornReplica], error) {
+	out, err := kc.KubectlGet(replicas, "-n", longhornNamespace, "-o", "yaml")
+	if err != nil {
+		return K8sList[LonghornReplica]{}, fmt.Errorf("failed to list all replicas : %w", err)
+	}
+	var replicaList K8sList[LonghornReplica]
+	if err := yaml.Unmarshal(out, &replicaList); err != nil {
+		return K8sList[LonghornReplica]{}, fmt.Errorf("failed unmarshal kubectl output : %w", err)
+	}
+	return replicaList, nil
+}
+
+func verifyAllReplicasRunning(r LonghornReplica, volumeName string, kc kubectl.Kubectl) (bool, error) {
+	replicaList, err := getReplicas(kc)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range replicaList.Items {
+		if r.Spec.VolumeName == volumeName {
+			// Current state not running, return false.
+			if r.Status.CurrentState != runningState {
+				return false, nil
+			}
+		}
+	}
+	// All replicas for specific volume are running, return true.
+	return true, nil
 }

--- a/services/terraformer/templates/gcp.tpl
+++ b/services/terraformer/templates/gcp.tpl
@@ -110,6 +110,14 @@ EOF
     managed-by = "claudie"
     claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
   }
+
+  {{- if not $nodepool.IsControl}}
+  # As the storage disk is attached via google_compute_attached_disk, 
+  # we must ignore attached_disk property.
+  lifecycle {
+    ignore_changes = [attached_disk]
+  }
+  {{- end }}
 }
 
 {{- if not $nodepool.IsControl }}

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -104,7 +104,12 @@ func getError(c *pb.Config) error {
 	var err error
 	for cluster, state := range c.State {
 		if state.Status == pb.Workflow_ERROR {
-			err = fmt.Errorf("----\nerror in cluster %s\n----\nStage: %s \n State: %s\n Description: %s \n %w", cluster, state.Stage, state.Status, state.Description, err)
+			err1 := fmt.Errorf("----\nerror in cluster %s\n----\nStage: %s \n State: %s\n Description: %s", cluster, state.Stage, state.Status, state.Description)
+			if err == nil {
+				err = err1
+			} else {
+				err = fmt.Errorf("%w \n %w", err1, err)
+			}
 		}
 	}
 	return err


### PR DESCRIPTION
This PR fixes the issue described in #746 by implementing more checks and cordoning the nodes before Claudie will move Replicas of Volumes. This was tested by migrating the ETDC cluster to multiple new node pools, where each migration resulted in the same state of the database.

There might occasionally be still one issue, which is not severe, as all replicas will migrate with the data correctly. The issue is described as a note in [one comment](https://github.com/berops/claudie/compare/feat/volume-replication?expand=1#diff-83286613a1db2b0823d24bedfdef1758c39d2ac7f08a39a1a8b491fc0930d0bbR111-R116), with the link to the discussion I started with Longhorn maintainers. 