### PR TITLE
Feature/put support for spot instances on the roadmap

### DIFF
--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -8,5 +8,5 @@
 - [ ] Periodic health checks & sync loops for the managed clusters
 - [ ] Hybrid-cloud support (on-premises)
 - [ ] `arm64` support for the nodepools
-- [ ] Support Spot instances
+- [ ] Support for Spot instances
 - [x] Autoscaler

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -8,4 +8,5 @@
 - [ ] Periodic health checks & sync loops for the managed clusters
 - [ ] Hybrid-cloud support (on-premises)
 - [ ] `arm64` support for the nodepools
+- [ ] Support Spot instances
 - [x] Autoscaler


### PR DESCRIPTION
Add support for Spot instances on the Roadmap.

FYI: It will be possible to add it on the Roadmap on [docs.claudie.io](docs.claudie.io) only, when changes from current PR and [this](https://github.com/berops/claudie/pull/791) PR will be merged together or to the master.