### PR TITLE
Make dynamo create table job idempotent

### DIFF
--- a/manifests/claudie/dynamo/cm.yaml
+++ b/manifests/claudie/dynamo/cm.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dynamodb-cm
+  labels:
+    app.kubernetes.io/part-of: claudie
+    app.kubernetes.io/name: dynamo
+data:
+  initialize: |
+    aws dynamodb describe-table \
+    --table-name $DYNAMO_TABLE_NAME \
+    --endpoint-url http://$DYNAMO_HOSTNAME:$DYNAMO_PORT > /dev/null 2>&1
+
+    if [ $? -ne 0 ]; then
+        echo "Creating table '$DYNAMO_TABLE_NAME'."
+        aws dynamodb create-table \
+        --table-name $DYNAMO_TABLE_NAME \
+        --attribute-definitions AttributeName=LockID,AttributeType=S \
+        --key-schema AttributeName=LockID,KeyType=HASH \
+        --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+        --endpoint-url http://$DYNAMO_HOSTNAME:$DYNAMO_PORT \
+        --region $AWS_REGION \
+        --output json
+    else
+        echo "Table '$DYNAMO_TABLE_NAME' already exists."
+    fi

--- a/manifests/claudie/dynamo/job.yaml
+++ b/manifests/claudie/dynamo/job.yaml
@@ -14,33 +14,15 @@ spec:
     spec:
       restartPolicy: OnFailure
       volumes:
-        - name: minio-configuration
+        - name: dynamodb-configuration
           projected:
             sources:
               - configMap:
-                  name: minio-cm
+                  name: dynamodb-cm
       containers:
         - name: awc-cli
           image: amazon/aws-cli
-          args:
-            [
-              "dynamodb",
-              "create-table",
-              "--table-name",
-              "$(DYNAMO_TABLE_NAME)",
-              "--attribute-definitions",
-              "AttributeName=LockID,AttributeType=S",
-              "--key-schema",
-              "AttributeName=LockID,KeyType=HASH",
-              "--provisioned-throughput",
-              "ReadCapacityUnits=1,WriteCapacityUnits=1",
-              "--endpoint-url",
-              "http://$(DYNAMO_HOSTNAME):$(DYNAMO_PORT)",
-              "--output",
-              "json",
-              "--region",
-              "$(AWS_REGION)",
-            ]
+          command: ["/bin/sh", "/config/initialize"]
           env:
             - name: DYNAMO_HOSTNAME
               valueFrom:
@@ -72,10 +54,13 @@ spec:
                 configMapKeyRef:
                   name: env
                   key: AWS_REGION
+          volumeMounts:
+            - name: dynamodb-configuration
+              mountPath: /config
           resources:
             requests:
               memory: 128Mi
-              cpu: 10m
+              cpu: 50m
             limits:
               memory: 200Mi
-              cpu: 35m
+              cpu: 100m

--- a/manifests/claudie/dynamo/kustomization.yaml
+++ b/manifests/claudie/dynamo/kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
 resources:
   - dynamodb.yaml
   - job.yaml
+  - cm.yaml
 secretGenerator:
   - name: dynamo-secret
     files:


### PR DESCRIPTION
fixes #814.

When users upgrade Claudie, they must remove completed jobs (`create-table-job` and `make-bucket-job`) as some fields are immutable. However, `create-table-job` was not idempotent and was failing once redeployed. This PR fixes it.