### PR TITLE
Feat/reference markdown from manifest claudie readme

### DIFF
--- a/docs/deploying-claudie.md
+++ b/docs/deploying-claudie.md
@@ -1,0 +1,3 @@
+{%
+    include-markdown "../manifests/claudie/README.md"
+%}

--- a/docs/input-manifest/example.md
+++ b/docs/input-manifest/example.md
@@ -1,3 +1,3 @@
-``` yaml title="example.yaml"
---8<-- "docs/input-manifest/example.yaml"
+```yaml title="example.yaml"
+{% include "./example.yaml" %}
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ plugins:
       width: 100%
       height: auto
       zoomable: true
+  - include-markdown
   - material-plausible
 
 copyright: |
@@ -50,6 +51,7 @@ nav:
   - Getting Started:
     - getting-started/get-started-using-claudie.md
     - CRUD for Claudie: crud/crud.md
+    - Deploying Claudie: deploying-claudie.md
   - Input manifest: 
       - input-manifest/api-reference.md
       - Example yaml file: input-manifest/example.md
@@ -98,21 +100,4 @@ extra:
           name: No, it could be a lot better
           data: bad
           note: >-
-            Thanks for your feedback! Help us improve this page by filling out this feedback form.
-            <br>
-            <br>
-            <form role="form" action="https://formspree.io/f/mzbqlkdj" method="POST">
-              <label>
-                Your email:
-                <br>
-                <input required=true type="email" name="email" style="width: 100%;">
-              </label>
-              <br>
-              <label>
-                Your message:
-                <br>
-                <textarea rows="8" style="width: 100%;" name="message"></textarea>
-              </label>
-              <br>
-              <button type="submit" style="background-color: #4CAF50; color: white; padding: 10px 20px; width: 100%; border: none; cursor: pointer;">Send</button>
-            </form>
+            Thanks for your feedback!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,5 +98,21 @@ extra:
           name: No, it could be a lot better
           data: bad
           note: >-
-            Thanks for your feedback! Help us improve this page by
-            using our <a href="..." target="_blank" rel="noopener">feedback form</a>.
+            Thanks for your feedback! Help us improve this page by filling out this feedback form.
+            <br>
+            <br>
+            <form role="form" action="https://formspree.io/f/mzbqlkdj" method="POST">
+              <label>
+                Your email:
+                <br>
+                <input required=true type="email" name="email" style="width: 100%;">
+              </label>
+              <br>
+              <label>
+                Your message:
+                <br>
+                <textarea rows="8" style="width: 100%;" name="message"></textarea>
+              </label>
+              <br>
+              <button type="submit" style="background-color: #4CAF50; color: white; padding: 10px 20px; width: 100%; border: none; cursor: pointer;">Send</button>
+            </form>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,14 @@ idna==3.4
 Jinja2==3.1.2
 Markdown==3.3.7
 MarkupSafe==2.1.2
+material-plausible-plugin==0.2.0
 mergedeep==1.3.4
 mike==1.1.2
 mkdocs==1.4.2
 mkdocs-glightbox==0.3.4
+mkdocs-include-markdown-plugin==4.0.4
 mkdocs-material==9.1.8
 mkdocs-material-extensions==1.1.1
-material-plausible-plugin==0.2.0
 packaging==23.1
 Pygments==2.15.1
 pymdown-extensions==10.0


### PR DESCRIPTION
Add Deploying Claudie from manifests/claudie/README.md and fix displaying content of example input-manifest, because it stopped displaying for unknown reason to me.