### PR TITLE
change release-docs pipeline trigger

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,10 +1,9 @@
 name: Release docs pipeline
 # Only trigger, when the release workflow has completed
 on:
-  workflow_run:
-    workflows: ["Release pipeline"]
-    types:
-      - completed
+  # Run when release is published
+  release:
+    types: [published]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Change the trigger of the release-docs pipeline to the same as the release pipeline has, because the release tag in Set release tag step wasn't successfully created.