### PR TITLE
fix href to feedback form

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,4 +98,4 @@ extra:
           data: bad
           note: >-
             Thanks for your feedback! Help us improve this page by
-            using our <a href="/feedback/feedback-form/" target="_blank" rel="noopener">feedback form</a>.
+            using our <a href="/latest/feedback/feedback-form/" target="_blank" rel="noopener">feedback form</a>.


### PR DESCRIPTION
This PR just fix the path to our feedback form (had to add `latest`, because we are using versioning).