### PR TITLE
Revert "fix href to feedback form"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,4 +99,4 @@ extra:
           data: bad
           note: >-
             Thanks for your feedback! Help us improve this page by
-            using our <a href="/latest/feedback/feedback-form/" target="_blank" rel="noopener">feedback form</a>.
+            using our <a href="/feedback/feedback-form/" target="_blank" rel="noopener">feedback form</a>.


### PR DESCRIPTION
Reverts berops/claudie#887

It seems this commit broke the feedback form (it worked earlier today). Therefore the revert.