### PR TITLE
Fix/grpc keepalive

### DIFF
--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -2,10 +2,13 @@ package utils
 
 import (
 	"fmt"
-
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+	"time"
 )
 
 // CloseClientConnection is a wrapper around grpc.ClientConn Close function
@@ -16,10 +19,48 @@ func CloseClientConnection(connection *grpc.ClientConn) {
 }
 
 func GrpcDialWithInsecure(serviceName string, serviceURL string) (*grpc.ClientConn, error) {
-	cc, err := grpc.Dial(serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	kacp := keepalive.ClientParameters{
+		Time:                60 * time.Second, // ping the server every ~60 seconds.
+		Timeout:             20 * time.Minute, // wait up to 20 minutes for a packet to be acknowledged.
+		PermitWithoutStream: true,             // send pings if there are no active streams (RPCs).
+	}
+
+	cc, err := grpc.Dial(serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to %s: %w", serviceName, err)
 	}
 
 	return cc, nil
+}
+
+// GrpcDialWithRetryAndBackoff creates an insecure gRPC connection to serviceURL
+// After successfully connected, any RPC calls made from this connection also have a retry
+// policy of ~10 minutes after which an error is returned that it couldn't connect to the service.
+func GrpcDialWithRetryAndBackoff(serviceName, serviceURL string) (*grpc.ClientConn, error) {
+	kacp := keepalive.ClientParameters{
+		Time:                60 * time.Second, // ping the server every ~60 seconds.
+		Timeout:             20 * time.Minute, // wait up to 20 minutes for a packet to be acknowledged.
+		PermitWithoutStream: true,             // send pings if there are no active streams (RPCs).
+	}
+
+	// retry policy for RPC calls.
+	opts := []grpc_retry.CallOption{
+		grpc_retry.WithBackoff(grpc_retry.BackoffLinearWithJitter(45*time.Second, 0.1)),
+		grpc_retry.WithMax(15),
+		grpc_retry.WithCodes(codes.Unavailable),
+	}
+
+	conn, err := grpc.Dial(
+		serviceURL,
+		grpc.WithKeepaliveParams(kacp),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(opts...)),
+		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(opts...)),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to %s: %w", serviceName, err)
+	}
+
+	return conn, nil
 }

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -18,35 +18,20 @@ func CloseClientConnection(connection *grpc.ClientConn) {
 	}
 }
 
-func GrpcDialWithInsecure(serviceName string, serviceURL string) (*grpc.ClientConn, error) {
-	kacp := keepalive.ClientParameters{
-		Time:                60 * time.Second, // ping the server every ~60 seconds.
-		Timeout:             20 * time.Minute, // wait up to 20 minutes for a packet to be acknowledged.
-		PermitWithoutStream: true,             // send pings if there are no active streams (RPCs).
-	}
-
-	cc, err := grpc.Dial(serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
-	if err != nil {
-		return nil, fmt.Errorf("could not connect to %s: %w", serviceName, err)
-	}
-
-	return cc, nil
-}
-
 // GrpcDialWithRetryAndBackoff creates an insecure gRPC connection to serviceURL
 // After successfully connected, any RPC calls made from this connection also have a retry
 // policy of ~10 minutes after which an error is returned that it couldn't connect to the service.
 func GrpcDialWithRetryAndBackoff(serviceName, serviceURL string) (*grpc.ClientConn, error) {
 	kacp := keepalive.ClientParameters{
-		Time:                60 * time.Second, // ping the server every ~60 seconds.
-		Timeout:             20 * time.Minute, // wait up to 20 minutes for a packet to be acknowledged.
+		Time:                45 * time.Second, // ping the server every ~60 seconds.
+		Timeout:             5 * time.Minute,  // wait up to 20 minutes for a packet to be acknowledged.
 		PermitWithoutStream: true,             // send pings if there are no active streams (RPCs).
 	}
 
 	// retry policy for RPC calls.
 	opts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffLinearWithJitter(45*time.Second, 0.1)),
-		grpc_retry.WithMax(15),
+		grpc_retry.WithMax(6),
 		grpc_retry.WithCodes(codes.Unavailable),
 	}
 

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -23,8 +23,8 @@ func CloseClientConnection(connection *grpc.ClientConn) {
 // policy of ~10 minutes after which an error is returned that it couldn't connect to the service.
 func GrpcDialWithRetryAndBackoff(serviceName, serviceURL string) (*grpc.ClientConn, error) {
 	kacp := keepalive.ClientParameters{
-		Time:                45 * time.Second, // ping the server every ~60 seconds.
-		Timeout:             5 * time.Minute,  // wait up to 20 minutes for a packet to be acknowledged.
+		Time:                45 * time.Second, // ping the server every ~45 seconds.
+		Timeout:             5 * time.Minute,  // wait up to 5 minutes for a packet to be acknowledged.
 		PermitWithoutStream: true,             // send pings if there are no active streams (RPCs).
 	}
 

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -27,8 +27,8 @@ func NewGRPCServer() *grpc.Server {
 		}),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle:     math.MaxInt64,   // If a client is idle for INFINITE seconds, send a GOAWAY.
-			MaxConnectionAge:      math.MaxInt64,   // If any connection is alive for more than INIFINITE seconds, send a GOAWAY.
-			MaxConnectionAgeGrace: math.MaxInt64,   // Allow INIFNITE seconds for pending RPCs to complete before forcibly closing connections.
+			MaxConnectionAge:      math.MaxInt64,   // If any connection is alive for more than INFINITE seconds, send a GOAWAY.
+			MaxConnectionAgeGrace: math.MaxInt64,   // Allow INFINITE seconds for pending RPCs to complete before forcibly closing connections.
 			Time:                  2 * time.Hour,   // Ping the client if it is idle for 2 Hours to ensure the connection is still active.
 			Timeout:               5 * time.Minute, // Wait 5 minutes for the ping ack before assuming the connection is dead.
 		}),

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -55,20 +55,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/frontend
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -55,20 +55,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/context-box
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/frontend
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/kuber
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -32,4 +32,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 32d3fc7-2057
+  newTag: c5a3fb5-2071

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -32,4 +32,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: c5a3fb5-2071
+  newTag: c7e6d35-2085

--- a/services/ansibler/server/adapters/inbound/grpc/adapter.go
+++ b/services/ansibler/server/adapters/inbound/grpc/adapter.go
@@ -32,7 +32,7 @@ func CreateGrpcAdapter() *GrpcAdapter {
 		log.Fatal().Msgf("Failed to listen on %s : %v", tcpBindingAddress, err)
 	}
 
-	g := &GrpcAdapter{tcpListener: listener, server: grpc.NewServer(), healthcheckServer: health.NewServer()}
+	g := &GrpcAdapter{tcpListener: listener, server: utils.NewGRPCServer(), healthcheckServer: health.NewServer()}
 	log.Info().Msgf("Ansibler microservice is listening on %s", tcpBindingAddress)
 
 	pb.RegisterAnsiblerServiceServer(g.server, &AnsiblerGrpcService{})

--- a/services/autoscaler-adapter/claudie_provider/claudie_node_groups.go
+++ b/services/autoscaler-adapter/claudie_provider/claudie_node_groups.go
@@ -167,7 +167,7 @@ func (c *ClaudieCloudProvider) updateNodepool(nodepool *pb.NodePool) error {
 	var err error
 
 	cboxURL := strings.ReplaceAll(envs.ContextBoxURL, ":tcp://", "")
-	if cc, err = utils.GrpcDialWithInsecure("context-box", cboxURL); err != nil {
+	if cc, err = utils.GrpcDialWithRetryAndBackoff("context-box", cboxURL); err != nil {
 		return fmt.Errorf("failed to dial context-box at %s : %w", envs.ContextBoxURL, err)
 	}
 	cbox := pb.NewContextBoxServiceClient(cc)

--- a/services/autoscaler-adapter/claudie_provider/claudie_provider.go
+++ b/services/autoscaler-adapter/claudie_provider/claudie_provider.go
@@ -82,7 +82,7 @@ func getClaudieState(projectName, clusterName string) (*pb.K8Scluster, error) {
 	var res *pb.GetConfigFromDBResponse
 	cboxURL := strings.ReplaceAll(envs.ContextBoxURL, ":tcp://", "")
 
-	if cc, err = utils.GrpcDialWithInsecure("context-box", cboxURL); err != nil {
+	if cc, err = utils.GrpcDialWithRetryAndBackoff("context-box", cboxURL); err != nil {
 		return nil, fmt.Errorf("failed to dial context-box at %s : %w", cboxURL, err)
 	}
 	defer func() {

--- a/services/autoscaler-adapter/claudie_provider/claudie_provider_test.go
+++ b/services/autoscaler-adapter/claudie_provider/claudie_provider_test.go
@@ -17,7 +17,7 @@ func TestRefresh(t *testing.T) {
 	var err error
 	URL := "localhost:50000"
 
-	if cc, err = utils.GrpcDialWithInsecure("adapter", URL); err != nil {
+	if cc, err = utils.GrpcDialWithRetryAndBackoff("adapter", URL); err != nil {
 		t.Error(err)
 	}
 

--- a/services/autoscaler-adapter/main.go
+++ b/services/autoscaler-adapter/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/services/autoscaler-adapter/claudie_provider"
 	"github.com/rs/zerolog/log"
-	"google.golang.org/grpc"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/externalgrpc/protos"
 )
 
@@ -22,7 +21,7 @@ func main() {
 	}
 	utils.InitLog(fmt.Sprintf("%s-%s", "autoscaler-adapter", clusterName))
 
-	server := grpc.NewServer()
+	server := utils.NewGRPCServer()
 
 	// Listen
 	serviceAddr := net.JoinHostPort("0.0.0.0", port)

--- a/services/builder/builder.go
+++ b/services/builder/builder.go
@@ -36,7 +36,7 @@ func healthCheck() error {
 		"kuber":       envs.KuberURL,
 	}
 	for service, url := range services {
-		if cc, err := utils.GrpcDialWithInsecure(service, url); err != nil {
+		if cc, err := utils.GrpcDialWithRetryAndBackoff(service, url); err != nil {
 			return err
 		} else {
 			if err := cc.Close(); err != nil {

--- a/services/builder/builder.go
+++ b/services/builder/builder.go
@@ -56,7 +56,7 @@ func main() {
 }
 
 func run() error {
-	conn, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
+	conn, err := utils.GrpcDialWithRetryAndBackoff("context-box", envs.ContextBoxURL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to context-box on %s : %w", envs.ContextBoxURL, err)
 	}

--- a/services/builder/serviceCaller.go
+++ b/services/builder/serviceCaller.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-
 	"github.com/rs/zerolog/log"
 
 	"github.com/berops/claudie/internal/envs"
@@ -125,7 +124,7 @@ func callTerraformer(ctx *BuilderContext, cboxClient pb.ContextBoxServiceClient)
 		return err
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("terraformer", envs.TerraformerURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("terraformer", envs.TerraformerURL)
 	if err != nil {
 		return err
 	}
@@ -180,7 +179,7 @@ func callUpdateAPIEndpoint(ctx *BuilderContext, cboxClient pb.ContextBoxServiceC
 		return err
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("ansibler", envs.AnsiblerURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("ansibler", envs.AnsiblerURL)
 	if err != nil {
 		return err
 	}
@@ -221,7 +220,7 @@ func callAnsibler(ctx *BuilderContext, cboxClient pb.ContextBoxServiceClient) er
 		return err
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("ansibler", envs.AnsiblerURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("ansibler", envs.AnsiblerURL)
 	if err != nil {
 		return err
 	}
@@ -331,7 +330,7 @@ func callKubeEleven(ctx *BuilderContext, cboxClient pb.ContextBoxServiceClient) 
 		return err
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("kube-eleven", envs.KubeElevenURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("kube-eleven", envs.KubeElevenURL)
 	if err != nil {
 		return err
 	}
@@ -368,7 +367,7 @@ func callPatchClusterInfoConfigMap(ctx *BuilderContext, cboxClient pb.ContextBox
 	description := ctx.Workflow.Description
 	ctx.Workflow.Stage = pb.Workflow_KUBER
 
-	cc, err := utils.GrpcDialWithInsecure("kuber", envs.KuberURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("kuber", envs.KuberURL)
 	if err != nil {
 		return err
 	}
@@ -398,7 +397,7 @@ func callKuber(ctx *BuilderContext, cboxClient pb.ContextBoxServiceClient) error
 	description := ctx.Workflow.Description
 	ctx.Workflow.Stage = pb.Workflow_KUBER
 
-	cc, err := utils.GrpcDialWithInsecure("kuber", envs.KuberURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("kuber", envs.KuberURL)
 	if err != nil {
 		return err
 	}
@@ -513,7 +512,7 @@ func destroyCluster(ctx *BuilderContext, c pb.ContextBoxServiceClient) error {
 		return fmt.Errorf("error in destroy config Terraformer for config %s project %s : %w", ctx.GetClusterName(), ctx.projectName, err)
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("kuber", envs.KuberURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("kuber", envs.KuberURL)
 	if err != nil {
 		return err
 	}
@@ -548,7 +547,7 @@ func destroyConfigTerraformer(ctx *BuilderContext, cboxClient pb.ContextBoxServi
 		return err
 	}
 
-	cc, err := utils.GrpcDialWithInsecure("terraformer", envs.TerraformerURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("terraformer", envs.TerraformerURL)
 	if err != nil {
 		return err
 	}
@@ -613,7 +612,7 @@ func deleteClusterData(ctx *BuilderContext, cboxClient pb.ContextBoxServiceClien
 func callDeleteNodes(master, worker []string, cluster *pb.K8Scluster) (*pb.K8Scluster, error) {
 	logger := utils.CreateLoggerWithClusterName(utils.GetClusterID(cluster.ClusterInfo))
 
-	cc, err := utils.GrpcDialWithInsecure("kuber", envs.KuberURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("kuber", envs.KuberURL)
 	if err != nil {
 		return nil, err
 	}

--- a/services/context-box/client/client_test.go
+++ b/services/context-box/client/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ClientConnection() (pb.ContextBoxServiceClient, *grpc.ClientConn) {
-	cc, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("context-box", envs.ContextBoxURL)
 	if err != nil {
 		log.Fatal().Err(err)
 	}

--- a/services/context-box/server/adapters/inbound/grpc/adapter.go
+++ b/services/context-box/server/adapters/inbound/grpc/adapter.go
@@ -2,15 +2,11 @@ package grpc
 
 import (
 	"fmt"
-	"google.golang.org/grpc/keepalive"
-	"math"
-	"net"
-	"time"
-
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"net"
 
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb"
@@ -40,13 +36,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 
 	log.Info().Msgf("context-box microservice bound to %s", listeningAddress)
 
-	g.server = grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionIdle:     math.MaxInt64,
-		MaxConnectionAge:      math.MaxInt64,
-		MaxConnectionAgeGrace: math.MaxInt64,
-		Time:                  2 * time.Hour,
-		Timeout:               10 * time.Minute,
-	}))
+	g.server = grpc.NewServer()
 	pb.RegisterContextBoxServiceServer(g.server, &ContextBoxGrpcService{usecases: usecases})
 
 	// Add health-check service to gRPC

--- a/services/context-box/server/adapters/inbound/grpc/adapter.go
+++ b/services/context-box/server/adapters/inbound/grpc/adapter.go
@@ -2,7 +2,10 @@ package grpc
 
 import (
 	"fmt"
+	"google.golang.org/grpc/keepalive"
+	"math"
 	"net"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -37,7 +40,13 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 
 	log.Info().Msgf("context-box microservice bound to %s", listeningAddress)
 
-	g.server = grpc.NewServer()
+	g.server = grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionIdle:     math.MaxInt64,
+		MaxConnectionAge:      math.MaxInt64,
+		MaxConnectionAgeGrace: math.MaxInt64,
+		Time:                  2 * time.Hour,
+		Timeout:               10 * time.Minute,
+	}))
 	pb.RegisterContextBoxServiceServer(g.server, &ContextBoxGrpcService{usecases: usecases})
 
 	// Add health-check service to gRPC

--- a/services/context-box/server/adapters/inbound/grpc/adapter.go
+++ b/services/context-box/server/adapters/inbound/grpc/adapter.go
@@ -36,7 +36,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 
 	log.Info().Msgf("context-box microservice bound to %s", listeningAddress)
 
-	g.server = grpc.NewServer()
+	g.server = utils.NewGRPCServer()
 	pb.RegisterContextBoxServiceServer(g.server, &ContextBoxGrpcService{usecases: usecases})
 
 	// Add health-check service to gRPC

--- a/services/kube-eleven/server/adapters/inbound/grpc/adapter.go
+++ b/services/kube-eleven/server/adapters/inbound/grpc/adapter.go
@@ -38,7 +38,7 @@ func CreateGrpcAdapter(usecases *usecases.Usecases) *GrpcAdapter {
 	}
 	log.Info().Msgf("Kube-eleven microservice is listening on %s", bindingAddress)
 
-	g.server = grpc.NewServer()
+	g.server = utils.NewGRPCServer()
 	pb.RegisterKubeElevenServiceServer(g.server, &KubeElevenGrpcService{usecases: usecases})
 
 	// Add healthcheck service to the gRPC server

--- a/services/kuber/server/server.go
+++ b/services/kuber/server/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"gopkg.in/yaml.v3"
@@ -432,7 +431,7 @@ func main() {
 	}
 	log.Info().Msgf("Kuber service is listening on: %s", trfAddr)
 
-	s := grpc.NewServer()
+	s := utils.NewGRPCServer()
 	pb.RegisterKuberServiceServer(s, &server{})
 
 	// Add health service to gRPC

--- a/services/scheduler/adapters/outbound/context_box_connector.go
+++ b/services/scheduler/adapters/outbound/context_box_connector.go
@@ -15,7 +15,7 @@ type ContextBoxConnector struct {
 
 // Connect establishes a gRPC connection with the context-box microservice
 func (c *ContextBoxConnector) Connect() error {
-	connection, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
+	connection, err := utils.GrpcDialWithRetryAndBackoff("context-box", envs.ContextBoxURL)
 	if err != nil {
 		return err
 	}

--- a/services/terraformer/server/adapters/inbound/grpc/adapter.go
+++ b/services/terraformer/server/adapters/inbound/grpc/adapter.go
@@ -2,12 +2,11 @@ package grpc
 
 import (
 	"fmt"
-	"net"
-
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"net"
 
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb"
@@ -38,7 +37,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 	}
 	log.Info().Msgf("Terraformer service is listening on: %s", listeningAddress)
 
-	g.server = grpc.NewServer()
+	g.server = utils.NewGRPCServer()
 	pb.RegisterTerraformerServiceServer(g.server, &TerraformerGrpcService{usecases: usecases})
 
 	// Add health service to gRPC

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -35,7 +35,7 @@ type idInfo struct {
 
 // clientConnection will return new client connection to Context-box
 func clientConnection() (pb.ContextBoxServiceClient, *grpc.ClientConn) {
-	cc, err := utils.GrpcDialWithInsecure("context-box", envs.ContextBoxURL)
+	cc, err := utils.GrpcDialWithRetryAndBackoff("context-box", envs.ContextBoxURL)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to create client connection to context-box")
 	}


### PR DESCRIPTION
closes #885 

by setting the keepalive params for a client connection and adding a retry policy on RPC that fail due to code `unavailable` 

`Unavailable indicates the service is currently unavailable`

The client will try for roughly ~10 minutes for the service to become available and retry the RPC, given that our calls are idempotent this shouldn't be an issues.

It may happen that two calls at the same time will be executed (the one previosly started where the connection was lost and the new one), however. In terraformer we use a lock so that shouldn't be an issues and with the rest of the calls it shouldn't raise any negative side effects.