### PR TITLE
remove check of workflow conclusion in release-docs pipeline

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,5 +1,4 @@
 name: Release docs pipeline
-# Only trigger, when the release workflow has completed
 on:
   # Run when release is published
   release:
@@ -20,8 +19,6 @@ jobs:
   build-and-publish:
     name: Create a new  docs release
     runs-on: ubuntu-22.04
-    # runs only, when the workflow was succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }} 
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
When the last release happened, the release-docs pipeline skipped it's job. I assume it was because of the condition, which is deleted in this PR, because this pipeline used to wait until release pipeline ends.

In a summary, last time I forgot to remove this condition, which is most probably the reason, why the pipeline job was skipped.