### PR TITLE
Feature/add changelog to docs website

### DIFF
--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -6,7 +6,7 @@
     - [x] Azure
     - [x] Cloudflare
 - [ ] Periodic health checks & sync loops for the managed clusters
-- [ ] Hybrid-cloud support (on-premises)
+- [x] Hybrid-cloud support (on-premises)
 - [ ] `arm64` support for the nodepools
 - [ ] Support for Spot instances
 - [x] Autoscaler

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Claudie v0.1: CHANGELOG/changelog-0.1.x.md
       - Claudie v0.2: CHANGELOG/changelog-0.2.x.md
       - Claudie v0.3: CHANGELOG/changelog-0.3.x.md
+      - Claudie v0.4: CHANGELOG/changelog-0.4.x.md
   - Troubleshooting: troubleshooting/troubleshooting.md
 
 extra:


### PR DESCRIPTION
This PR adds green checkmark for Hybrid-cloud support and v0.4.x changelog to docs.claudie.io