### PR TITLE
comment setting upstream in Set up git author step

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -31,12 +31,8 @@ jobs:
       
       - name: Set up git author
         run: |
-          remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote rm origin
-          git remote add origin "${remote_repo}"
-          # git push --set-upstream origin master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,17 +69,21 @@ jobs:
           
               sed -i "${new_entry_line}i\\
               - ${navigation_entry}" $filename
-          
+
+              git fetch
+
+              git checkout master
+
               # commit and push
               git commit -am "add new changelog file to mkdocs.yml"
           
-              git push
+              git push origin
           
               echo "Altered mkdocs.yml with new Changelog navigation entry was commited and pushed to origin"
           else
               echo "There isn't a new changelog file"
           fi
-
+          
       # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
       - name: Git fetch gh-pages
         run: git fetch origin gh-pages

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git remote rm origin
           git remote add origin "${remote_repo}"
-          git push --set-upstream origin master
+          # git push --set-upstream origin master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,33 +52,33 @@ theme:
 nav:
   - index.md
   - Getting Started:
-      - Getting started: getting-started/get-started-using-claudie.md
-      - Detailed guide: getting-started/detailed-guide.md
+    - Getting started: getting-started/get-started-using-claudie.md
+    - Detailed guide: getting-started/detailed-guide.md
   - Input manifest:
-      - Providers:
-          - AWS: input-manifest/providers/aws.md
-          - Azure: input-manifest/providers/azure.md
-          - GCP: input-manifest/providers/gcp.md
-          - Cloudflare: input-manifest/providers/cloudflare.md
-          - Hetzner: input-manifest/providers/hetzner.md
-          - OCI: input-manifest/providers/oci.md
-          - On Premise: input-manifest/providers/on-prem.md
-      - Example yaml file: input-manifest/example.md
-      - API reference: input-manifest/api-reference.md
+    - Providers:
+      - AWS: input-manifest/providers/aws.md
+      - Azure: input-manifest/providers/azure.md
+      - GCP: input-manifest/providers/gcp.md
+      - Cloudflare: input-manifest/providers/cloudflare.md
+      - Hetzner: input-manifest/providers/hetzner.md
+      - OCI: input-manifest/providers/oci.md
+      - On Premise: input-manifest/providers/on-prem.md
+    - Example yaml file: input-manifest/example.md
+    - API reference: input-manifest/api-reference.md
   - How Claudie works:
-      - Claudie Workflow: claudie-workflow/claudie-workflow.md
-      - Claudie Storage solution: storage/storage-solution.md
-      - Loadbalancing in Claudie: ./loadbalancing/loadbalancing-solution.md
-      - Autoscaling in Claudie: autoscaling/autoscaling.md
+    - Claudie Workflow: claudie-workflow/claudie-workflow.md
+    - Claudie Storage solution: storage/storage-solution.md
+    - Loadbalancing in Claudie: ./loadbalancing/loadbalancing-solution.md
+    - Autoscaling in Claudie: autoscaling/autoscaling.md
   - Claudie Use Cases: use-cases/use-cases.md
   - FAQ: faq/FAQ.md
   - Roadmap for Claudie: roadmap/roadmap.md
   - Contributing: contributing/contributing.md
   - Changelog:
-      - Claudie v0.1: CHANGELOG/changelog-0.1.x.md
-      - Claudie v0.2: CHANGELOG/changelog-0.2.x.md
-      - Claudie v0.3: CHANGELOG/changelog-0.3.x.md
-      - Claudie v0.4: CHANGELOG/changelog-0.4.x.md
+    - Claudie v0.1: CHANGELOG/changelog-0.1.x.md
+    - Claudie v0.2: CHANGELOG/changelog-0.2.x.md
+    - Claudie v0.3: CHANGELOG/changelog-0.3.x.md
+    - Claudie v0.4: CHANGELOG/changelog-0.4.x.md
   - Troubleshooting: troubleshooting/troubleshooting.md
   - Creating Claudie Backup: creating-claudie-backup/creating-claudie-backup.md
 


### PR DESCRIPTION
This PR should fix not working release-docs pipeline by not using `git push --set-upstream origin master` in `Set up git author` step.
I have tested this in my own [repository](https://github.com/JKBGIT1/claudie-docs).
You can [see](https://github.com/JKBGIT1/claudie-docs/actions/runs/5656890589/job/15324807882), that pipeline did run successfully, when the `git push --set-upstream origin master` was commented. And you can also [see](https://github.com/JKBGIT1/claudie-docs/actions/runs/5656947668/job/15324984767), that it fails, when it wasn't commented.

If this PR gets merged I would like to rerun [this](https://github.com/berops/claudie/actions/runs/5507554544), just to make sure it is also working in claudie repository.