### PR TITLE
limit spawned child processes

### DIFF
--- a/manifests/claudie/ansibler.yaml
+++ b/manifests/claudie/ansibler.yaml
@@ -46,10 +46,10 @@ spec:
           resources:
             requests:
               cpu: 700m
-              memory: 768Mi
+              memory: 500Mi
             limits:
               cpu: 1024m
-              memory: 1248Mi
+              memory: 900Mi
           env:
             - name: ANSIBLER_PORT
               valueFrom:

--- a/manifests/claudie/kube-eleven.yaml
+++ b/manifests/claudie/kube-eleven.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 500Mi
+              memory: 150Mi
             limits:
               cpu: 700m
-              memory: 700Mi
+              memory: 300Mi
           env:
             - name: KUBE_ELEVEN_PORT
               valueFrom:

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -59,7 +59,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ef96fe1-2272
+  newTag: 2ab7a97-2273
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -69,10 +69,10 @@ images:
 - name: ghcr.io/berops/claudie/context-box
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ef96fe1-2272
+  newTag: 2ab7a97-2273
 - name: ghcr.io/berops/claudie/kuber
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ef96fe1-2272
+  newTag: 2ab7a97-2273

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -59,7 +59,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 9ce8ce3-2271
+  newTag: ef96fe1-2272
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -69,10 +69,10 @@ images:
 - name: ghcr.io/berops/claudie/context-box
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 9ce8ce3-2271
+  newTag: ef96fe1-2272
 - name: ghcr.io/berops/claudie/kuber
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 9ce8ce3-2271
+  newTag: ef96fe1-2272

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -59,7 +59,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: a8241bd-2270
+  newTag: 9ce8ce3-2271
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -69,10 +69,10 @@ images:
 - name: ghcr.io/berops/claudie/context-box
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: a8241bd-2270
+  newTag: 9ce8ce3-2271
 - name: ghcr.io/berops/claudie/kuber
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: a8241bd-2270
+  newTag: 9ce8ce3-2271

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -59,7 +59,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 2ab7a97-2273
+  newTag: 66de2a2-2274
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -69,10 +69,10 @@ images:
 - name: ghcr.io/berops/claudie/context-box
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 2ab7a97-2273
+  newTag: 66de2a2-2274
 - name: ghcr.io/berops/claudie/kuber
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 2ab7a97-2273
+  newTag: 66de2a2-2274

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -59,7 +59,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 5a374d3-2256
+  newTag: a8241bd-2270
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -69,10 +69,10 @@ images:
 - name: ghcr.io/berops/claudie/context-box
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 5a374d3-2256
+  newTag: a8241bd-2270
 - name: ghcr.io/berops/claudie/kuber
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5a374d3-2256
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 5a374d3-2256
+  newTag: a8241bd-2270

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             requests:
               cpu: 700m
-              memory: 768Mi
+              memory: 1024Mi
             limits:
               cpu: 1024m
               memory: 1200Mi

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -46,10 +46,10 @@ spec:
           resources:
             requests:
               cpu: 700m
-              memory: 1200Mi
+              memory: 768Mi
             limits:
               cpu: 1024m
-              memory: 1700Mi
+              memory: 1200Mi
           env:
             - name: TERRAFORMER_PORT
               valueFrom:

--- a/services/ansibler/server/adapters/inbound/grpc/adapter.go
+++ b/services/ansibler/server/adapters/inbound/grpc/adapter.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"fmt"
+	"github.com/berops/claudie/services/ansibler/server/domain/usecases"
 	"net"
 
 	"github.com/rs/zerolog/log"
@@ -24,7 +25,7 @@ type GrpcAdapter struct {
 }
 
 // CreateGrpcAdapter return new gRPC adapter for Ansibler.
-func CreateGrpcAdapter() *GrpcAdapter {
+func CreateGrpcAdapter(usecases *usecases.Usecases) *GrpcAdapter {
 	port := utils.GetEnvDefault("ANSIBLER_PORT", fmt.Sprint(defaultPort))
 	tcpBindingAddress := net.JoinHostPort("0.0.0.0", port)
 	listener, err := net.Listen("tcp", tcpBindingAddress)
@@ -35,7 +36,7 @@ func CreateGrpcAdapter() *GrpcAdapter {
 	g := &GrpcAdapter{tcpListener: listener, server: utils.NewGRPCServer(), healthcheckServer: health.NewServer()}
 	log.Info().Msgf("Ansibler microservice is listening on %s", tcpBindingAddress)
 
-	pb.RegisterAnsiblerServiceServer(g.server, &AnsiblerGrpcService{})
+	pb.RegisterAnsiblerServiceServer(g.server, &AnsiblerGrpcService{usecases: usecases})
 
 	// Ansibler microservice does not have any custom healthcheck functions,
 	// thus always serving.

--- a/services/ansibler/server/adapters/inbound/grpc/ansibler_service.go
+++ b/services/ansibler/server/adapters/inbound/grpc/ansibler_service.go
@@ -10,7 +10,7 @@ import (
 type AnsiblerGrpcService struct {
 	pb.UnimplementedAnsiblerServiceServer
 
-	usecases usecases.Usecases
+	usecases *usecases.Usecases
 }
 
 func (a *AnsiblerGrpcService) UpdateAPIEndpoint(_ context.Context, request *pb.UpdateAPIEndpointRequest) (*pb.UpdateAPIEndpointResponse, error) {

--- a/services/ansibler/server/domain/usecases/usecases.go
+++ b/services/ansibler/server/domain/usecases/usecases.go
@@ -9,9 +9,16 @@ const (
 	outputDirectory = "clusters"
 	// sshPrivateKeyFileExtension is a private key file extension.
 	sshPrivateKeyFileExtension = "pem"
+	// SpawnProcessLimit is the number of processes concurrently executing ansible.
+	SpawnProcessLimit = 5
 )
 
-type Usecases struct{}
+type Usecases struct {
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned ansible
+	// processes. This values should always be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
+}
 
 type (
 	NodepoolsInfo struct {

--- a/services/ansibler/server/main.go
+++ b/services/ansibler/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"github.com/berops/claudie/services/ansibler/server/domain/usecases"
 	"os"
 	"os/signal"
 	"syscall"
@@ -19,7 +20,9 @@ func main() {
 	// Initialize logger
 	utils.InitLog("ansibler")
 
-	grpcAdapter := grpc.CreateGrpcAdapter()
+	grpcAdapter := grpc.CreateGrpcAdapter(&usecases.Usecases{
+		SpawnProcessLimit: make(chan struct{}, usecases.SpawnProcessLimit),
+	})
 
 	errGroup, errGroupContext := errgroup.WithContext(context.Background())
 	errGroup.Go(grpcAdapter.Serve)

--- a/services/ansibler/server/utils/api_endpoint.go
+++ b/services/ansibler/server/utils/api_endpoint.go
@@ -34,12 +34,13 @@ func FindNewAPIEndpointCandidate(current, desired []*pb.NodePool, excludeNodepoo
 // ChangeAPIEndpoint will change the kubeadm configuration.
 // It will set the Api endpoint of the cluster to the public IP of the
 // newly selected ApiEndpoint node.
-func ChangeAPIEndpoint(clusterName, oldEndpoint, newEndpoint, directory string) error {
+func ChangeAPIEndpoint(clusterName, oldEndpoint, newEndpoint, directory string, spawnProcessLimit chan struct{}) error {
 	ansible := Ansible{
-		Playbook:  apiChangePlaybookFilePath,
-		Inventory: InventoryFileName,
-		Flags:     fmt.Sprintf("--extra-vars \"NewEndpoint=%s OldEndpoint=%s\"", newEndpoint, oldEndpoint),
-		Directory: directory,
+		Playbook:          apiChangePlaybookFilePath,
+		Inventory:         InventoryFileName,
+		Flags:             fmt.Sprintf("--extra-vars \"NewEndpoint=%s OldEndpoint=%s\"", newEndpoint, oldEndpoint),
+		Directory:         directory,
+		SpawnProcessLimit: spawnProcessLimit,
 	}
 
 	if err := ansible.RunAnsiblePlaybook(fmt.Sprintf("EP - %s", clusterName)); err != nil {

--- a/services/ansibler/server/utils/loadbalancers.go
+++ b/services/ansibler/server/utils/loadbalancers.go
@@ -204,7 +204,7 @@ func GenerateLBBaseFiles(outputDirectory string, lbClustersInfo *LBClustersInfo)
 	return nil
 }
 
-func HandleAPIEndpointChange(apiServerTypeLBCluster *LBClusterData, k8sCluster *LBClustersInfo, outputDirectory string) error {
+func HandleAPIEndpointChange(apiServerTypeLBCluster *LBClusterData, k8sCluster *LBClustersInfo, outputDirectory string, spawnProcessLimit chan struct{}) error {
 	// If there is no ApiSever type LB cluster, that means that the ports 6443 are exposed
 	// on one of the control nodes (which acts as the api endpoint).
 	// Thus we don't need to do anything.
@@ -318,7 +318,7 @@ func HandleAPIEndpointChange(apiServerTypeLBCluster *LBClusterData, k8sCluster *
 	}
 
 	log.Debug().Str("LB-cluster", utils.GetClusterID(lbCluster.ClusterInfo)).Msgf("Changing the API endpoint from %s to %s", oldEndpoint, newEndpoint)
-	if err := ChangeAPIEndpoint(lbCluster.ClusterInfo.Name, oldEndpoint, newEndpoint, outputDirectory); err != nil {
+	if err := ChangeAPIEndpoint(lbCluster.ClusterInfo.Name, oldEndpoint, newEndpoint, outputDirectory, spawnProcessLimit); err != nil {
 		return fmt.Errorf("error while changing the endpoint for %s : %w", lbCluster.ClusterInfo.Name, err)
 	}
 

--- a/services/kube-eleven/server/domain/usecases/build_cluster.go
+++ b/services/kube-eleven/server/domain/usecases/build_cluster.go
@@ -15,8 +15,9 @@ func (u *Usecases) BuildCluster(req *pb.BuildClusterRequest) (*pb.BuildClusterRe
 	logger.Info().Msgf("Building kubernetes cluster")
 
 	k := kube_eleven.KubeEleven{
-		K8sCluster: req.Desired,
-		LBClusters: req.DesiredLbs,
+		K8sCluster:        req.Desired,
+		LBClusters:        req.DesiredLbs,
+		SpawnProcessLimit: u.SpawnProcessLimit,
 	}
 
 	if err := k.BuildCluster(); err != nil {

--- a/services/kube-eleven/server/domain/usecases/usecases.go
+++ b/services/kube-eleven/server/domain/usecases/usecases.go
@@ -1,3 +1,13 @@
 package usecases
 
-type Usecases struct{}
+const (
+	// SpawnProcessLimit is the number of processes concurrently executing kubeone.
+	SpawnProcessLimit = 5
+)
+
+type Usecases struct {
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned terraform
+	// processes. This values must be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
+}

--- a/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
+++ b/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
@@ -36,6 +36,11 @@ type KubeEleven struct {
 	// LB clusters attached to the above Kubernetes cluster.
 	// If nil, the first control node becomes the api endpoint of the cluster.
 	LBClusters []*pb.LBcluster
+
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned kubeone
+	// processes. This values must be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
 }
 
 // BuildCluster is responsible for managing the given K8sCluster along with the attached LBClusters
@@ -51,7 +56,10 @@ func (k *KubeEleven) BuildCluster() error {
 	}
 
 	// Execute Kubeone apply
-	kubeone := kubeone.Kubeone{ConfigDirectory: k.outputDirectory}
+	kubeone := kubeone.Kubeone{
+		ConfigDirectory:   k.outputDirectory,
+		SpawnProcessLimit: k.SpawnProcessLimit,
+	}
 	err = kubeone.Apply(clusterID)
 	if err != nil {
 		return fmt.Errorf("error while running \"kubeone apply\" in %s : %w", k.outputDirectory, err)

--- a/services/kube-eleven/server/main.go
+++ b/services/kube-eleven/server/main.go
@@ -20,7 +20,9 @@ func main() {
 	// Initialize logger
 	utils.InitLog("kube-eleven")
 
-	usecases := &usecases.Usecases{}
+	usecases := &usecases.Usecases{
+		SpawnProcessLimit: make(chan struct{}, usecases.SpawnProcessLimit),
+	}
 	grpcAdapter := grpc.GrpcAdapter{}
 	grpcAdapter.Init(usecases)
 

--- a/services/terraformer/server/domain/usecases/build_infrastructure.go
+++ b/services/terraformer/server/domain/usecases/build_infrastructure.go
@@ -16,6 +16,7 @@ func (u *Usecases) BuildInfrastructure(request *pb.BuildInfrastructureRequest) (
 		DesiredState:       request.Desired,
 		CurrentState:       request.Current,
 		AttachedLBClusters: request.DesiredLbs,
+		SpawnProcessLimit:  u.SpawnProcessLimit,
 	}
 
 	var lbClusters []*loadbalancer.LBcluster
@@ -30,9 +31,10 @@ func (u *Usecases) BuildInfrastructure(request *pb.BuildInfrastructureRequest) (
 		}
 
 		lbClusters = append(lbClusters, &loadbalancer.LBcluster{
-			DesiredState: desiredLBCluster,
-			CurrentState: current,
-			ProjectName:  request.ProjectName,
+			DesiredState:      desiredLBCluster,
+			CurrentState:      current,
+			ProjectName:       request.ProjectName,
+			SpawnProcessLimit: u.SpawnProcessLimit,
 		})
 	}
 

--- a/services/terraformer/server/domain/usecases/destroy_infrastructure.go
+++ b/services/terraformer/server/domain/usecases/destroy_infrastructure.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb"
 	outboundAdapters "github.com/berops/claudie/services/terraformer/server/adapters/outbound"
 	"github.com/berops/claudie/services/terraformer/server/domain/utils/kubernetes"
 	"github.com/berops/claudie/services/terraformer/server/domain/utils/loadbalancer"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -30,15 +30,17 @@ func (u *Usecases) DestroyInfrastructure(ctx context.Context, request *pb.Destro
 	// then add the Kubernetes cluster to the "clusters" slice.
 	if request.Current != nil {
 		clusters = append(clusters, &kubernetes.K8Scluster{
-			ProjectName:  request.ProjectName,
-			CurrentState: request.Current,
+			ProjectName:       request.ProjectName,
+			CurrentState:      request.Current,
+			SpawnProcessLimit: u.SpawnProcessLimit,
 		})
 	}
 
 	for _, currentLB := range request.CurrentLbs {
 		clusters = append(clusters, &loadbalancer.LBcluster{
-			ProjectName:  request.ProjectName,
-			CurrentState: currentLB,
+			ProjectName:       request.ProjectName,
+			CurrentState:      currentLB,
+			SpawnProcessLimit: u.SpawnProcessLimit,
 		})
 	}
 

--- a/services/terraformer/server/domain/usecases/usecases.go
+++ b/services/terraformer/server/domain/usecases/usecases.go
@@ -1,9 +1,13 @@
 package usecases
 
 import (
-	"github.com/rs/zerolog"
-
 	"github.com/berops/claudie/services/terraformer/server/domain/ports"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// SpawnProcessLimit is the number of processes concurrently executing terraform.
+	SpawnProcessLimit = 5
 )
 
 type Usecases struct {
@@ -11,6 +15,10 @@ type Usecases struct {
 	DynamoDB ports.DynamoDBPort
 	// Minio connector.
 	MinIO ports.MinIOPort
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned terraform
+	// processes. This values should always be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
 }
 
 type Cluster interface {

--- a/services/terraformer/server/domain/utils/cluster-builder/cluster_builder.go
+++ b/services/terraformer/server/domain/utils/cluster-builder/cluster_builder.go
@@ -48,6 +48,10 @@ type ClusterBuilder struct {
 	// in the case of LoadBalancer this will contain the defined
 	// roles from the manifest. Can be nil if no data is supplied.
 	Metadata map[string]any
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned terraform
+	// processes. This values should always be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
 }
 
 type NodepoolsData struct {
@@ -88,7 +92,8 @@ func (c ClusterBuilder) CreateNodepools() error {
 	}
 
 	terraform := terraform.Terraform{
-		Directory: clusterDir,
+		Directory:         clusterDir,
+		SpawnProcessLimit: c.SpawnProcessLimit,
 	}
 
 	if log.Logger.GetLevel() == zerolog.DebugLevel {
@@ -147,7 +152,8 @@ func (c ClusterBuilder) DestroyNodepools() error {
 	}
 
 	terraform := terraform.Terraform{
-		Directory: clusterDir,
+		Directory:         clusterDir,
+		SpawnProcessLimit: c.SpawnProcessLimit,
 	}
 
 	if log.Logger.GetLevel() == zerolog.DebugLevel {

--- a/services/terraformer/server/domain/utils/loadbalancer/dns.go
+++ b/services/terraformer/server/domain/utils/loadbalancer/dns.go
@@ -35,6 +35,11 @@ type DNS struct {
 
 	CurrentDNS *pb.DNS
 	DesiredDNS *pb.DNS
+
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned terraform
+	// processes. This values should always be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
 }
 
 type DNSData struct {
@@ -59,7 +64,8 @@ func (d DNS) CreateDNSRecords(logger zerolog.Logger) (string, error) {
 	dnsDir := filepath.Join(cluster_builder.Output, dnsID)
 
 	terraform := terraform.Terraform{
-		Directory: dnsDir,
+		Directory:         dnsDir,
+		SpawnProcessLimit: d.SpawnProcessLimit,
 	}
 
 	if log.Logger.GetLevel() == zerolog.DebugLevel {
@@ -128,7 +134,8 @@ func (d DNS) DestroyDNSRecords(logger zerolog.Logger) error {
 	}
 
 	terraform := terraform.Terraform{
-		Directory: dnsDir,
+		Directory:         dnsDir,
+		SpawnProcessLimit: d.SpawnProcessLimit,
 	}
 
 	if log.Logger.GetLevel() == zerolog.DebugLevel {

--- a/services/terraformer/server/domain/utils/terraform/terraform.go
+++ b/services/terraformer/server/domain/utils/terraform/terraform.go
@@ -20,7 +20,7 @@ const (
 	maxTfCommandRetryCount = 5
 
 	// Parallelism is the number of resource to be work on in parallel during the apply/destroy commands.
-	Parallelism = 6
+	Parallelism = 8
 )
 
 type Terraform struct {

--- a/services/terraformer/server/domain/utils/terraform/terraform.go
+++ b/services/terraformer/server/domain/utils/terraform/terraform.go
@@ -20,7 +20,7 @@ const (
 	maxTfCommandRetryCount = 5
 
 	// Parallelism is the number of resource to be work on in parallel during the apply/destroy commands.
-	Parallelism = 10
+	Parallelism = 6
 )
 
 type Terraform struct {

--- a/services/terraformer/server/domain/utils/terraform/terraform.go
+++ b/services/terraformer/server/domain/utils/terraform/terraform.go
@@ -18,6 +18,9 @@ const (
 	// it succeeds. If after "maxTfCommandRetryCount" retries the commands still fails an error should be
 	// returned containing the reason.
 	maxTfCommandRetryCount = 5
+
+	// Parallelism is the number of resource to be work on in parallel during the apply/destroy commands.
+	Parallelism = 10
 )
 
 type Terraform struct {
@@ -26,9 +29,20 @@ type Terraform struct {
 
 	Stdout io.Writer
 	Stderr io.Writer
+
+	// Parallelism is the number of resources to be worked on in parallel by terraform.
+	Parallelism int
+
+	// SpawnProcessLimit represents a synchronization channel which limits the number of spawned terraform
+	// processes. This values must be non-nil and be buffered, where the capacity indicates
+	// the limit.
+	SpawnProcessLimit chan struct{}
 }
 
 func (t *Terraform) Init() error {
+	t.SpawnProcessLimit <- struct{}{}
+	defer func() { <-t.SpawnProcessLimit }()
+
 	cmd := exec.Command("terraform", "init")
 	cmd.Dir = t.Directory
 	cmd.Stdout = t.Stdout
@@ -53,11 +67,19 @@ func (t *Terraform) Init() error {
 }
 
 func (t *Terraform) Apply() error {
+	t.SpawnProcessLimit <- struct{}{}
+	defer func() { <-t.SpawnProcessLimit }()
+
 	output := new(bytes.Buffer)
+
+	if t.Parallelism <= 0 {
+		t.Parallelism = Parallelism
+	}
 
 	args := []string{
 		"apply",
 		"--auto-approve",
+		fmt.Sprintf("--parallelism=%v", t.Parallelism),
 	}
 
 	if log.Logger.GetLevel() != zerolog.DebugLevel {
@@ -123,11 +145,19 @@ func (t *Terraform) Apply() error {
 }
 
 func (t *Terraform) Destroy() error {
+	t.SpawnProcessLimit <- struct{}{}
+	defer func() { <-t.SpawnProcessLimit }()
+
 	output := new(bytes.Buffer)
+
+	if t.Parallelism <= 0 {
+		t.Parallelism = Parallelism
+	}
 
 	args := []string{
 		"destroy",
 		"--auto-approve",
+		fmt.Sprintf("--parallelism=%v", t.Parallelism),
 	}
 
 	if log.Logger.GetLevel() != zerolog.DebugLevel {
@@ -192,7 +222,7 @@ func (t *Terraform) Destroy() error {
 	return nil
 }
 
-func (t Terraform) Output(resourceName string) (string, error) {
+func (t *Terraform) Output(resourceName string) (string, error) {
 	cmd := exec.Command("terraform", "output", "-json", resourceName)
 	cmd.Dir = t.Directory
 	out, err := cmd.CombinedOutput()

--- a/services/terraformer/server/main.go
+++ b/services/terraformer/server/main.go
@@ -26,8 +26,9 @@ func main() {
 	dynamoDBAdapter := outboundAdapters.CreateDynamoDBAdapter()
 
 	usecases := &usecases.Usecases{
-		DynamoDB: dynamoDBAdapter,
-		MinIO:    minIOAdapter,
+		DynamoDB:          dynamoDBAdapter,
+		MinIO:             minIOAdapter,
+		SpawnProcessLimit: make(chan struct{}, usecases.SpawnProcessLimit),
 	}
 
 	grpcAdapter := &grpc.GrpcAdapter{}


### PR DESCRIPTION
closes #692 

Limit the number of go-routines (i.e. clusters) that spawn ansible, terraform, kubeOne to 5.
I've adjusted the Resource limits based on the changes.

