### PR TITLE
Chore/add recommended labels to input manifest examples in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ For adding support for other cloud providers, open an issue or propose a PR.
     kind: InputManifest
     metadata:
       name: examplemanifest
+      labels:
+        app.kubernetes.io/part-of: claudie
     spec:
       providers:
           - name: aws-1

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Claudie outputs base64 encoded kubeconfig secret `<cluster-name>-<cluster-hash>-
     kind: InputManifest
     metadata:
       name: examplemanifest
+      labels:
+        app.kubernetes.io/part-of: claudie
     spec:
       providers:
           - name: aws-1

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For adding support for other cloud providers, open an issue or propose a PR.
       --from-literal=secretkey='myAwsSecretKey'
     ```
 
-    Check the [supported providers](#supported-providers) for input manifest examples. For an input manifest spanning all supported hyperscalers checkout out [this example](https://docs.claudie.io/latest/input-manifest/example.md).
+    Check the [supported providers](#supported-providers) for input manifest examples. For an input manifest spanning all supported hyperscalers checkout out [this example](https://docs.claudie.io/latest/input-manifest/example/).
 
 2. Deploy InputManifest resource which Claudie uses to create infrastructure, include the created secret in `.spec.providers` as follows:
     ```bash

--- a/docs/getting-started/detailed-guide.md
+++ b/docs/getting-started/detailed-guide.md
@@ -103,6 +103,8 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     kind: InputManifest
     metadata:
       name: cloud-bursting
+      labels:
+        app.kubernetes.io/part-of: claudie
     spec:
       providers:
         - name: aws-1
@@ -290,6 +292,8 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     kind: InputManifest
     metadata:
       name: cloud-bursting
+      labels:
+        app.kubernetes.io/part-of: claudie
     spec:
       providers:
         - name: hetzner-1         # add under nodePools.dynamic section
@@ -341,6 +345,8 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     kind: InputManifest
     metadata:
       name: cloud-bursting
+      labels:
+        app.kubernetes.io/part-of: claudie
     spec:
       ...
       loadBalancers:

--- a/docs/input-manifest/example.md
+++ b/docs/input-manifest/example.md
@@ -3,6 +3,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: ExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   # Providers field is used for defining the providers. 
   # It is referencing a secret resource in Kubernetes cluster.

--- a/docs/input-manifest/providers/aws.md
+++ b/docs/input-manifest/providers/aws.md
@@ -97,6 +97,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: AWSExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
 
   providers:
@@ -181,6 +183,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: AWSExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
 
   providers:

--- a/docs/input-manifest/providers/azure.md
+++ b/docs/input-manifest/providers/azure.md
@@ -93,6 +93,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: AzureExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: azure-1
@@ -173,6 +175,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: AzureExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: azure-1

--- a/docs/input-manifest/providers/cloudflare.md
+++ b/docs/input-manifest/providers/cloudflare.md
@@ -50,6 +50,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: CloudflareExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: cloudflare-1

--- a/docs/input-manifest/providers/gcp.md
+++ b/docs/input-manifest/providers/gcp.md
@@ -85,6 +85,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: GCPExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: gcp-1
@@ -167,6 +169,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: GCPExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: gcp-1

--- a/docs/input-manifest/providers/hetzner.md
+++ b/docs/input-manifest/providers/hetzner.md
@@ -58,6 +58,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: HetznerExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: hetzner-1
@@ -139,6 +141,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: HetznerExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: hetzner-1

--- a/docs/input-manifest/providers/oci.md
+++ b/docs/input-manifest/providers/oci.md
@@ -131,6 +131,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: OCIExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: oci-1
@@ -217,6 +219,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: OCIExampleManifest
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: oci-1

--- a/docs/input-manifest/providers/on-prem.md
+++ b/docs/input-manifest/providers/on-prem.md
@@ -35,6 +35,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: PrivateClusterExample
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   nodePools:
     static:
@@ -82,6 +84,8 @@ apiVersion: claudie.io/v1beta1
 kind: InputManifest
 metadata:
   name: HybridCloudExample
+  labels:
+    app.kubernetes.io/part-of: claudie
 spec:
   providers:
     - name: hetzner-1


### PR DESCRIPTION
This PR adds `app.kubernetes.io/part-of: claudie` label to all examples in docs.claudie.io and fix not working link for example of InputManifest, which includes all supported hyperscalers.