### PR TITLE
Feat/render yaml from manifests in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,30 +73,24 @@ jobs:
             kustomize edit set image ghcr.io/berops/claudie/$SERVICE:${RELEASE}
           done
 
-      - name: Create archives for manifests
-        working-directory: manifests/claudie
+      - name: Create claudie.yaml file from manifests
         run: |
-          sudo apt update && sudo apt install -y zip tar
-          tar -czvf ../../claudie.tar.gz .
-          zip -r ../../claudie.zip .
+          kustomize build manifests/claudie > claudie.yaml
 
-      - name: Get checksums of the archives
+      - name: Get checksum of the claudie.yaml
         run: |
-          touch claudie_checksums.txt
-          sha256sum claudie.tar.gz >> claudie_checksums.txt
-          sha256sum claudie.zip >> claudie_checksums.txt
+          sha256sum claudie.yaml >> claudie_checksum.txt
 
       - name: Add manifests to the release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
-          file: claudie.*
-          file_glob: true
+          file: claudie.yaml
 
       - name: Add checksums file to the release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
-          file: claudie_checksums.txt
+          file: claudie_checksum.txt

--- a/README.md
+++ b/README.md
@@ -92,14 +92,9 @@ For adding support for other cloud providers, open an issue or propose a PR.
 
 ### Install Claudie
 
-1. Download and extract Claudie manifests from our [release page](https://github.com/berops/claudie/releases):
+1. Deploy Claudie to the Management Cluster:
     ```bash
-    wget https://github.com/berops/claudie/releases/latest/download/claudie.zip && unzip claudie.zip -d claudie
-    ```
-
-2. Deploy Claudie to the Management Cluster:
-    ```bash
-    kubectl apply -k claudie
+    kubectl apply -f https://github.com/berops/claudie/releases/latest/download/claudie.yaml
     ```
 
 ### Deploy your cluster

--- a/docs/getting-started/detailed-guide.md
+++ b/docs/getting-started/detailed-guide.md
@@ -46,18 +46,18 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
     ```
 
-5. Download latest Claudie release and unzip it:
+5. Download latest Claudie release:
 
     ```bash
-    wget https://github.com/berops/claudie/releases/latest/download/claudie.zip && unzip claudie.zip -d claudie
+    wget https://github.com/berops/claudie/releases/latest/download/claudie.yaml
     ```
 
     !!! note "Tip!"  
-        For the initial attempt, it's highly recommended to enable debug logs, especially when creating a large cluster with DNS. This helps identify and resolve any permission issues that may occur across different hyperscalers. Edit `claudie/.env` file, and change `GOLANG_LOG=info` to `GOLANG_LOG=debug` to enable debug logging, for more customization refer to [this table](#claudie-customization).
+        For the initial attempt, it's highly recommended to enable debug logs, especially when creating a large cluster with DNS. This helps identify and resolve any permission issues that may occur across different hyperscalers. Locate `ConfigMap` with `GOLANG_LOG` variable in `claudie.yaml` file, and change `GOLANG_LOG: info` to `GOLANG_LOG: debug` to enable debug logging, for more customization refer to [this table](#claudie-customization).
 
 6. Deploy Claudie using Kustomize plugin:
     ```bash
-    kubectl apply -k claudie
+    kubectl apply -f claudie.yaml
     ```
 
 7. Claudie will be deployed into `claudie` namespace, you can view if all pods are running:


### PR DESCRIPTION
This PR updates `release` pipeline to add only `claudie.yaml` (generated from all manifests using `kustomize`) and `claudie_checksum.txt` to release.
Users will then be able to deploy Claudie just by using `kubectl apply -f https://github.com/berops/claudie/releases/latest/download/claudie.yaml`

IMO we should wait until the release to merge this PR, because it contains changes of deployment approach in main README.md 