### PR TITLE
update release-docs.yml to create a PR, when there's a new Changelog file

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -85,7 +85,7 @@ jobs:
           
               echo "Altered mkdocs.yml with new Changelog navigation entry was commited and pushed to origin"
 
-              gh pr create --title "Add reference to new Changelog" --body "Add reference to new Changelog file in mkdocs.yml"
+              gh pr create --title "Add reference to new Changelog ${RELEASE}" --body "Add reference to new Changelog file in mkdocs.yml"
           else
               echo "There isn't a new changelog file"
           fi

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set release tag
         run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -36,7 +37,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add new changelog file to mkdocs.yml navigation under Changelog section
+      - name: Handle Changelog file
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           filename="mkdocs.yml"
           start_line=$(sed -n '/- Changelog:/=' "$filename")
@@ -72,14 +75,16 @@ jobs:
 
               git fetch
 
-              git checkout master
+              git checkout -b feat/add-reference-to-new-changelog-${RELEASE}
 
               # commit and push
               git commit -am "add new changelog file to mkdocs.yml"
           
-              git push origin
+              git push --set-upstream origin feat/add-reference-to-new-changelog-${RELEASE}
           
               echo "Altered mkdocs.yml with new Changelog navigation entry was commited and pushed to origin"
+
+              gh pr create --title "Add reference to new Changelog" --body "Add reference to new Changelog file in mkdocs.yml"
           else
               echo "There isn't a new changelog file"
           fi


### PR DESCRIPTION
This PR fix failing `release-docs` pipeline, by pushing updated `mkdocs.yml` (with added reference to new Changelog file) to feature branch and opening a new PR to merge it directly into the master.