### PR TITLE
Feat/update release.md to align with release process

### DIFF
--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -22,9 +22,8 @@ A [release pipeline](https://github.com/berops/claudie/blob/master/.github/workf
 
 A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) consists of the following steps:
 
-1. Check if there is a new Changelog file
-2. In case there is a new Changelog file:
+1. If there is a new Changelog file:
     1. Checkout to a new feature branch
     2. Add reference to the new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
     3. Create a PR to merge changes from new feature branch to master (PR needs to be created, to update changes in `master` branch and align with branch protection)
-3. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)
+2. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -26,5 +26,5 @@ A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/
 2. In case there is a new Changelog file:
     1. Checkout to a new feature branch
     2. Add reference to that new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
-    3. Create PR to merges changes from new feature branch to master (PR need to be created due to `master` branch protection)
+    3. Create a PR to merge changes from new feature branch to master (PR needs to be created due to `master` branch protection)
 3. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -14,17 +14,17 @@ Whoever is responsible for creating a new release has to:
 
 After a new release is published, a [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) and a [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) runs.
 
-A [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) consist of the following steps:
+A [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) consists of the following steps:
 
 1. Build new images tagged with the release tag
 2. Push them to the container registry where anyone can pull them
 3. Add Claudie manifest files to the release assets, with image tags referencing this release
 
-A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) consist of the following steps:
+A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) consists of the following steps:
 
-1. Check if there is a new Changelog file.
+1. Check if there is a new Changelog file
 2. In case there is a new Changelog file:
     1. Checkout to a new feature branch
-    2. Add reference to that new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
-    3. Create a PR to merge changes from new feature branch to master (PR needs to be created due to `master` branch protection)
+    2. Add reference to the new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
+    3. Create a PR to merge changes from new feature branch to master (PR needs to be created, to update changes in `master` branch and align with branch protection)
 3. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -25,5 +25,5 @@ A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/
 1. If there is a new Changelog file:
     1. Checkout to a new feature branch
     2. Add reference to the new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
-    3. Create a PR to merge changes from new feature branch to master (PR needs to be created, to update changes in `master` branch and align with branch protection)
+    3. Create a PR to merge changes from new feature branch to master (PR needs to be created to update changes in `master` branch and align with branch protection)
 2. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -12,8 +12,19 @@ Whoever is responsible for creating a new release has to:
 
 ## Automated steps
 
-After a new release is published, a [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) runs, which will:
+After a new release is published, a [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) and a [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) runs.
+
+A [release pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release.yml) consist of the following steps:
 
 1. Build new images tagged with the release tag
 2. Push them to the container registry where anyone can pull them
 3. Add Claudie manifest files to the release assets, with image tags referencing this release
+
+A [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) consist of the following steps:
+
+1. Check if there is a new Changelog file.
+2. In case there is a new Changelog file:
+    1. Checkout to a new feature branch
+    2. Add reference to that new Changelog file in [mkdocs.yml](https://github.com/berops/claudie/blob/master/mkdocs.yml)
+    3. Create PR to merges changes from new feature branch to master (PR need to be created due to `master` branch protection)
+3. Deploy new version of docs on [docs.claudie.io](https://docs.claudie.io)


### PR DESCRIPTION
This PR adds description of [release-docs pipeline](https://github.com/berops/claudie/blob/master/.github/workflows/release-docs.yml) in [release.md](https://github.com/berops/claudie/blob/master/docs/contributing/release.md)
Is it detailed enough?