### PR TITLE
Improve Slack invite workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Everyone is more than welcome to open an issue, a PR or to start a discussion.
 
 For more information about contributing please read the [contribution guidelines](https://docs.claudie.io/latest/contributing/contributing/).
 
-If you want to have a chat with us, feel free to join our [Slack workspace](https://kubernetes.slack.com/archives/C05SW4GKPL3).
+If you want to have a chat with us, feel free to join our channel on [kubernetes Slack workspace](https://kubernetes.slack.com/archives/C05SW4GKPL3) (get invite [here](https://communityinviter.com/apps/kubernetes/community)).
 
 ## Security
 


### PR DESCRIPTION
Mention Kubernetes Slack explicitly and provide a link so that people do not need to search for it.