### PR TITLE
Feat/metrics

### DIFF
--- a/internal/utils/cluster.go
+++ b/internal/utils/cluster.go
@@ -202,3 +202,30 @@ func GetCommonDynamicNodePools(nps []*pb.NodePool) []*pb.NodePool {
 	}
 	return dynamic
 }
+
+func CountLbNodes(lb *pb.LBcluster) int {
+	var out int
+	for _, np := range lb.GetClusterInfo().GetNodePools() {
+		switch i := np.GetNodePoolType().(type) {
+		case *pb.NodePool_DynamicNodePool:
+			out += int(i.DynamicNodePool.Count)
+		case *pb.NodePool_StaticNodePool:
+			// Lbs are only dynamic.
+		}
+	}
+
+	return out
+}
+
+func CountNodes(k *pb.K8Scluster) int {
+	var out int
+	for _, np := range k.GetClusterInfo().GetNodePools() {
+		switch i := np.GetNodePoolType().(type) {
+		case *pb.NodePool_DynamicNodePool:
+			out += int(i.DynamicNodePool.Count)
+		case *pb.NodePool_StaticNodePool:
+			out += len(i.StaticNodePool.GetNodeKeys())
+		}
+	}
+	return out
+}

--- a/internal/utils/generic.go
+++ b/internal/utils/generic.go
@@ -1,5 +1,7 @@
 package utils
 
+import "golang.org/x/exp/constraints"
+
 // MergeMaps merges two or more maps together, into single map.
 func MergeMaps[M ~map[K]V, K comparable, V any](maps ...M) M {
 	merged := make(M)
@@ -21,4 +23,12 @@ func Into[K, V any](k []K, f func(k K) *V) []*V {
 		}
 	}
 	return result
+}
+
+func Sum[M ~map[K]V, K comparable, V constraints.Integer | constraints.Float](m M) int {
+	var out int
+	for _, v := range m {
+		out += int(v)
+	}
+	return out
 }

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -24,8 +24,8 @@ func CloseClientConnection(connection *grpc.ClientConn) {
 	}
 }
 
-func NewGRPCServer() *grpc.Server {
-	return grpc.NewServer(
+func NewGRPCServer(opts ...grpc.ServerOption) *grpc.Server {
+	opts = append(opts,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             45 * time.Second, // If a client pings more than once every 45 seconds, terminate the connection
 			PermitWithoutStream: true,             // Allow pings even when there are no active streams
@@ -38,6 +38,8 @@ func NewGRPCServer() *grpc.Server {
 			Timeout:               5 * time.Minute, // Wait 5 minutes for the ping ack before assuming the connection is dead.
 		}),
 	)
+
+	return grpc.NewServer(opts...)
 }
 
 // GrpcDialWithRetryAndBackoff creates an insecure gRPC connection to serviceURL

--- a/internal/utils/metrics/middleware.go
+++ b/internal/utils/metrics/middleware.go
@@ -30,7 +30,7 @@ var (
 
 	Latency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "claudie_grpc_grpc_call_latency_seconds",
+			Name: "claudie__grpc_call_latency_seconds",
 			Help: "Latency of gRPC API calls in seconds.",
 			Buckets: []float64{
 				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, // up to 10sec

--- a/internal/utils/metrics/middleware.go
+++ b/internal/utils/metrics/middleware.go
@@ -30,7 +30,7 @@ var (
 
 	Latency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "claudie__grpc_call_latency_seconds",
+			Name: "claudie_grpc_call_latency_seconds",
 			Help: "Latency of gRPC API calls in seconds.",
 			Buckets: []float64{
 				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, // up to 10sec

--- a/internal/utils/metrics/middleware.go
+++ b/internal/utils/metrics/middleware.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+)
+
+const (
+	MethodLabel = "method"
+)
+
+var (
+	RequestsInFlight = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "claudie_grpc_request_in_flight",
+			Help: "Number of grpc requests currently handled",
+		},
+	)
+
+	RequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "claudie_grpc_request_count",
+			Help: "Total number of gRPC API calls.",
+		},
+		[]string{MethodLabel},
+	)
+
+	Latency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "claudie_grpc_grpc_call_latency_seconds",
+			Help: "Latency of gRPC API calls in seconds.",
+			Buckets: []float64{
+				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, // up to 10sec
+				20, 30, 60, 300, 600, // up to 10 min
+				1200, 1800, 2700, 3600, // up to 1hour
+			},
+		},
+		[]string{MethodLabel},
+	)
+
+	ErrorCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grpc_error_count",
+			Help: "Total number of gRPC API call errors.",
+		},
+		[]string{MethodLabel},
+	)
+)
+
+func MetricsMiddleware(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	RequestsInFlight.Inc()
+
+	now := time.Now()
+	resp, err := handler(ctx, req)
+	duration := time.Since(now)
+
+	RequestCount.WithLabelValues(info.FullMethod).Inc()
+	Latency.WithLabelValues(info.FullMethod).Observe(duration.Seconds())
+
+	if err != nil {
+		ErrorCount.WithLabelValues(info.FullMethod).Inc()
+	}
+
+	RequestsInFlight.Dec()
+	return resp, err
+}
+
+func MustRegisterCounters() {
+	prometheus.MustRegister(RequestCount)
+	prometheus.MustRegister(Latency)
+	prometheus.MustRegister(ErrorCount)
+	prometheus.MustRegister(RequestsInFlight)
+}

--- a/manifests/claudie/ansibler.yaml
+++ b/manifests/claudie/ansibler.yaml
@@ -24,16 +24,16 @@ spec:
         fsGroup: 2000
       volumes:
         - name: data
-          emptyDir: {}
+          emptyDir: { }
         - name: temp
-          emptyDir: {}
+          emptyDir: { }
       containers:
         - name: ansibler
           volumeMounts:
-          - mountPath: /bin/services/ansibler/server/clusters
-            name: data
-          - mountPath: /.ansible
-            name: temp
+            - mountPath: /bin/services/ansibler/server/clusters
+              name: data
+            - mountPath: /.ansible
+              name: temp
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -63,6 +63,8 @@ spec:
                   key: GOLANG_LOG
           ports:
             - containerPort: 50053
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 50053

--- a/manifests/claudie/builder.yaml
+++ b/manifests/claudie/builder.yaml
@@ -95,6 +95,9 @@ spec:
                 configMapKeyRef:
                   name: env
                   key: GOLANG_LOG
+          ports:
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             httpGet:
               path: /ready

--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -74,6 +74,8 @@ spec:
                   key: GOLANG_LOG
           ports:
             - containerPort: 50055
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 50055

--- a/manifests/claudie/kube-eleven.yaml
+++ b/manifests/claudie/kube-eleven.yaml
@@ -24,14 +24,14 @@ spec:
         fsGroup: 2000
       volumes:
         - name: data
-          emptyDir: {}
+          emptyDir: { }
       containers:
         - name: kube-eleven
           imagePullPolicy: Always
           image: ghcr.io/berops/claudie/kube-eleven
           volumeMounts:
-          - mountPath: /bin/services/kube-eleven/server/clusters
-            name: data
+            - mountPath: /bin/services/kube-eleven/server/clusters
+              name: data
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -59,6 +59,8 @@ spec:
                   key: GOLANG_LOG
           ports:
             - containerPort: 50054
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 50054

--- a/manifests/claudie/kuber.yaml
+++ b/manifests/claudie/kuber.yaml
@@ -24,14 +24,14 @@ spec:
         fsGroup: 2000
       volumes:
         - name: data
-          emptyDir: {}
+          emptyDir: { }
       containers:
         - name: kuber
           imagePullPolicy: Always
           image: ghcr.io/berops/claudie/kuber
           volumeMounts:
-          - mountPath: /bin/services/kuber/server/clusters
-            name: data
+            - mountPath: /bin/services/kuber/server/clusters
+              name: data
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -72,6 +72,8 @@ spec:
                   fieldPath: metadata.namespace
           ports:
             - containerPort: 50057
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 50057
@@ -119,12 +121,12 @@ metadata:
     app.kubernetes.io/part-of: claudie
     app.kubernetes.io/name: kuber
 rules:
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps", "services"]
-    verbs: ["create", "patch", "update", "get", "list", "delete"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["create", "patch", "update", "get", "list", "delete"]
+  - apiGroups: [ "" ]
+    resources: [ "secrets", "configmaps", "services" ]
+    verbs: [ "create", "patch", "update", "get", "list", "delete" ]
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments" ]
+    verbs: [ "create", "patch", "update", "get", "list", "delete" ]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/context-box
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/kuber
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: f598df9-2441
+  newTag: 02ede16-2442
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: f598df9-2441
+  newTag: 02ede16-2442

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 68d3060-2407
+  newTag: 9356426-2439
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 68d3060-2407
+  newTag: 9356426-2439

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 9356426-2439
+  newTag: f598df9-2441
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 9356426-2439
+  newTag: f598df9-2441

--- a/manifests/claudie/scheduler.yaml
+++ b/manifests/claudie/scheduler.yaml
@@ -56,6 +56,9 @@ spec:
                 configMapKeyRef:
                   name: env
                   key: GOLANG_LOG
+          ports:
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             httpGet:
               path: /ready

--- a/manifests/claudie/terraformer.yaml
+++ b/manifests/claudie/terraformer.yaml
@@ -24,18 +24,18 @@ spec:
         fsGroup: 2000
       volumes:
         - name: data
-          emptyDir: {}
+          emptyDir: { }
         - name: temp
-          emptyDir: {}
+          emptyDir: { }
       containers:
         - name: terraformer
           imagePullPolicy: Always
           image: ghcr.io/berops/claudie/terraformer
           volumeMounts:
-          - mountPath: /bin/services/terraformer/server/clusters
-            name: data
-          - mountPath: /tmp
-            name: temp
+            - mountPath: /bin/services/terraformer/server/clusters
+              name: data
+            - mountPath: /tmp
+              name: temp
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -115,6 +115,8 @@ spec:
                   key: AWS_REGION
           ports:
             - containerPort: 50052
+            - name: "metrics"
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 50052

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 68d3060-2407
+  newTag: 9356426-2439

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 9356426-2439
+  newTag: f598df9-2441

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: f598df9-2441
+  newTag: 02ede16-2442

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 02ede16-2442
+  newTag: 5b5ed1a-2449

--- a/services/ansibler/server/adapters/inbound/grpc/adapter.go
+++ b/services/ansibler/server/adapters/inbound/grpc/adapter.go
@@ -25,7 +25,7 @@ type GrpcAdapter struct {
 }
 
 // CreateGrpcAdapter return new gRPC adapter for Ansibler.
-func CreateGrpcAdapter(usecases *usecases.Usecases) *GrpcAdapter {
+func CreateGrpcAdapter(usecases *usecases.Usecases, opts ...grpc.ServerOption) *GrpcAdapter {
 	port := utils.GetEnvDefault("ANSIBLER_PORT", fmt.Sprint(defaultPort))
 	tcpBindingAddress := net.JoinHostPort("0.0.0.0", port)
 	listener, err := net.Listen("tcp", tcpBindingAddress)
@@ -33,7 +33,7 @@ func CreateGrpcAdapter(usecases *usecases.Usecases) *GrpcAdapter {
 		log.Fatal().Msgf("Failed to listen on %s : %v", tcpBindingAddress, err)
 	}
 
-	g := &GrpcAdapter{tcpListener: listener, server: utils.NewGRPCServer(), healthcheckServer: health.NewServer()}
+	g := &GrpcAdapter{tcpListener: listener, server: utils.NewGRPCServer(opts...), healthcheckServer: health.NewServer()}
 	log.Info().Msgf("Ansibler microservice is listening on %s", tcpBindingAddress)
 
 	pb.RegisterAnsiblerServiceServer(g.server, &AnsiblerGrpcService{usecases: usecases})

--- a/services/ansibler/server/main.go
+++ b/services/ansibler/server/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	defaultPrometheusPort = "9091"
+	defaultPrometheusPort = "9090"
 )
 
 func main() {

--- a/services/ansibler/server/main.go
+++ b/services/ansibler/server/main.go
@@ -3,7 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"github.com/berops/claudie/internal/utils/metrics"
 	"github.com/berops/claudie/services/ansibler/server/domain/usecases"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	grpc2 "google.golang.org/grpc"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,13 +21,23 @@ import (
 	"github.com/berops/claudie/services/ansibler/server/adapters/inbound/grpc"
 )
 
+const (
+	defaultPrometheusPort = "9091"
+)
+
 func main() {
 	// Initialize logger
 	utils.InitLog("ansibler")
 
-	grpcAdapter := grpc.CreateGrpcAdapter(&usecases.Usecases{
-		SpawnProcessLimit: make(chan struct{}, usecases.SpawnProcessLimit),
-	})
+	grpcAdapter := grpc.CreateGrpcAdapter(
+		&usecases.Usecases{
+			SpawnProcessLimit: make(chan struct{}, usecases.SpawnProcessLimit),
+		},
+		grpc2.UnaryInterceptor(metrics.MetricsMiddleware),
+	)
+
+	metricsServer := &http.Server{Addr: fmt.Sprintf(":%s", utils.GetEnvDefault("PROMETHEUS_PORT", defaultPrometheusPort))}
+	metrics.MustRegisterCounters()
 
 	errGroup, errGroupContext := errgroup.WithContext(context.Background())
 	errGroup.Go(grpcAdapter.Serve)
@@ -45,6 +60,10 @@ func main() {
 			err = errors.New("program interruption signal")
 		}
 
+		if err := metricsServer.Shutdown(errGroupContext); err != nil {
+			log.Err(err).Msgf("Failed to shutdown metrics server")
+		}
+
 		grpcAdapter.Stop()
 
 		// Sometimes when the container terminates gRPC logs the following message:
@@ -54,6 +73,11 @@ func main() {
 		time.Sleep(1 * time.Second)
 
 		return err
+	})
+
+	errGroup.Go(func() error {
+		http.Handle("/metrics", promhttp.Handler())
+		return metricsServer.ListenAndServe()
 	})
 
 	log.Info().Msgf("Stopping ansibler microservice: %v", errGroup.Wait())

--- a/services/builder/domain/usecases/config_processor.go
+++ b/services/builder/domain/usecases/config_processor.go
@@ -42,7 +42,6 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 		clusterView := cutils.NewClusterView(config)
 
 		if config.DsChecksum == nil && config.CsChecksum != nil { // all current state needs to be deleted.
-
 			metrics.InputManifestInDeletion.Inc()
 			defer func() { metrics.InputManifestInDeletion.Dec() }()
 

--- a/services/builder/domain/usecases/config_processor.go
+++ b/services/builder/domain/usecases/config_processor.go
@@ -65,6 +65,8 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 				metrics.InputManifestLabel: config.Name,
 			})
 
+			metrics.ClustersDeleted.Add(float64(len(clusterView.CurrentClusters)))
+
 			logger.Info().Msgf("Config successfully destroyed")
 
 			return

--- a/services/builder/domain/usecases/config_processor.go
+++ b/services/builder/domain/usecases/config_processor.go
@@ -3,6 +3,8 @@ package usecases
 import (
 	"errors"
 	"fmt"
+	"github.com/berops/claudie/services/builder/domain/usecases/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	"sync"
 
@@ -31,28 +33,63 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 	go func() {
 		defer wg.Done()
 
+		metrics.InputManifestsProcessedCounter.Inc()
+
+		metrics.InputManifestsInProgress.Inc()
+		defer func() { metrics.InputManifestsInProgress.Dec() }()
+
 		logger := cutils.CreateLoggerWithProjectName(config.Name)
 		clusterView := cutils.NewClusterView(config)
 
 		if config.DsChecksum == nil && config.CsChecksum != nil { // all current state needs to be deleted.
+			metrics.InputManifestsDeleted.Inc()
+
+			metrics.InputManifestInDeletion.Inc()
+			defer func() { metrics.InputManifestInDeletion.Dec() }()
+
 			logger.Info().Msgf("Destroying config")
 			if err := u.deleteConfig(config, clusterView, cboxClient); err != nil {
+				metrics.InputManifestsErrorCounter.Inc()
+				metrics.InputManifestClusterBuildError.With(prometheus.Labels{
+					metrics.InputManifestLabel: config.Name,
+				}).Add(1)
+
 				logger.Err(err).Msg("Error while destroying config")
 				if err := utils.SaveConfigWithWorkflowError(config, cboxClient, clusterView); err != nil {
 					logger.Err(err).Msg("Failed to save error message")
 					return
 				}
 			}
+
+			metrics.InputManifestClusterBuildError.Delete(prometheus.Labels{
+				metrics.InputManifestLabel: config.Name,
+			})
+
 			logger.Info().Msgf("Config successfully destroyed")
+
 			return
 		}
 
 		// Process each cluster concurrently through the Claudie workflow.
 		if err := cutils.ConcurrentExec(clusterView.AllClusters(), func(_ int, clusterName string) error {
+			metrics.ClusterProcessedCounter.Inc()
+			metrics.LoadBalancersProcessedCounter.Add(float64(len(clusterView.DesiredLoadbalancers[clusterName])))
+
+			metrics.ClustersInProgress.Inc()
+			defer func() { metrics.ClustersInProgress.Dec() }()
+
+			metrics.LoadBalancersInProgress.Add(float64(len(clusterView.DesiredLoadbalancers[clusterName])))
+			defer func(c int) { metrics.LoadBalancersInProgress.Add(float64(-c)) }(len(clusterView.DesiredLoadbalancers[clusterName]))
+
 			logger := cutils.CreateLoggerWithClusterName(clusterName)
 
 			// Handle deletion of a single cluster as a separate step.
 			if clusterView.DesiredClusters[clusterName] == nil {
+				metrics.ClustersDeleted.Inc()
+
+				metrics.ClustersInDeletion.Inc()
+				defer func() { metrics.ClustersInDeletion.Dec() }()
+
 				if err := u.deleteCluster(config.Name, clusterName, clusterView, cboxClient); err != nil {
 					clusterView.SetWorkflowError(clusterName, err)
 					logger.Err(err).Msg("Error while destroying cluster")
@@ -60,6 +97,10 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 				}
 
 				clusterView.RemoveCurrentState(clusterName)
+
+				metrics.InputManifestClusterBuildError.Delete(prometheus.Labels{
+					metrics.InputManifestLabel: config.Name,
+				})
 
 				clusterView.SetWorkflowDone(clusterName)
 				logger.Info().Msg("Finished workflow for cluster")
@@ -113,6 +154,18 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 
 			// If difference between states results in some nodes being deleted, delete them.
 			if len(diff.ToDelete) > 0 {
+				metrics.K8sDeletingNodesInProgress.With(prometheus.Labels{
+					metrics.K8sClusterLabel:    clusterName,
+					metrics.InputManifestLabel: config.Name,
+				}).Add(float64(cutils.Sum(diff.ToDelete)))
+
+				defer func(c int) {
+					metrics.K8sDeletingNodesInProgress.With(prometheus.Labels{
+						metrics.K8sClusterLabel:    clusterName,
+						metrics.InputManifestLabel: config.Name,
+					}).Add(-float64(c))
+				}(cutils.Sum(diff.ToDelete))
+
 				currentStage++
 				clusterView.ClusterWorkflows[clusterName].Description = fmt.Sprintf("Processing stage [%d/%d]", currentStage, stages)
 				logger.Info().Msgf("Processing stage [%d/%d] for cluster", currentStage, stages)
@@ -192,6 +245,11 @@ func (u *Usecases) ConfigProcessor(wg *sync.WaitGroup) error {
 			logger.Info().Msg("Finished building cluster")
 			return nil
 		}); err != nil {
+			metrics.InputManifestsErrorCounter.Inc()
+			metrics.InputManifestClusterBuildError.With(prometheus.Labels{
+				metrics.InputManifestLabel: config.Name,
+			}).Add(1)
+
 			logger.Err(err).Msg("Error encountered while processing config")
 
 			// Even if the config fails to build, merge the changes as it might be in an in-between state

--- a/services/builder/domain/usecases/metrics/metrics.go
+++ b/services/builder/domain/usecases/metrics/metrics.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	InputManifestLabel = "claudie_input_manifest"
+	K8sClusterLabel    = "claudie_k8s_cluster"
+	LBClusterLabel     = "claudie_lb_cluster"
+)
+
+var (
+	InputManifestsProcessedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_processed",
+		Help: "Counter for processed input manifests",
+	})
+	ClusterProcessedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_clusters_processed",
+		Help: "Counter for processed clusters",
+	})
+	LoadBalancersProcessedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_lb_clusters_processed",
+		Help: "Counter for processed LB clusters",
+	})
+	InputManifestsErrorCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_err",
+		Help: "Counter for the errors occurred during processing of Input Manifests",
+	})
+
+	InputManifestsDeleted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_deleted",
+		Help: "Input Manifests deleted",
+	})
+	ClustersDeleted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_clusters_deleted",
+		Help: "Clusters deleted",
+	})
+
+	InputManifestClusterBuildError = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "claudie_cluster_error",
+		Help: "Number of build errors per cluster",
+	}, []string{InputManifestLabel, K8sClusterLabel})
+
+	InputManifestInDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_input_manifests_in_deletion",
+		Help: "Input Manifests in deletion",
+	})
+	ClustersInDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_clusters_in_deletion",
+		Help: "Clusters in deletion",
+	})
+
+	InputManifestsInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_input_manifests_in_progress",
+		Help: "Input Manifests in progress",
+	})
+	ClustersInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_clusters_in_progress",
+		Help: "Clusters in progress",
+	})
+	LoadBalancersInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_loadbalancers_clusters_in_progress",
+		Help: "LoadBalancer clusters in progress",
+	})
+
+	K8sAddingNodesInProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "claudie_k8s_cluster_nodes_adding",
+			Help: "Nodes currently added to the cluster",
+		},
+		[]string{K8sClusterLabel, InputManifestLabel},
+	)
+
+	K8sDeletingNodesInProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "claudie_k8s_cluster_nodes_deleting",
+			Help: "Nodes currently deleted from the cluster",
+		},
+		[]string{K8sClusterLabel, InputManifestLabel},
+	)
+
+	LbAddingNodesInProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "claudie_lb_cluster_nodes_adding",
+			Help: "Nodes currently added to the lb cluster",
+		},
+		[]string{LBClusterLabel, InputManifestLabel, K8sClusterLabel},
+	)
+
+	LbDeletingNodesInProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "claudie_lb_cluster_nodes_deleting",
+			Help: "Nodes currently deleted from the lb cluster",
+		},
+		[]string{LBClusterLabel, InputManifestLabel, K8sClusterLabel},
+	)
+)
+
+func MustRegisterCounters() {
+	prometheus.MustRegister(ClusterProcessedCounter)
+	prometheus.MustRegister(InputManifestsProcessedCounter)
+	prometheus.MustRegister(InputManifestsErrorCounter)
+	prometheus.MustRegister(LoadBalancersProcessedCounter)
+
+	prometheus.MustRegister(InputManifestInDeletion)
+	prometheus.MustRegister(ClustersInDeletion)
+	prometheus.MustRegister(InputManifestsDeleted)
+	prometheus.MustRegister(ClustersDeleted)
+
+	prometheus.MustRegister(InputManifestClusterBuildError)
+
+	prometheus.MustRegister(InputManifestsInProgress)
+	prometheus.MustRegister(ClustersInProgress)
+	prometheus.MustRegister(LoadBalancersInProgress)
+
+	prometheus.MustRegister(K8sAddingNodesInProgress)
+	prometheus.MustRegister(K8sDeletingNodesInProgress)
+	prometheus.MustRegister(LbAddingNodesInProgress)
+	prometheus.MustRegister(LbDeletingNodesInProgress)
+}

--- a/services/builder/domain/usecases/metrics/metrics.go
+++ b/services/builder/domain/usecases/metrics/metrics.go
@@ -36,6 +36,10 @@ var (
 		Name: "claudie_clusters_deleted",
 		Help: "Clusters deleted",
 	})
+	LBClustersDeleted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_lb_clusters_deleted",
+		Help: "Loadbalancer clusters deleted",
+	})
 
 	InputManifestBuildError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "claudie_cluster_error",
@@ -49,6 +53,10 @@ var (
 	ClustersInDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "claudie_clusters_in_deletion",
 		Help: "Clusters in deletion",
+	})
+	LBClustersInDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_lb_clusters_in_deletion",
+		Help: "Loadbalancers clusters in deletion",
 	})
 
 	InputManifestsInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -105,8 +113,10 @@ func MustRegisterCounters() {
 
 	prometheus.MustRegister(InputManifestInDeletion)
 	prometheus.MustRegister(ClustersInDeletion)
+	prometheus.MustRegister(LBClustersInDeletion)
 	prometheus.MustRegister(InputManifestsDeleted)
 	prometheus.MustRegister(ClustersDeleted)
+	prometheus.MustRegister(LBClustersDeleted)
 
 	prometheus.MustRegister(InputManifestBuildError)
 

--- a/services/builder/domain/usecases/metrics/metrics.go
+++ b/services/builder/domain/usecases/metrics/metrics.go
@@ -37,10 +37,10 @@ var (
 		Help: "Clusters deleted",
 	})
 
-	InputManifestClusterBuildError = prometheus.NewCounterVec(prometheus.CounterOpts{
+	InputManifestBuildError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "claudie_cluster_error",
-		Help: "Number of build errors per cluster",
-	}, []string{InputManifestLabel, K8sClusterLabel})
+		Help: "Number of build errors per input manifest",
+	}, []string{InputManifestLabel})
 
 	InputManifestInDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "claudie_input_manifests_in_deletion",
@@ -108,7 +108,7 @@ func MustRegisterCounters() {
 	prometheus.MustRegister(InputManifestsDeleted)
 	prometheus.MustRegister(ClustersDeleted)
 
-	prometheus.MustRegister(InputManifestClusterBuildError)
+	prometheus.MustRegister(InputManifestBuildError)
 
 	prometheus.MustRegister(InputManifestsInProgress)
 	prometheus.MustRegister(ClustersInProgress)

--- a/services/builder/domain/usecases/workflow_helpers.go
+++ b/services/builder/domain/usecases/workflow_helpers.go
@@ -128,6 +128,9 @@ func (u *Usecases) destroyCluster(ctx *utils.BuilderContext, cboxClient pb.Conte
 		}(lb.TargetedK8S, lb.ClusterInfo.Name, cutils.CountLbNodes(lb))
 	}
 
+	metrics.LBClustersInDeletion.Add(float64(len(ctx.CurrentLoadbalancers)))
+	defer func(c int) { metrics.LBClustersInDeletion.Add(-float64(c)) }(len(ctx.CurrentLoadbalancers))
+
 	if s := cutils.GetCommonStaticNodePools(ctx.CurrentCluster.GetClusterInfo().GetNodePools()); len(s) > 0 {
 		if err := u.destroyK8sCluster(ctx, cboxClient); err != nil {
 			return fmt.Errorf("error in destroy Kube-Eleven for config %s project %s : %w", ctx.GetClusterName(), ctx.ProjectName, err)
@@ -147,6 +150,8 @@ func (u *Usecases) destroyCluster(ctx *utils.BuilderContext, cboxClient pb.Conte
 	if err := u.deleteClusterData(ctx, cboxClient); err != nil {
 		return fmt.Errorf("error in delete kubeconfig for config %s project %s : %w", ctx.GetClusterName(), ctx.ProjectName, err)
 	}
+
+	metrics.LBClustersDeleted.Add(float64(len(ctx.CurrentLoadbalancers)))
 
 	return nil
 }

--- a/services/builder/domain/usecases/workflow_helpers.go
+++ b/services/builder/domain/usecases/workflow_helpers.go
@@ -3,6 +3,8 @@ package usecases
 import (
 	"errors"
 	"fmt"
+	"github.com/berops/claudie/services/builder/domain/usecases/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"strings"
 
 	cutils "github.com/berops/claudie/internal/utils"
@@ -17,6 +19,44 @@ const (
 
 // buildCluster performs whole Claudie workflow on the given cluster.
 func (u *Usecases) buildCluster(ctx *utils.BuilderContext, cboxClient pb.ContextBoxServiceClient) (*utils.BuilderContext, error) {
+	// LB add nodes prometheus metrics.
+	for _, lb := range ctx.DesiredLoadbalancers {
+		var currNodes int
+		if idx := cutils.GetLBClusterByName(lb.ClusterInfo.Name, ctx.CurrentLoadbalancers); idx >= 0 {
+			currNodes = cutils.CountLbNodes(ctx.CurrentLoadbalancers[idx])
+		}
+
+		adding := max(0, cutils.CountLbNodes(lb)-currNodes)
+
+		metrics.LbAddingNodesInProgress.With(prometheus.Labels{
+			metrics.LBClusterLabel:     lb.ClusterInfo.Name,
+			metrics.K8sClusterLabel:    lb.TargetedK8S,
+			metrics.InputManifestLabel: ctx.ProjectName,
+		}).Add(float64(adding))
+
+		defer func(k8s, lb string, c int) {
+			metrics.LbAddingNodesInProgress.With(prometheus.Labels{
+				metrics.LBClusterLabel:     lb,
+				metrics.K8sClusterLabel:    k8s,
+				metrics.InputManifestLabel: ctx.ProjectName,
+			}).Add(-float64(c))
+		}(lb.TargetedK8S, lb.ClusterInfo.Name, adding)
+	}
+
+	metrics.K8sAddingNodesInProgress.With(prometheus.Labels{
+		metrics.K8sClusterLabel:    ctx.GetClusterName(),
+		metrics.InputManifestLabel: ctx.ProjectName,
+	}).Add(float64(
+		max(0, cutils.CountNodes(ctx.DesiredCluster)-cutils.CountNodes(ctx.CurrentCluster)),
+	))
+
+	defer func(c int) {
+		metrics.K8sAddingNodesInProgress.With(prometheus.Labels{
+			metrics.K8sClusterLabel:    ctx.GetClusterName(),
+			metrics.InputManifestLabel: ctx.ProjectName,
+		}).Add(-float64(c))
+	}(max(0, cutils.CountNodes(ctx.DesiredCluster)-cutils.CountNodes(ctx.CurrentCluster)))
+
 	// Reconcile infrastructure via terraformer.
 	if err := u.reconcileInfrastructure(ctx, cboxClient); err != nil {
 		return ctx, fmt.Errorf("error in Terraformer for cluster %s project %s : %w", ctx.GetClusterName(), ctx.ProjectName, err)
@@ -42,6 +82,36 @@ func (u *Usecases) buildCluster(ctx *utils.BuilderContext, cboxClient pb.Context
 
 // destroyCluster destroys existing clusters infrastructure for a config and cleans up management cluster from any of the cluster data.
 func (u *Usecases) destroyCluster(ctx *utils.BuilderContext, cboxClient pb.ContextBoxServiceClient) error {
+	// K8s delete nodes prometheus metric.
+	metrics.K8sDeletingNodesInProgress.With(prometheus.Labels{
+		metrics.K8sClusterLabel:    ctx.GetClusterName(),
+		metrics.InputManifestLabel: ctx.ProjectName,
+	}).Add(float64(cutils.CountNodes(ctx.CurrentCluster)))
+
+	defer func(c int) {
+		metrics.K8sDeletingNodesInProgress.With(prometheus.Labels{
+			metrics.K8sClusterLabel:    ctx.GetClusterName(),
+			metrics.InputManifestLabel: ctx.ProjectName,
+		}).Add(-float64(c))
+	}(cutils.CountNodes(ctx.CurrentCluster))
+
+	// LB delete nodes prometheus metrics.
+	for _, lb := range ctx.DeletedLoadBalancers {
+		metrics.LbDeletingNodesInProgress.With(prometheus.Labels{
+			metrics.K8sClusterLabel:    lb.TargetedK8S,
+			metrics.LBClusterLabel:     lb.ClusterInfo.Name,
+			metrics.InputManifestLabel: ctx.ProjectName,
+		}).Add(float64(cutils.CountLbNodes(lb)))
+
+		defer func(k8s, lb string, c int) {
+			metrics.LbDeletingNodesInProgress.With(prometheus.Labels{
+				metrics.K8sClusterLabel:    k8s,
+				metrics.LBClusterLabel:     lb,
+				metrics.InputManifestLabel: ctx.ProjectName,
+			}).Add(-float64(c))
+		}(lb.TargetedK8S, lb.ClusterInfo.Name, cutils.CountLbNodes(lb))
+	}
+
 	if s := cutils.GetCommonStaticNodePools(ctx.CurrentCluster.GetClusterInfo().GetNodePools()); len(s) > 0 {
 		if err := u.destroyK8sCluster(ctx, cboxClient); err != nil {
 			return fmt.Errorf("error in destroy Kube-Eleven for config %s project %s : %w", ctx.GetClusterName(), ctx.ProjectName, err)

--- a/services/builder/main.go
+++ b/services/builder/main.go
@@ -25,7 +25,10 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-const defaultBuilderPort = 50051
+const (
+	defaultBuilderPort    = 50051
+	defaultPrometheusPort = "9090"
+)
 
 // healthCheck function is function used for querying readiness of the pod running this microservice
 func healthCheck(usecases *usecases.Usecases) func() error {
@@ -88,7 +91,7 @@ func main() {
 	}
 	defer kb.Disconnect()
 
-	metricsServer := &http.Server{Addr: ":9090"}
+	metricsServer := &http.Server{Addr: fmt.Sprintf(":%s", utils.GetEnvDefault("PROMETHEUS_PORT", defaultPrometheusPort))}
 	metrics.MustRegisterCounters()
 
 	usecases := &usecases.Usecases{

--- a/services/context-box/server/adapters/inbound/grpc/adapter.go
+++ b/services/context-box/server/adapters/inbound/grpc/adapter.go
@@ -24,7 +24,7 @@ type GrpcAdapter struct {
 }
 
 // Init will create the underlying gRPC server and the gRPC healthcheck server
-func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
+func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOption) {
 	port := utils.GetEnvDefault("CONTEXT_BOX_PORT", fmt.Sprint(defaultContextBoxPort))
 	listeningAddress := net.JoinHostPort("0.0.0.0", port)
 
@@ -36,7 +36,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 
 	log.Info().Msgf("context-box microservice bound to %s", listeningAddress)
 
-	g.server = utils.NewGRPCServer()
+	g.server = utils.NewGRPCServer(opts...)
 	pb.RegisterContextBoxServiceServer(g.server, &ContextBoxGrpcService{usecases: usecases})
 
 	// Add health-check service to gRPC

--- a/services/context-box/server/domain/usecases/enqueue_configs.go
+++ b/services/context-box/server/domain/usecases/enqueue_configs.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"fmt"
+	"github.com/berops/claudie/services/context-box/server/domain/usecases/metrics"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -128,6 +129,7 @@ func (u *Usecases) enqueueConfigs() error {
 					u.schedulerQueue.Enqueue(configInfo)
 					configInfo.SchedulerTTL = defaultSchedulerTTL
 
+					metrics.InputManifestsEnqueuedScheduler.Inc()
 					continue
 				} else if !configInfo.hasAnyError() {
 					// If the item is already present in the scheduler queue but the config is still not pulled by the scheduler
@@ -152,6 +154,8 @@ func (u *Usecases) enqueueConfigs() error {
 					// config and provision the corresponding infrastructure.
 					u.builderQueue.Enqueue(configInfo)
 					configInfo.BuilderTTL = defaultBuilderTTL
+
+					metrics.InputManifestsEnqueuedBuilder.Inc()
 
 					continue
 				}

--- a/services/context-box/server/domain/usecases/metrics/metrics.go
+++ b/services/context-box/server/domain/usecases/metrics/metrics.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	InputManifestsEnqueuedScheduler = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_enqueued_scheduler",
+		Help: "Number of input manifests enqueued for scheduler service",
+	})
+
+	InputManifestsEnqueuedBuilder = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_enqueued_builder",
+		Help: "Number of input manifests enqueued for builder service",
+	})
+)
+
+func MustRegisterCounters() {
+	prometheus.MustRegister(InputManifestsEnqueuedScheduler)
+	prometheus.MustRegister(InputManifestsEnqueuedBuilder)
+}

--- a/services/context-box/server/main.go
+++ b/services/context-box/server/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultPrometheusPort = "9095"
+	defaultPrometheusPort = "9090"
 )
 
 func main() {

--- a/services/context-box/server/main.go
+++ b/services/context-box/server/main.go
@@ -3,20 +3,31 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	metrics2 "github.com/berops/claudie/services/context-box/server/domain/usecases/metrics"
+
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+	grpc2 "google.golang.org/grpc"
 
 	"github.com/berops/claudie/internal/envs"
 	"github.com/berops/claudie/internal/utils"
+	"github.com/berops/claudie/internal/utils/metrics"
 	"github.com/berops/claudie/internal/worker"
 	"github.com/berops/claudie/services/context-box/server/adapters/inbound/grpc"
 	outboundAdapters "github.com/berops/claudie/services/context-box/server/adapters/outbound"
 	"github.com/berops/claudie/services/context-box/server/domain/usecases"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultPrometheusPort = "9095"
 )
 
 func main() {
@@ -39,8 +50,12 @@ func main() {
 		DB: mongoDBConnector,
 	}
 
+	metricsServer := &http.Server{Addr: fmt.Sprintf(":%s", utils.GetEnvDefault("PROMETHEUS_PORT", defaultPrometheusPort))}
+	metrics.MustRegisterCounters()
+	metrics2.MustRegisterCounters()
+
 	grpcAdapter := &grpc.GrpcAdapter{}
-	grpcAdapter.Init(usecases)
+	grpcAdapter.Init(usecases, grpc2.UnaryInterceptor(metrics.MetricsMiddleware))
 
 	errGroup, errGroupContext := errgroup.WithContext(context.Background())
 
@@ -75,6 +90,10 @@ func main() {
 			err = errors.New("program interruption signal")
 		}
 
+		if err := metricsServer.Shutdown(errGroupContext); err != nil {
+			log.Err(err).Msgf("Failed to shutdown metrics server")
+		}
+
 		// Perform graceful shutdown
 		log.Info().Msg("Gracefully shutting down GrpcAdapter")
 		grpcAdapter.Stop()
@@ -85,6 +104,11 @@ func main() {
 		time.Sleep(1 * time.Second)
 
 		return err
+	})
+
+	errGroup.Go(func() error {
+		http.Handle("/metrics", promhttp.Handler())
+		return metricsServer.ListenAndServe()
 	})
 
 	log.Info().Msgf("Stopping context-box microservice: %v", errGroup.Wait())

--- a/services/kube-eleven/server/adapters/inbound/grpc/adapter.go
+++ b/services/kube-eleven/server/adapters/inbound/grpc/adapter.go
@@ -24,7 +24,7 @@ type GrpcAdapter struct {
 	healthcheckServer *health.Server
 }
 
-func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
+func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOption) {
 	var err error
 	port := utils.GetEnvDefault("KUBE_ELEVEN_PORT", fmt.Sprint(defaultPort))
 	bindingAddress := net.JoinHostPort("0.0.0.0", port)
@@ -34,7 +34,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 	}
 	log.Info().Msgf("Kube-eleven microservice is listening on %s", bindingAddress)
 
-	g.server = utils.NewGRPCServer()
+	g.server = utils.NewGRPCServer(opts...)
 	pb.RegisterKubeElevenServiceServer(g.server, &KubeElevenGrpcService{usecases: usecases})
 
 	// Add healthcheck service to the gRPC server

--- a/services/kube-eleven/server/main.go
+++ b/services/kube-eleven/server/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	defaultPrometheusPort = "9092"
+	defaultPrometheusPort = "9090"
 )
 
 func main() {

--- a/services/kuber/server/adapters/inbound/grpc/adapter.go
+++ b/services/kuber/server/adapters/inbound/grpc/adapter.go
@@ -26,7 +26,7 @@ type GrpcAdapter struct {
 
 // Init sets up the GrpcAdapter by creating the underlying tcpListener, gRPC server and
 // gRPC health check server.
-func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
+func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOption) {
 	port := utils.GetEnvDefault("KUBER_PORT", fmt.Sprint(defaultKuberPort))
 
 	var err error
@@ -38,7 +38,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 	}
 	log.Info().Msgf("Kuber service is listening on: %s", listeningAddress)
 
-	g.server = utils.NewGRPCServer()
+	g.server = utils.NewGRPCServer(opts...)
 	pb.RegisterKuberServiceServer(g.server, &KuberGrpcService{usecases: usecases})
 
 	// Add health service to gRPC

--- a/services/kuber/server/main.go
+++ b/services/kuber/server/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	defaultPrometheusPort = "9094"
+	defaultPrometheusPort = "9090"
 )
 
 func main() {

--- a/services/scheduler/domain/usecases/metrics/metrics.go
+++ b/services/scheduler/domain/usecases/metrics/metrics.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	InputManifestsProcessedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_processed",
+		Help: "Counter for processed input manifests",
+	})
+	InputManifestsErrorCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "claudie_input_manifests_err",
+		Help: "Counter for the errors occurred during processing of Input Manifests",
+	})
+	InputManifestsInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "claudie_input_manifests_in_progress",
+		Help: "Number of input manifests currently processed by scheduler",
+	})
+)
+
+func MustRegisterCounters() {
+	prometheus.MustRegister(InputManifestsProcessedCounter)
+	prometheus.MustRegister(InputManifestsErrorCounter)
+	prometheus.MustRegister(InputManifestsInProgress)
+}

--- a/services/scheduler/main.go
+++ b/services/scheduler/main.go
@@ -28,7 +28,7 @@ import (
 const (
 	defaultHealthcheckPort    = 50056
 	defaultConfigPullInterval = 10
-	defaultPrometheusPort     = "9096"
+	defaultPrometheusPort     = "9090"
 )
 
 func main() {

--- a/services/terraformer/server/adapters/inbound/grpc/adapter.go
+++ b/services/terraformer/server/adapters/inbound/grpc/adapter.go
@@ -26,7 +26,7 @@ type GrpcAdapter struct {
 
 // Init sets up the GrpcAdapter by creating the underlying tcpListener, gRPC server and
 // gRPC health check server.
-func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
+func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOption) {
 	port := utils.GetEnvDefault("TERRAFORMER_PORT", fmt.Sprint(defaultTerraformerPort))
 
 	var err error
@@ -38,7 +38,7 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases) {
 	}
 	log.Info().Msgf("Terraformer service is listening on: %s", listeningAddress)
 
-	g.server = utils.NewGRPCServer()
+	g.server = utils.NewGRPCServer(opts...)
 	pb.RegisterTerraformerServiceServer(g.server, &TerraformerGrpcService{usecases: usecases})
 
 	// Add health service to gRPC

--- a/services/terraformer/server/domain/usecases/metrics/metrics.go
+++ b/services/terraformer/server/domain/usecases/metrics/metrics.go
@@ -1,0 +1,1 @@
+package metrics

--- a/services/terraformer/server/domain/usecases/metrics/metrics.go
+++ b/services/terraformer/server/domain/usecases/metrics/metrics.go
@@ -1,1 +1,0 @@
-package metrics

--- a/services/terraformer/server/main.go
+++ b/services/terraformer/server/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultPrometheusPort = "9093"
+	defaultPrometheusPort = "9090"
 )
 
 func main() {


### PR DESCRIPTION
Closes #994 

For the gRPC services (Terraformer, Ansibler, Kube-Eleven, Kuber, ContextBox)

Only these metrics are collected https://github.com/berops/claudie/blob/fb94505bf236c272fa33cd107f6290e6851d037b/internal/utils/metrics/middleware.go#L16-L50

For Builder https://github.com/berops/claudie/blob/fb94505bf236c272fa33cd107f6290e6851d037b/services/builder/domain/usecases/metrics/metrics.go#L14-L98

For scheduler
https://github.com/berops/claudie/blob/fb94505bf236c272fa33cd107f6290e6851d037b/services/scheduler/domain/usecases/metrics/metrics.go#L8-L19

Additionally for contexbox two more (number of enqued) merics are collected

https://github.com/berops/claudie/blob/fb94505bf236c272fa33cd107f6290e6851d037b/services/context-box/server/domain/usecases/metrics/metrics.go#L8-L17

I believe this should give enough inside as to what each of the services are doing

Let me know if I should add anything more or delete some of these metrics 

