### PR TITLE
remove process substitution

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -42,14 +42,7 @@ func (k *Kubectl) KubectlApply(manifest string, options ...string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl apply -f %s %s", manifest, arg)
 	return k.run(command, options...)
@@ -62,14 +55,7 @@ func (k *Kubectl) KubectlApplyString(str string, options ...string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("echo '%s' | kubectl apply -f - %s", str, arg)
 	return k.run(command, options...)
@@ -83,14 +69,7 @@ func (k *Kubectl) KubectlDeleteManifest(manifest string, options ...string) erro
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl delete -f %s %s", manifest, arg)
 	return k.run(command, options...)
@@ -104,14 +83,7 @@ func (k *Kubectl) KubectlDeleteResource(resource, resourceName string, options .
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl delete %s %s %s", resource, resourceName, arg)
 	return k.run(command, options...)
@@ -125,14 +97,7 @@ func (k *Kubectl) KubectlDeleteString(str string, options ...string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("echo '%s' | kubectl delete -f - %s", str, arg)
 	return k.run(command, options...)
@@ -145,14 +110,7 @@ func (k *Kubectl) KubectlDrain(nodeName string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl drain %s --ignore-daemonsets --delete-emptydir-data %s", nodeName, arg)
 	return k.run(command)
@@ -167,14 +125,7 @@ func (k *Kubectl) KubectlDescribe(resource, resourceName string, options ...stri
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl describe %s %s %s", resource, resourceName, arg)
 	return k.run(command, options...)
@@ -189,14 +140,7 @@ func (k *Kubectl) KubectlGet(resource string, options ...string) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl get %s %s", resource, arg)
 	return k.runWithOutput(command, options...)
@@ -209,14 +153,7 @@ func (k *Kubectl) KubectlAnnotate(resource, resourceName, annotation string, opt
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl annotate %s %s %s %s", resource, resourceName, annotation, arg)
 	return k.run(command, options...)
@@ -229,14 +166,7 @@ func (k *Kubectl) KubectlLabel(resource, resourceName, label string, options ...
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl label %s %s %s %s", resource, resourceName, label, arg)
 	return k.run(command, options...)
@@ -249,14 +179,7 @@ func (k *Kubectl) KubectlGetNodeNames() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	nodesQueryCmd := fmt.Sprintf("kubectl get nodes --no-headers -o custom-columns=\":metadata.name\" %s", arg)
 	return k.runWithOutput(nodesQueryCmd)
@@ -269,14 +192,7 @@ func (k *Kubectl) KubectlGetEtcdPods(masterNodeName string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	// get etcd pods name
 	podsQueryCmd := fmt.Sprintf("kubectl %s %s-%s", arg, getEtcdPodsCmd, masterNodeName)
@@ -288,14 +204,7 @@ func (k *Kubectl) KubectlExecEtcd(etcdPod, etcdctlCmd string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	kcExecEtcdCmd := fmt.Sprintf("kubectl %s -n kube-system exec -i %s -- /bin/sh -c \" %s && %s \"",
 		arg, etcdPod, exportEtcdEnvsCmd, etcdctlCmd)
@@ -310,14 +219,7 @@ func (k *Kubectl) KubectlPatch(resource, resourceName, patchPath string, options
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl patch %s %s -p '%s' %s", resource, resourceName, patchPath, arg)
 	return k.run(command, options...)
@@ -329,14 +231,7 @@ func (k *Kubectl) KubectlCordon(nodeName string, options ...string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl cordon %s %s", nodeName, arg)
 	return k.run(command, options...)
@@ -388,23 +283,16 @@ func (k Kubectl) RolloutRestart(resource string, options ...string) error {
 	if err != nil {
 		return err
 	}
-
-	if cleanup != nil {
-		defer func() {
-			if err := cleanup(); err != nil {
-				log.Err(err).Msg("failed to cleanup kubeconfig")
-			}
-		}()
-	}
+	defer cleanup()
 
 	command := fmt.Sprintf("kubectl rollout restart %s %s", resource, arg)
 	return k.run(command, options...)
 }
 
 // getKubeconfig function returns either the "--kubeconfig <(echo ...)" if kubeconfig is specified, or empty string of none is given
-func (k Kubectl) getKubeconfig() (string, func() error, error) {
+func (k Kubectl) getKubeconfig() (string, func(), error) {
 	if k.Kubeconfig == "" {
-		return "", nil, nil
+		return "", func() {}, nil
 	}
 
 	id := uuid.New()
@@ -413,7 +301,11 @@ func (k Kubectl) getKubeconfig() (string, func() error, error) {
 		return "", nil, err
 	}
 
-	cleanup := func() error { return os.Remove(tmpName) }
+	cleanup := func() {
+		if err := os.Remove(tmpName); err != nil {
+			log.Err(err).Msg("failed to cleanup kubeconfig")
+		}
+	}
 
 	return fmt.Sprintf("--kubeconfig %s", tmpName), cleanup, nil
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -2,12 +2,15 @@
 package kubectl
 
 import (
+	"encoding/hex"
 	"fmt"
+	comm "github.com/berops/claudie/internal/command"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
-
-	comm "github.com/berops/claudie/internal/command"
 )
 
 // Kubeconfig - the kubeconfig of the cluster as a string
@@ -35,14 +38,40 @@ const (
 // example: kubectl apply -f test.yaml -> k.KubectlApply("test.yaml")
 // example: kubectl apply -f test.yaml -n test -> k.KubectlApply("test.yaml", "-n", "test")
 func (k *Kubectl) KubectlApply(manifest string, options ...string) error {
-	command := fmt.Sprintf("kubectl apply -f %s %s", manifest, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl apply -f %s %s", manifest, arg)
 	return k.run(command, options...)
 }
 
 // KubectlApplyString runs kubectl apply in k.Directory directory, with specified string data
 // example: echo 'Kind: Pod ...' | kubectl apply -f - -> k.KubectlApply("Kind: Pod ...")
 func (k *Kubectl) KubectlApplyString(str string, options ...string) error {
-	command := fmt.Sprintf("echo '%s' | kubectl apply -f - %s", str, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("echo '%s' | kubectl apply -f - %s", str, arg)
 	return k.run(command, options...)
 }
 
@@ -50,7 +79,20 @@ func (k *Kubectl) KubectlApplyString(str string, options ...string) error {
 // example: kubectl delete -f test.yaml -> k.KubectlDelete("test.yaml")
 // example: kubectl delete -f test.yaml -n test -> k.KubectlDelete("test.yaml", "-n", "test")
 func (k *Kubectl) KubectlDeleteManifest(manifest string, options ...string) error {
-	command := fmt.Sprintf("kubectl delete -f %s %s", manifest, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl delete -f %s %s", manifest, arg)
 	return k.run(command, options...)
 }
 
@@ -58,7 +100,20 @@ func (k *Kubectl) KubectlDeleteManifest(manifest string, options ...string) erro
 // example: kubectl delete ns test -> k.KubectlDeleteResource("ns","test")
 // example: kubectl delete pod busy-box -n test -> k.KubectlDeleteResource("pod","busy-box", "-n","test")
 func (k *Kubectl) KubectlDeleteResource(resource, resourceName string, options ...string) error {
-	command := fmt.Sprintf("kubectl delete %s %s %s", resource, resourceName, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl delete %s %s %s", resource, resourceName, arg)
 	return k.run(command, options...)
 }
 
@@ -66,14 +121,40 @@ func (k *Kubectl) KubectlDeleteResource(resource, resourceName string, options .
 // example: echo 'kind: Namespace...' | kubectl delete -f - -> k.KubectlDeleteResource("kind: Namespace ...")
 // example: echo 'kind: Namespace...' | kubectl delete -f - -n test -> k.KubectlDeleteResource("kind: Namespace ...", "-n","test")
 func (k *Kubectl) KubectlDeleteString(str string, options ...string) error {
-	command := fmt.Sprintf("echo '%s' | kubectl delete -f - %s", str, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("echo '%s' | kubectl delete -f - %s", str, arg)
 	return k.run(command, options...)
 }
 
 // KubectlDrain runs kubectl drain in k.Directory, on a specified node with flags --ignore-daemonsets --delete-emptydir-data
 // example: kubectl drain node1 -> k.KubectlDrain("node1")
 func (k *Kubectl) KubectlDrain(nodeName string) error {
-	command := fmt.Sprintf("kubectl drain %s --ignore-daemonsets --delete-emptydir-data %s", nodeName, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl drain %s --ignore-daemonsets --delete-emptydir-data %s", nodeName, arg)
 	return k.run(command)
 }
 
@@ -82,7 +163,20 @@ func (k *Kubectl) KubectlDrain(nodeName string) error {
 // example: kubectl describe pod test -> k.KubectlDescribe("pod","test")
 // example: kubectl describe pod busy-box -n test -> k.KubectlDescribe("pod","busy-box", "-n", "test")
 func (k *Kubectl) KubectlDescribe(resource, resourceName string, options ...string) error {
-	command := fmt.Sprintf("kubectl describe %s %s %s", resource, resourceName, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl describe %s %s %s", resource, resourceName, arg)
 	return k.run(command, options...)
 }
 
@@ -91,42 +185,120 @@ func (k *Kubectl) KubectlDescribe(resource, resourceName string, options ...stri
 // example: kubectl get ns -> k.KubectlGet("ns")
 // example: kubectl get pods -n test -> k.KubectlGet("pods","-n", "test")
 func (k *Kubectl) KubectlGet(resource string, options ...string) ([]byte, error) {
-	command := fmt.Sprintf("kubectl get %s %s", resource, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl get %s %s", resource, arg)
 	return k.runWithOutput(command, options...)
 }
 
 // KubectlAnnotate runs kubectl annotate in k.Directory, with the specified annotation on a specified resource and resource name
 // example: kubectl annotate node node-1 node.longhorn.io/default-node-tags='["zone2"]' -> k.KubectlAnnotate("node","node-1","node.longhorn.io/default-node-tags='["zone2"]")
 func (k *Kubectl) KubectlAnnotate(resource, resourceName, annotation string, options ...string) error {
-	command := fmt.Sprintf("kubectl annotate %s %s %s %s", resource, resourceName, annotation, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl annotate %s %s %s %s", resource, resourceName, annotation, arg)
 	return k.run(command, options...)
 }
 
 // KubectlLabel runs kubectl label in k.Directory, with the specified label on a specified resource and resource name
 // example: kubectl label node node-1 label=value -> k.KubectlLabel("node","node-1","label=value")
 func (k *Kubectl) KubectlLabel(resource, resourceName, label string, options ...string) error {
-	command := fmt.Sprintf("kubectl label %s %s %s %s", resource, resourceName, label, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl label %s %s %s %s", resource, resourceName, label, arg)
 	return k.run(command, options...)
 }
 
 // KubectlGetNodeNames will find node names for a particular cluster
 // return slice of node names and nil if successful, nil and error otherwise
 func (k *Kubectl) KubectlGetNodeNames() ([]byte, error) {
-	nodesQueryCmd := fmt.Sprintf("kubectl get nodes --no-headers -o custom-columns=\":metadata.name\" %s", k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	nodesQueryCmd := fmt.Sprintf("kubectl get nodes --no-headers -o custom-columns=\":metadata.name\" %s", arg)
 	return k.runWithOutput(nodesQueryCmd)
 }
 
 // getEtcdPods finds all etcd pods in cluster
 // returns slice of pod names and nil if successful, nil and error otherwise
 func (k *Kubectl) KubectlGetEtcdPods(masterNodeName string) ([]byte, error) {
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
 	// get etcd pods name
-	podsQueryCmd := fmt.Sprintf("kubectl %s %s-%s", k.getKubeconfig(), getEtcdPodsCmd, masterNodeName)
+	podsQueryCmd := fmt.Sprintf("kubectl %s %s-%s", arg, getEtcdPodsCmd, masterNodeName)
 	return k.runWithOutput(podsQueryCmd)
 }
 
 func (k *Kubectl) KubectlExecEtcd(etcdPod, etcdctlCmd string) ([]byte, error) {
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
 	kcExecEtcdCmd := fmt.Sprintf("kubectl %s -n kube-system exec -i %s -- /bin/sh -c \" %s && %s \"",
-		k.getKubeconfig(), etcdPod, exportEtcdEnvsCmd, etcdctlCmd)
+		arg, etcdPod, exportEtcdEnvsCmd, etcdctlCmd)
 	return k.runWithOutput(kcExecEtcdCmd)
 }
 
@@ -134,13 +306,39 @@ func (k *Kubectl) KubectlExecEtcd(etcdPod, etcdctlCmd string) ([]byte, error) {
 // example: kubectl patch node node-1 -p {\"spec\":{\"providerID\":\"claudie://node-1\"}} -> KubectlPatch("node", "node-1", "{\"spec\":{\"providerID\":\"claudie://node-1\"}}")
 // example: kubectl patch node node-1 -p {\"spec\":{\"providerID\":\"claudie://node-1\"}} --type="strategic" -> KubectlPatch("node", "node-1", "{\"spec\":{\"providerID\":\"claudie://node-1\"}}", "--type=\"strategic\"")
 func (k *Kubectl) KubectlPatch(resource, resourceName, patchPath string, options ...string) error {
-	command := fmt.Sprintf("kubectl patch %s %s -p '%s' %s", resource, resourceName, patchPath, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl patch %s %s -p '%s' %s", resource, resourceName, patchPath, arg)
 	return k.run(command, options...)
 }
 
 // KubectlCordon runs kubectl cordon <node name> for a particular node in cluster
 func (k *Kubectl) KubectlCordon(nodeName string, options ...string) error {
-	command := fmt.Sprintf("kubectl cordon %s %s", nodeName, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl cordon %s %s", nodeName, arg)
 	return k.run(command, options...)
 }
 
@@ -186,15 +384,36 @@ func (k Kubectl) runWithOutput(command string, options ...string) ([]byte, error
 }
 
 func (k Kubectl) RolloutRestart(resource string, options ...string) error {
-	command := fmt.Sprintf("kubectl rollout restart %s %s", resource, k.getKubeconfig())
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return err
+	}
+
+	if cleanup != nil {
+		defer func() {
+			if err := cleanup(); err != nil {
+				log.Err(err).Msg("failed to cleanup kubeconfig")
+			}
+		}()
+	}
+
+	command := fmt.Sprintf("kubectl rollout restart %s %s", resource, arg)
 	return k.run(command, options...)
 }
 
 // getKubeconfig function returns either the "--kubeconfig <(echo ...)" if kubeconfig is specified, or empty string of none is given
-func (k Kubectl) getKubeconfig() string {
+func (k Kubectl) getKubeconfig() (string, func() error, error) {
 	if k.Kubeconfig == "" {
-		return ""
-	} else {
-		return fmt.Sprintf("--kubeconfig <(echo '%s')", k.Kubeconfig)
+		return "", nil, nil
 	}
+
+	id := uuid.New()
+	tmpName := fmt.Sprintf("/tmp/k%s", hex.EncodeToString(id[:]))
+	if err := os.WriteFile(tmpName, []byte(k.Kubeconfig), os.ModePerm); err != nil {
+		return "", nil, err
+	}
+
+	cleanup := func() error { return os.Remove(tmpName) }
+
+	return fmt.Sprintf("--kubeconfig %s", tmpName), cleanup, nil
 }

--- a/manifests/claudie/kuber.yaml
+++ b/manifests/claudie/kuber.yaml
@@ -35,7 +35,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - all

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 397ce04-2463
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/context-box
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/kuber
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: c16a343-2474
+  newTag: 63db526-2480
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: c16a343-2474
+  newTag: 63db526-2480

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/context-box
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/kuber
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: c16a343-2474
+  newTag: 63db526-2480

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 63db526-2480
+  newTag: 99cf1dc-2481

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: bd74b46-2486
+  newTag: 7ad2d7d-2487

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 5b5ed1a-2449
+  newTag: c16a343-2474

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 7ad2d7d-2487
+  newTag: c9139a6-2488

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 99cf1dc-2481
+  newTag: bd74b46-2486


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1126

The issue is when the combination `bash -c` `<()` is used while the entrypoint of the docker image is not a shell. Thus replace the proces subsitution `<()` by directly creating a temporary file.

for a quick verification of the issue one can try 

docker run -it --rm [docker.io/library/alpine:3.18.4](http://docker.io/library/alpine:3.18.4) tail -f /dev/null 

and in another terminal exec into the container and  execute a simple command like `bash -c 'echo <(echo 1)'` and look at the `ps` output, the subprocess won't be terminated