### PR TITLE
docs/fix-logo-visibility-on-light-theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,13 +45,15 @@ theme:
     - navigation.top
   palette:
     - media: "(prefers-color-scheme)"
+      primary: white
+      accent: black
       toggle:
         icon: material/link
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: indigo
+      primary: white
+      accent: black
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode


### PR DESCRIPTION
Fix logo visibility on the light theme.

Previously
![image](https://github.com/berops/claudie/assets/43497822/a7a0d9cf-0959-4896-9916-182b1ba0b07e)

Now
![image](https://github.com/berops/claudie/assets/43497822/c5b76455-0818-4f2c-8107-2cebcf052af2)
