### PR TITLE
Cluster-autoscaler tag validation

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 5861642-2547
+  newTag: f02bca9-2550
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: a1302cb-2540
+  newTag: "626087e-2544"
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: f02bca9-2550
+  newTag: d256c38-2551
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: "626087e-2544"
+  newTag: 5861642-2547
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: d4fcf7f-2520
+  newTag: cee0c74-2539
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,7 +58,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 7c3ecf9-2546
+  newTag: 1a0d4d5-2549
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/kuber
-  newTag: cee0c74-2539
+  newTag: a1302cb-2540
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/terraformer

--- a/services/ansibler/templates/conf.gotpl
+++ b/services/ansibler/templates/conf.gotpl
@@ -9,7 +9,6 @@ upstream {{ $role.Role.Name }}{
 server  {
     listen {{ $role.Role.Port }};
     proxy_pass {{ $role.Role.Name}};
-    proxy_protocol on;
     proxy_next_upstream on;
 }
 {{- end }}

--- a/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
+++ b/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
@@ -1,6 +1,7 @@
 package autoscaler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -210,9 +211,13 @@ func getClusterAutoscaleVersions() ([]string, error) {
 	var TagsResponse TagsResponse
 
 	// Query CA registry
-	response, err := http.Get(clusterAutoscalerRegistry)
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, clusterAutoscalerRegistry, nil)
 	if err != nil {
-		return nil, err
+			return nil, err
+	}
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+			return nil, err
 	}
 	defer response.Body.Close()
 

--- a/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
+++ b/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
@@ -213,11 +213,11 @@ func getClusterAutoscaleVersions() ([]string, error) {
 	// Query CA registry
 	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, clusterAutoscalerRegistry, nil)
 	if err != nil {
-			return nil, err
+		return nil, err
 	}
 	response, err := http.DefaultClient.Do(req)
 	if err != nil {
-			return nil, err
+		return nil, err
 	}
 	defer response.Body.Close()
 

--- a/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
+++ b/services/kuber/server/domain/utils/autoscaler/cluster_autoscaler.go
@@ -1,7 +1,10 @@
 package autoscaler
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"strconv"
@@ -27,6 +30,8 @@ const (
 	defaultOperatorHostname = "claudie-operator"
 	// Default port for Claudie operator.
 	defaultOperatorPort = "50058"
+	// CA registry address to query for tags
+	clusterAutoscalerRegistry = "https://registry.k8s.io/v2/autoscaling/cluster-autoscaler/tags/list"
 )
 
 // ClusterAutoscalerManager either creates or destroys Cluster Autoscaler resources for given k8s cluster.
@@ -47,6 +52,11 @@ type autoscalerDeploymentData struct {
 	KubernetesVersion string
 	OperatorHostname  string
 	OperatorPort      string
+}
+
+// TagResponse will carry the information about cluster-autoscaler tags
+type TagsResponse struct {
+	Tags []string `json:"tags"`
 }
 
 // NewAutoscalerManager returns configured AutoscalerManager which can set up or remove Cluster Autoscaler.
@@ -147,7 +157,86 @@ func getK8sVersion(version string) (string, error) {
 		if minor < 25 {
 			return "v1.25.0", nil
 		}
-		return fmt.Sprintf("v%s.%s.%s", match[1], match[2], match[3]), nil
+		// Find latest autoscaler patch version
+		latestVersion, err := getLatestMinorVersion(version)
+		if err != nil {
+			log.Warn().Msg("Could not retrieve latest cluster-autoscaler version, fallback to defined Kubernetes version")
+			return fmt.Sprintf("v%s.%s.%s", match[1], match[2], match[3]), nil
+		}
+		return latestVersion, nil
 	}
 	return "", fmt.Errorf("failed to parse %s into autoscaler image tag [vX.Y.Z]", version)
+}
+
+// getLatestMinorVersion returns latest patch tag for given kubernetes version
+// Example: for v1.25.1 returns v1.25.3
+func getLatestMinorVersion(k8sVersion string) (string, error) {
+	var minor, patch int
+
+	tagList, err := getClusterAutoscaleVersions()
+	if err != nil {
+		return "", err
+	}
+
+	// Extract values from k8sVersion
+	_, err = fmt.Sscanf(k8sVersion, "v1.%d.%d", &minor, &patch)
+	if err != nil {
+		return "", err
+	}
+
+	// Find latest patch version
+	var latestPatch int
+	for _, semver := range tagList {
+		var listMinor, listPatch int
+		_, err := fmt.Sscanf(semver, "v1.%d.%d", &listMinor, &listPatch)
+		if err != nil {
+			return "", err
+		}
+		if minor == listMinor {
+			if listPatch > latestPatch {
+				latestPatch = listPatch
+			}
+		}
+	}
+
+	latestSemver := fmt.Sprintf("v1.%d.%d", minor, latestPatch)
+
+	return latestSemver, nil
+}
+
+// getClusterAutoscaleVersions query the CA registry to retrieve all available tags,
+// extracts proper semver from it, and returns a slice of available tags
+func getClusterAutoscaleVersions() ([]string, error) {
+	var TagsResponse TagsResponse
+
+	// Query CA registry
+	response, err := http.Get(clusterAutoscalerRegistry)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	// Unmarshal tags from the response
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &TagsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract semver from the slice
+	var semverList []string
+	semverRegex := regexp.MustCompile(`v\d+\.\d+\.\d+(-[\w\d]+(\.[\w\d]+)*)?`)
+
+	// Iterate through the input slice and filter out non-semver strings
+	for _, str := range TagsResponse.Tags {
+		semverMatches := semverRegex.FindStringSubmatch(str)
+		if len(semverMatches) > 0 {
+			semverList = append(semverList, semverMatches[0])
+		}
+	}
+
+	return semverList, nil
 }


### PR DESCRIPTION
closes #1122 
This PR implements the logic for choosing upstream cluster-autoscaler components. It will lookup cluster-autoscaler container registry and choose the latest PATCH version of defined Kubernetes version.