### PR TITLE
Revert "add "proxy_protocol on;" to the LoadBalancer nginx config"

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,7 +58,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 5b98b6d-2519
+  newTag: 1a0d4d5-2549
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,7 +58,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 7c3ecf9-2546
+  newTag: 5b98b6d-2519
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder

--- a/services/ansibler/templates/conf.gotpl
+++ b/services/ansibler/templates/conf.gotpl
@@ -9,7 +9,6 @@ upstream {{ $role.Role.Name }}{
 server  {
     listen {{ $role.Role.Port }};
     proxy_pass {{ $role.Role.Name}};
-    proxy_protocol on;
     proxy_next_upstream on;
 }
 {{- end }}


### PR DESCRIPTION
Reverts berops/claudie#1178

`proxy_protocol on;` is responsible for an error in `kube-eleven` when Claudie wants to build an `InputManifest` with the LoadBalancer cluster.