### PR TITLE
Fix/static nodes

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -315,9 +315,14 @@ jobs:
           
           for file in test-set5/*; do
               if [ -f "$file" ]; then
-                ENDPOINT=${IP_ARR[0]} ./yq e '.spec.nodePools.static.[0].nodes.[0].endpoint = strenv(ENDPOINT)' $file -i 
-                ENDPOINT=${IP_ARR[1]} ./yq e '.spec.nodePools.static.[1].nodes.[0].endpoint = strenv(ENDPOINT)' $file -i
-                ENDPOINT=${IP_ARR[2]} ./yq e '.spec.nodePools.static.[1].nodes.[1].endpoint = strenv(ENDPOINT)' $file -i
+                  filename=$(basename "$file")
+                  if [[ $filename == "1.yaml" ]]; then
+                      ENDPOINT=${IP_ARR[1]} ./yq e '.spec.nodePools.static.[0].nodes.[0].endpoint = strenv(ENDPOINT)' $file -i
+                      ENDPOINT=${IP_ARR[2]} ./yq e '.spec.nodePools.static.[0].nodes.[1].endpoint = strenv(ENDPOINT)' $file -i
+                  fi
+                  if [[ $filename == "2.yaml" ]]; then
+                      ENDPOINT=${IP_ARR[0]} ./yq e '.spec.nodePools.static.[0].nodes.[0].endpoint = strenv(ENDPOINT)' $file -i
+                  fi
               fi
           done
 

--- a/internal/manifest/utils.go
+++ b/internal/manifest/utils.go
@@ -238,18 +238,19 @@ func getNodeKeys(nodepool *StaticNodePool) map[string]string {
 }
 
 // nodePoolDefined returns true if node pool is defined in manifest, false otherwise.
-func (ds *Manifest) nodePoolDefined(pool string) bool {
+func (ds *Manifest) nodePoolDefined(pool string) (defined bool, static bool) {
 	for _, nodePool := range ds.NodePools.Static {
 		if nodePool.Name == pool {
-			return true
+			return true, true
 		}
 	}
 	for _, nodePool := range ds.NodePools.Dynamic {
 		if nodePool.Name == pool {
-			return true
+			return true, false
 		}
 	}
-	return false
+
+	return
 }
 
 func getTaints(taints []k8sV1.Taint) []*pb.Taint {

--- a/internal/utils/generic.go
+++ b/internal/utils/generic.go
@@ -32,3 +32,15 @@ func Sum[M ~map[K]V, K comparable, V constraints.Integer | constraints.Float](m 
 	}
 	return out
 }
+
+func RemoveDuplicates[K comparable](slice []K) []K {
+	keys := make(map[K]bool)
+	list := []K{}
+	for _, entry := range slice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 1a0d4d5-2549
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: e7e652d-2538
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/kuber
-  newTag: d256c38-2551
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,20 +58,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/context-box
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/kuber
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/scheduler
-  newTag: c0246df-2553
+  newTag: 53c719e-2554
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: c0246df-2553
+  newTag: 53c719e-2554

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: c0246df-2553
+  newTag: 53c719e-2554

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -37,4 +37,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 5b98b6d-2519
+  newTag: c0246df-2553

--- a/manifests/testing-framework/test-sets/test-set5/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/1.yaml
@@ -28,17 +28,6 @@ spec:
         image: ami-0039da1f3917fa8e3
         storageDiskSize: 50
 
-      - name: aws-compute
-        providerSpec:
-          name: aws-1
-          region: eu-central-1
-          zone: eu-central-1c
-        count: 1
-        serverType: t3.small
-        #ubuntu
-        image: ami-0039da1f3917fa8e3
-        storageDiskSize: 50
-
       - name: aws-lb
         providerSpec:
           name: aws-1
@@ -51,13 +40,6 @@ spec:
         storageDiskSize: 50
 
     static:
-      - name: static-pool-1
-        nodes:
-          - endpoint: replace-me
-            secretRef:
-              name: static-nodes-key
-              namespace: e2e-secrets
-
       - name: static-pool-2
         nodes:
           - endpoint: replace-me

--- a/manifests/testing-framework/test-sets/test-set5/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/2.yaml
@@ -17,17 +17,6 @@ spec:
 
   nodePools:
     dynamic:
-      - name: aws-control
-        providerSpec:
-          name: aws-1
-          region: eu-central-1
-          zone: eu-central-1c
-        count: 1
-        serverType: t3.small
-        #ubuntu
-        image: ami-0039da1f3917fa8e3
-        storageDiskSize: 50
-
       - name: aws-compute
         providerSpec:
           name: aws-1

--- a/manifests/testing-framework/test-sets/test-set5/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/2.yaml
@@ -47,17 +47,6 @@ spec:
               name: static-nodes-key
               namespace: e2e-secrets
 
-      - name: static-pool-2
-        nodes:
-          - endpoint: replace-me
-            secretRef:
-              name: static-nodes-key
-              namespace: e2e-secrets
-          - endpoint: replace-me
-            secretRef:
-              name: static-nodes-key
-              namespace: e2e-secrets
-
   kubernetes:
     clusters:
       - name: hybrid-cluster

--- a/services/context-box/server/domain/usecases/save_config_frontend.go
+++ b/services/context-box/server/domain/usecases/save_config_frontend.go
@@ -2,11 +2,13 @@ package usecases
 
 import (
 	"fmt"
-
+	"github.com/berops/claudie/internal/manifest"
 	"github.com/rs/zerolog/log"
 
 	"github.com/berops/claudie/proto/pb"
 	"github.com/berops/claudie/services/context-box/server/utils"
+
+	"gopkg.in/yaml.v3"
 )
 
 // SaveConfigOperator saves config to MongoDB after receiving it from the Operator microservice
@@ -40,6 +42,15 @@ func (u *Usecases) SaveConfigOperator(request *pb.SaveConfigRequest) (*pb.SaveCo
 		newConfig = oldConfig
 	}
 
+	// Check if the new config has reference to already existing static nodes.
+	configs, err := u.DB.GetAllConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stored configs")
+	}
+	if err := validateStaticNodepools(newConfig, configs); err != nil {
+		return nil, fmt.Errorf("error while verifying static nodepools: %w", err)
+	}
+
 	if err = u.DB.SaveConfig(newConfig); err != nil {
 		return nil, fmt.Errorf("error while saving config %s in MongoDB: %w", newConfig.Name, err)
 	}
@@ -47,4 +58,65 @@ func (u *Usecases) SaveConfigOperator(request *pb.SaveConfigRequest) (*pb.SaveCo
 	log.Info().Msgf("Config %s successfully saved from claudie-operator", newConfig.Name)
 
 	return &pb.SaveConfigResponse{Config: newConfig}, nil
+}
+
+func validateStaticNodepools(refConf *pb.Config, other []*pb.Config) error {
+	refManifest, err := unmarshallManifest(refConf)
+	if err != nil {
+		return err
+	}
+
+	refManifestStaticIPs := collectIPs(refManifest)
+
+	for _, cfg := range other {
+		if cfg.Name == refConf.Name {
+			continue
+		}
+
+		otherManifest, err := unmarshallManifest(cfg)
+		if err != nil {
+			return err
+		}
+
+		otherManifestStaticIPs := collectIPs(otherManifest)
+
+		if match := findMatch(refManifestStaticIPs, otherManifestStaticIPs); match != "" {
+			return fmt.Errorf("reference to the same static node with IP %q referenced in the newly added config %q is already in use by config %q, reference to the same static node across different clusters/configs is discouraged as it can lead to corrupt state of the cluster", match, refConf.Name, cfg.Name)
+		}
+	}
+
+	return nil
+}
+
+func findMatch(first, second map[string]struct{}) string {
+	for checkIP := range first {
+		if _, ok := second[checkIP]; ok {
+			return checkIP
+		}
+	}
+	return ""
+}
+
+// todo add unused nodepool as error for validation.
+func collectIPs(m *manifest.Manifest) map[string]struct{} {
+	nodepools := make(map[string]struct{})
+
+	for _, snp := range m.NodePools.Static {
+		for _, node := range snp.Nodes {
+			nodepools[node.Endpoint] = struct{}{}
+		}
+	}
+
+	return nodepools
+}
+
+func unmarshallManifest(config *pb.Config) (*manifest.Manifest, error) {
+	d := []byte(config.GetManifest())
+
+	var m manifest.Manifest
+	if err := yaml.Unmarshal(d, &m); err != nil {
+		return nil, fmt.Errorf("error while unmarshalling manifest for config %s: %w", config.Name, err)
+	}
+
+	return &m, nil
 }


### PR DESCRIPTION
Closes #1141 

Check if the same static node is re-used.

1. Within the same config (by tracking the nodepool name)
2. Across different configs (by tracking the IP of every node) No two static nodes can have the same IP, thus if the same IP is used in different config this means the same static node is referenced.

This will work for now, but once https://github.com/berops/claudie/issues/962 is being worked on this should be revisited.
