### PR TITLE
fix wrong cmds to obtain loadbalancer private key and IPs

### DIFF
--- a/docs/getting-started/detailed-guide.md
+++ b/docs/getting-started/detailed-guide.md
@@ -274,13 +274,13 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     In case you want to connect to your load balancer nodes via SSH, you can recover private SSH key:
 
     ```bash
-    kubectl get secrets -n claudie -l claudie.io/output=metadata -ojsonpath='{.items[0].data.metadata}' | base64 -d | jq -r .load_balancer_node_pools.cluster_private_key > ~/.ssh/my-super-cluster-lb-key
+    kubectl get secrets -n claudie -l claudie.io/output=metadata -ojsonpath='{.items[0].data.metadata}' | base64 -d | jq -r '.load_balancer_node_pools[] | .cluster_private_key' > ~/.ssh/my-super-cluster-lb-key
     ```
 
     To recover public IP of your load balancer nodes to connect to via SSH:
 
     ```bash
-    kubectl get secrets -n claudie -l claudie.io/output=metadata -ojsonpath='{.items[0].data.metadata}' | base64 -d | jq -r .load_balancer_node_pools.node_ips
+    kubectl get secrets -n claudie -l claudie.io/output=metadata -ojsonpath='{.items[0].data.metadata}' | base64 -d | jq -r '.load_balancer_node_pools[] | .node_ips'
     ```
 
     Each secret created by Claudie has following labels:


### PR DESCRIPTION
This PR just fixes wrong cmds to obtain the LB private key and LB IPs in the docs.