### PR TITLE
fix not working custom storage classes

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -70,7 +70,7 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 2bc5b89-2592
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 2bc5b89-2592
+  newTag: 39ec029-2594
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 2bc5b89-2592
 - name: ghcr.io/berops/claudie/terraformer

--- a/services/kuber/templates/storage-class.goyaml
+++ b/services/kuber/templates/storage-class.goyaml
@@ -6,7 +6,7 @@ metadata:
     claudie.io/storage-class: {{ .StorageClassName }}
 provisioner: driver.longhorn.io
 parameters:
-  fromBackup: "false"
+  fromBackup: ""
   nodeSelector: {{ .ZoneName }}
   fsType: xfs
   numberOfReplicas: "3"


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1217

`fromBackup` needs to have an empty value ([see](https://longhorn.io/docs/1.6.0/references/storage-class-parameters/#from-backup-field-parametersfrombackup)). We used `false` before.

was tested locally, and everything worked.