### PR TITLE
Feat/add automatic docs update on label

### DIFF
--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -1,0 +1,113 @@
+name: Automatic docs update pipeline
+on:
+  # Run when PR is labeled
+  pull_request:
+    types: [labeled]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    name: Create a new  docs release
+    if: ${{ github.event.label.name == 'refresh-docs' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set release tag
+        run: |
+          R=${GITHUB_REF#"refs/tags/"}
+          echo "RELEASE=$R" >> $GITHUB_ENV
+      
+      - name: Set up git author
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Handle Changelog file
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          filename="mkdocs.yml"
+          start_line=$(sed -n '/- Changelog:/=' "$filename")
+          
+          changelogs_from_dir=$(ls ./docs/CHANGELOG) 
+          changelogs_from_mkdocs_file=$(grep -Eo "CHANGELOG/changelog-[0-9]+\.[0-9]+\.x\.md" "$filename" | awk -F'/' '{print $2}')
+          
+          changelogs_mkdocs_arr=( $changelogs_from_mkdocs_file )
+          changelogs_dir_arr=( $changelogs_from_dir )
+          
+          new_changelog_file=""
+          
+          # check if all files from CHANGELOG dir are present in mkdocs.yml
+          for value in "${changelogs_dir_arr[@]}"; do
+              if [[ ! " ${changelogs_mkdocs_arr[@]} " =~ " $value " ]]; then
+                  # the value of the new_changelog_file will be name of the changelog file, which isn't in mkdocs.yml nav
+                  new_changelog_file=$value
+              fi
+          done
+          
+          # add new navigation entry only, when there is a new changelog file
+          if [[ -n "$new_changelog_file" ]]; then
+              echo "Found new changelog file"
+          
+              version=$(echo $new_changelog_file | grep -oE [0-9]+\.[0-9]+)
+          
+              navigation_entry="Claudie v$version: CHANGELOG/$new_changelog_file"
+          
+              new_entry_line=$(($start_line + ${#changelogs_dir_arr[@]}))
+          
+              sed -i "${new_entry_line}i\\
+              - ${navigation_entry}" $filename
+
+              git fetch
+
+              git checkout -b feat/add-reference-to-new-changelog-${RELEASE}
+
+              # commit and push
+              git commit -am "add new changelog file to mkdocs.yml"
+          
+              git push --set-upstream origin feat/add-reference-to-new-changelog-${RELEASE}
+          
+              echo "Altered mkdocs.yml with new Changelog navigation entry was commited and pushed to origin"
+
+              gh pr create --title "Add reference to new Changelog ${RELEASE}" --body "Add reference to new Changelog file in mkdocs.yml"
+          else
+              echo "There isn't a new changelog file"
+          fi
+          
+      # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
+      - name: Git fetch gh-pages
+        run: git fetch origin gh-pages
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9  
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      # this is only possible, when there is already a version with latest alias
+      # in case there isn't a version like this you have to
+      #   1. mike deploy <version> latest
+      #   2. mike set-default latest
+      #   3. mike deploy <version_from_cmd_1> latest --push
+      # --push flag in the latest cmd is necessary, when you want to apply changes in gh-pages branch and also in GH Pages
+      - name: Deploy new docs version
+        run: mike deploy ${RELEASE} latest --update-aliases --push

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    name: Create a new  docs release
+    name: Automatically update docs
     if: ${{ github.event.label.name == 'refresh-docs' }}
     runs-on: ubuntu-22.04
     steps:
@@ -26,11 +26,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set release tag
-        run: |
-          R=${GITHUB_REF#"refs/tags/"}
-          echo "RELEASE=$R" >> $GITHUB_ENV
       
       - name: Set up git author
         run: |
@@ -39,69 +34,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Handle Changelog file
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          filename="mkdocs.yml"
-          start_line=$(sed -n '/- Changelog:/=' "$filename")
-          
-          changelogs_from_dir=$(ls ./docs/CHANGELOG) 
-          changelogs_from_mkdocs_file=$(grep -Eo "CHANGELOG/changelog-[0-9]+\.[0-9]+\.x\.md" "$filename" | awk -F'/' '{print $2}')
-          
-          changelogs_mkdocs_arr=( $changelogs_from_mkdocs_file )
-          changelogs_dir_arr=( $changelogs_from_dir )
-          
-          new_changelog_file=""
-          
-          # check if all files from CHANGELOG dir are present in mkdocs.yml
-          for value in "${changelogs_dir_arr[@]}"; do
-              if [[ ! " ${changelogs_mkdocs_arr[@]} " =~ " $value " ]]; then
-                  # the value of the new_changelog_file will be name of the changelog file, which isn't in mkdocs.yml nav
-                  new_changelog_file=$value
-              fi
-          done
-          
-          # add new navigation entry only, when there is a new changelog file
-          if [[ -n "$new_changelog_file" ]]; then
-              echo "Found new changelog file"
-          
-              version=$(echo $new_changelog_file | grep -oE [0-9]+\.[0-9]+)
-          
-              navigation_entry="Claudie v$version: CHANGELOG/$new_changelog_file"
-          
-              new_entry_line=$(($start_line + ${#changelogs_dir_arr[@]}))
-          
-              sed -i "${new_entry_line}i\\
-              - ${navigation_entry}" $filename
-
-              git fetch
-
-              git checkout -b feat/add-reference-to-new-changelog-${RELEASE}
-
-              # commit and push
-              git commit -am "add new changelog file to mkdocs.yml"
-          
-              git push --set-upstream origin feat/add-reference-to-new-changelog-${RELEASE}
-          
-              echo "Altered mkdocs.yml with new Changelog navigation entry was commited and pushed to origin"
-
-              gh pr create --title "Add reference to new Changelog ${RELEASE}" --body "Add reference to new Changelog file in mkdocs.yml"
-          else
-              echo "There isn't a new changelog file"
-          fi
-          
-      # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
-      - name: Git fetch gh-pages
-        run: git fetch origin gh-pages
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9  
-
+  
       - name: Install Python dependencies
         run: pip install -r requirements.txt
+
+      - name: Retrieve latest version tag
+        run: |
+          LATEST_VERSION=$(mike list | grep [latest] | awk '{sub(/\[latest\]/, ""); print}')
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
+
+      - name: Print latest version tag
+        run : echo ${LATEST_VERSION}
+          
+      # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
+      - name: Git fetch gh-pages
+        run: git fetch origin gh-pages
 
       # this is only possible, when there is already a version with latest alias
       # in case there isn't a version like this you have to
@@ -110,4 +61,4 @@ jobs:
       #   3. mike deploy <version_from_cmd_1> latest --push
       # --push flag in the latest cmd is necessary, when you want to apply changes in gh-pages branch and also in GH Pages
       - name: Deploy new docs version
-        run: mike deploy ${RELEASE} latest --update-aliases --push
+        run: mike deploy ${LATEST_VERSION} latest --update-aliases --push

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -1,5 +1,7 @@
 name: Automatic docs update pipeline
 on:
+  issue_comment:
+    types: [created, edited]
   # Run when PR is labeled
   pull_request:
     types: [labeled]
@@ -19,7 +21,7 @@ concurrency:
 jobs:
   build-and-publish:
     name: Automatically update docs
-    if: ${{ github.event.label.name == 'refresh-docs' }}
+    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/refresh-docs')) || github.event.label.name == 'refresh-docs' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +36,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
+      - name: Git fetch gh-pages
+        run: git fetch origin gh-pages
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -46,13 +52,6 @@ jobs:
         run: |
           LATEST_VERSION=$(mike list | grep [latest] | awk '{sub(/\[latest\]/, ""); print}')
           echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
-
-      - name: Print latest version tag
-        run : echo ${LATEST_VERSION}
-          
-      # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
-      - name: Git fetch gh-pages
-        run: git fetch origin gh-pages
 
       # this is only possible, when there is already a version with latest alias
       # in case there isn't a version like this you have to

--- a/docs/docs-guides/deployment-workflow.md
+++ b/docs/docs-guides/deployment-workflow.md
@@ -24,7 +24,7 @@ mike deploy <version> --push
 mike set-default <version>
 ```
 
-## Deploy docs from some older GitHub tags
+## Deploy docs manually from some older GitHub tags
 
 - Checkout to the desired tag
 
@@ -97,3 +97,7 @@ mike deploy <release tag> latest --push -u
 > :warning: Don't forget to use the `latest` tag in the last command, because otherwise the new version will not be loaded as default one, when visiting [docs.claudie.io](docs.claudie.io) :warning:
 
 Find more about how to work with [mike](https://github.com/jimporter/mike).
+
+## Automatic update of the latest documentation version
+
+The `automatic-docs-update.yml` pipeline will update the docs automatically, in case you add the label `refresh-docs` or comment `/refresh-docs` on your PR. In order to trigger this pipeline again you have to re-add `refresh-docs` label or once again comment `/refresh-docs` in your PR.

--- a/docs/docs-guides/deployment-workflow.md
+++ b/docs/docs-guides/deployment-workflow.md
@@ -101,3 +101,6 @@ Find more about how to work with [mike](https://github.com/jimporter/mike).
 ## Automatic update of the latest documentation version
 
 The `automatic-docs-update.yml` pipeline will update the docs automatically, in case you add the label `refresh-docs` or comment `/refresh-docs` on your PR. In order to trigger this pipeline again you have to re-add `refresh-docs` label or once again comment `/refresh-docs` in your PR.
+
+> [!NOTE]  
+> `/refresh-docs` comment trigger automatic update only when the `automatic-docs-update.yml` file is in the default branch.

--- a/docs/docs-guides/deployment-workflow.md
+++ b/docs/docs-guides/deployment-workflow.md
@@ -103,4 +103,4 @@ Find more about how to work with [mike](https://github.com/jimporter/mike).
 The `automatic-docs-update.yml` pipeline will update the docs automatically, in case you add the label `refresh-docs` or comment `/refresh-docs` on your PR. In order to trigger this pipeline again you have to re-add `refresh-docs` label or once again comment `/refresh-docs` in your PR.
 
 > [!NOTE]  
-> `/refresh-docs` comment trigger automatic update only when the `automatic-docs-update.yml` file is in the default branch.
+> `/refresh-docs` comment triggers automatic update only when the `automatic-docs-update.yml` file is in the default branch.


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1248

You can trigger an automatic update of the latest docs version by adding a `refresh-docs` label or commenting `/refresh-docs` in the PR. In case you want to re-trigger the pipeline you have to re-add the `refresh-docs` label or comment `refresh-docs` once again.