### PR TITLE
Fix MountVolume.SetUp errors by updating multipath configuration

### DIFF
--- a/services/ansibler/server/ansible-playbooks/longhorn-req.yml
+++ b/services/ansibler/server/ansible-playbooks/longhorn-req.yml
@@ -21,3 +21,17 @@
         name: nfs-common
         state: present
         update_cache: true
+
+    - name: Update /etc/multipath.conf with blacklist configuration
+      blockinfile:
+        path: /etc/multipath.conf
+        block: |
+          blacklist {
+              devnode "^sd[a-z0-9]+"
+          }
+        create: yes
+
+    - name: Restart multipathd.service
+      ansible.builtin.systemd:
+        name: multipathd.service
+        state: restarted


### PR DESCRIPTION
Related to #1383
Fixes to #1383

Updates the `longhorn-req.yml` playbook to include multipath configuration for Longhorn support.

- **Configures `/etc/multipath.conf`**: Adds a task to insert a blacklist configuration into `/etc/multipath.conf` to prevent MountVolume.SetUp errors, ensuring compatibility with Longhorn.
- **Restarts `multipathd.service`**: Includes a task to restart the `multipathd.service` after updating the multipath configuration, applying the changes immediately.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/berops/claudie/issues/1383?shareId=299e6fe1-8384-4bdf-a6dc-ce8f11c896e0).