### PR TITLE
Fix autoscaling request to update dsChecksum

### DIFF
--- a/services/context-box/server/domain/usecases/update_nodepool.go
+++ b/services/context-box/server/domain/usecases/update_nodepool.go
@@ -38,6 +38,8 @@ func (u *Usecases) UpdateNodepool(request *pb.UpdateNodepoolRequest) (*pb.Update
 			if err := updateNodepool(config.CurrentState, request.ClusterName, request.Nodepool.Name, request.Nodepool.Nodes, nil); err != nil {
 				return nil, fmt.Errorf("error while updating current state in project %s : %w", config.Name, err)
 			}
+			// Calculate and update dsChecksum to reflect the changes in desired state
+			config.DsChecksum = utils.CalculateChecksum(config)
 			// Save new config in the database with dummy CsChecksum to initiate a build.
 			config.CsChecksum = utils.CalculateChecksum(internalUtils.CreateHash(8))
 			if err := u.DB.SaveConfig(config); err != nil {


### PR DESCRIPTION
Fixes #1340

Updates the `updateNodepool` function in `services/context-box/server/domain/usecases/update_nodepool.go` to correctly update the `dsChecksum` alongside the `desiredState` during autoscaling requests.

- Adds logic to calculate and update `dsChecksum` after updating the nodepool, ensuring the autoscaler functions as expected by triggering builds when the `desiredState` changes.
- Utilizes the `utils.CalculateChecksum` function to generate the new `dsChecksum` and updates it in the `pb.Config` object before saving to the database.
- Maintains the existing functionality of updating the nodepool count & nodes in both desired and current state, and initiating a build by updating `CsChecksum` with a dummy value.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/berops/claudie/issues/1340?shareId=4054b361-c9b3-4ee8-b47f-ef3d926aebe8).