### PR TITLE
volume timing issue

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -74,4 +74,4 @@ images:
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 203e8a5-2794
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 203e8a5-2794
+  newTag: e7e6bfa-2795

--- a/services/terraformer/templates/genesiscloud/node.tpl
+++ b/services/terraformer/templates/genesiscloud/node.tpl
@@ -67,6 +67,7 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyA
 mkdir -p /opt/claudie/data
     {{- if not $nodepool.IsControl }}
      {{- if gt $nodepool.NodePool.StorageDiskSize 0 }}
+     sleep 30
 # The IDs listed by `/dev/disk/by-id` are different then the volume ids assigned by genesis cloud.
 # This is a hacky way assuming that only the longhorn volume will be mounted at startup and no other volume
 longhorn_diskuuid=$(blkid | grep genesis_cloud | grep -oP 'UUID="\K[^"]+')


### PR DESCRIPTION
without a timeout the volume will not be reconfigured correctly.

This will trigger a backwards incompatible change to genesis cloud instances