### PR TITLE
context-box healthcheck

### DIFF
--- a/manifests/claudie/context-box.yaml
+++ b/manifests/claudie/context-box.yaml
@@ -66,12 +66,6 @@ spec:
               service: context-box-readiness
             initialDelaySeconds: 5
             periodSeconds: 30
-          livenessProbe:
-            grpc:
-              port: 50055
-              service: context-box-liveness
-            initialDelaySeconds: 5
-            periodSeconds: 30
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -66,7 +66,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 43f201d-2805
 - name: ghcr.io/berops/claudie/context-box
-  newTag: 43f201d-2805
+  newTag: ab6f6da-2807
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 43f201d-2805
 - name: ghcr.io/berops/claudie/kuber
@@ -74,4 +74,4 @@ images:
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 43f201d-2805
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 43f201d-2805
+  newTag: ab6f6da-2807

--- a/services/context-box/server/adapters/inbound/grpc/adapter.go
+++ b/services/context-box/server/adapters/inbound/grpc/adapter.go
@@ -20,7 +20,7 @@ const (
 type GrpcAdapter struct {
 	tcpListener       net.Listener
 	server            *grpc.Server
-	healthCheckServer *health.Server
+	HealthCheckServer *health.Server
 }
 
 // Init will create the underlying gRPC server and the gRPC healthcheck server
@@ -40,11 +40,10 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOptio
 	pb.RegisterContextBoxServiceServer(g.server, &ContextBoxGrpcService{usecases: usecases})
 
 	// Add health-check service to gRPC
-	g.healthCheckServer = health.NewServer()
+	g.HealthCheckServer = health.NewServer()
 	// Context-box does not have any custom health check functions, thus always serving.
-	g.healthCheckServer.SetServingStatus("context-box-liveness", grpc_health_v1.HealthCheckResponse_SERVING)
-	g.healthCheckServer.SetServingStatus("context-box-readiness", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(g.server, g.healthCheckServer)
+	g.HealthCheckServer.SetServingStatus("context-box-readiness", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(g.server, g.HealthCheckServer)
 }
 
 // Serve will create a service goroutine for each connection
@@ -60,5 +59,5 @@ func (g *GrpcAdapter) Serve() error {
 // Stop will gracefully shutdown the gRPC server and the healthcheck server
 func (g *GrpcAdapter) Stop() {
 	g.server.GracefulStop()
-	g.healthCheckServer.Shutdown()
+	g.HealthCheckServer.Shutdown()
 }

--- a/services/context-box/server/adapters/outbound/mongodb_connector.go
+++ b/services/context-box/server/adapters/outbound/mongodb_connector.go
@@ -22,7 +22,7 @@ const (
 	databaseName   = "claudie"
 	collectionName = "inputManifests"
 
-	maxConnectionRetriesCount = 20
+	maxConnectionRetriesCount = 30
 	pingTimeout               = 5 * time.Second
 	pingRetrialDelay          = 5 * time.Second
 )
@@ -69,9 +69,7 @@ func NewMongoDBConnector(connectionUri string) *MongoDBConnector {
 func (m *MongoDBConnector) Connect() error {
 	// Establish DB connection, this does not do any deployment checks/IO on the DB
 	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(m.connectionUri))
-
 	censoredUri := utils.SanitiseURI(m.connectionUri)
-
 	if err != nil {
 		return fmt.Errorf("failed to create a mongoDB client with connection uri %s: %w", censoredUri, err)
 	}
@@ -105,6 +103,13 @@ func pingDB(client *mongo.Client) error {
 	}
 
 	return nil
+}
+
+func (m *MongoDBConnector) HealthCheck() error {
+	if m.client == nil {
+		return fmt.Errorf("unintialized client")
+	}
+	return pingDB(m.client)
 }
 
 // Init performs the initialization tasks after connection is established with MongoDB

--- a/services/terraformer/server/adapters/inbound/grpc/adapter.go
+++ b/services/terraformer/server/adapters/inbound/grpc/adapter.go
@@ -43,8 +43,6 @@ func (g *GrpcAdapter) Init(usecases *usecases.Usecases, opts ...grpc.ServerOptio
 
 	// Add health service to gRPC
 	g.HealthServer = health.NewServer()
-	// Set liveness to SERVING
-	g.HealthServer.SetServingStatus("terraformer-liveness", grpc_health_v1.HealthCheckResponse_SERVING)
 	// Set readiness to NOT_SERVING, as it will be changed later.
 	g.HealthServer.SetServingStatus("terraformer-readiness", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	grpc_health_v1.RegisterHealthServer(g.server, g.HealthServer)

--- a/services/terraformer/server/adapters/outbound/s3_adapter.go
+++ b/services/terraformer/server/adapters/outbound/s3_adapter.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/rs/zerolog/log"
-
 	"github.com/berops/claudie/internal/envs"
 )
 
@@ -88,7 +86,7 @@ func (s *S3Adapter) Healthcheck() error {
 	})
 
 	if err != nil {
-		log.Fatal().Msgf("Error creating healthcheck client for AWS S3: %v", err)
+		return fmt.Errorf("error creating healthcheck client for AWS S3: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
closes #1325 

Context-box will continue to restart if MongoDB is not deployed. As Context-box depends solely on mongoDB without which it cannot start.  The current state where contextbox restarts if mongodb is not deployed is okay I think, we can revisit this in the future, but currently without major changes to the context-box service I don't think it's a good idea.

However, I've added more time to check for MongoDB readiness before restarting the service and also added a healthcheck in case the MongoDB pod got terminated (which will not issue a restart of the context-box, the restart only happens when it is first deployed as a new pod) 