### PR TITLE
Chore/support ubuntu 24.04 in Azure and hetzner

### DIFF
--- a/manifests/claudie/ansibler.yaml
+++ b/manifests/claudie/ansibler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 1320
       securityContext:
-        runAsUser: 1000
+        runAsUser: 65534
         runAsGroup: 3000
         fsGroup: 2000
       volumes:

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,7 +58,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 43f201d-2805
+  newTag: d857d14-2811
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 688726a-1932
 - name: ghcr.io/berops/claudie/builder
@@ -74,4 +74,4 @@ images:
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 43f201d-2805
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 1786803-2810
+  newTag: d857d14-2811

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -150,7 +150,7 @@ spec:
           zone: "1"
         count: 2
         serverType: Standard_B2s
-        image: Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts:22.04.202212120
+        image: Canonical:ubuntu-24_04-lts:server:latest
         taints:
           - key: test
             value: test
@@ -167,7 +167,7 @@ spec:
           zone: "1"
         count: 2
         serverType: Standard_B2s
-        image: Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts:22.04.202212120
+        image: Canonical:ubuntu-24_04-lts:server:latest
         storageDiskSize: 50
         labels:
           test-set: test-set1

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -48,7 +48,7 @@ spec:
           zone: nbg1-dc3
         count: 1
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         labels:
           test-set: test-set1
         annotations:
@@ -61,7 +61,7 @@ spec:
           zone: nbg1-dc3
         count: 1
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         storageDiskSize: 50
         labels:
           test-set: test-set1

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -149,7 +149,7 @@ spec:
           zone: "1"
         count: 2
         serverType: Standard_B2s
-        image: Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts:22.04.202212120
+        image: Canonical:ubuntu-24_04-lts:server:latest
         taints:
           - key: test-new
             value: test
@@ -166,7 +166,7 @@ spec:
           zone: "1"
         count: 3
         serverType: Standard_B2s
-        image: Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts:22.04.202212120
+        image: Canonical:ubuntu-24_04-lts:server:latest
         storageDiskSize: 50
         labels:
           test-set: test-set1-new

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -48,7 +48,7 @@ spec:
           zone: nbg1-dc3
         count: 2
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         labels:
           test-set: test-set1-new
         annotations:
@@ -61,7 +61,7 @@ spec:
           zone: nbg1-dc3
         count: 1
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         storageDiskSize: 50
         labels:
           test-set: test-set1-new

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -76,7 +76,7 @@ spec:
           zone: fsn1-dc14
         count: 1
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         storageDiskSize: 50
 
       - name: oci-ldbl-nodes

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -76,7 +76,7 @@ spec:
           zone: fsn1-dc14
         count: 2
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         storageDiskSize: 50
 
       - name: oci-ldbl-nodes

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -76,7 +76,7 @@ spec:
           zone: fsn1-dc14
         count: 1
         serverType: cpx11
-        image: ubuntu-22.04
+        image: ubuntu-24.04
         storageDiskSize: 50
 
       - name: oci-ldbl-nodes

--- a/services/ansibler/Dockerfile
+++ b/services/ansibler/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux \
 
 RUN set -eux \
 	# ansible 9.6.0 includes ansible-core 2.16.7 and ansible-community 9.6.0
-	pip3 install --no-cache-dir --no-binary pyyaml ansible~=9.0 \
+	&& pip3 install --no-cache-dir --no-binary pyyaml ansible~=9.0 \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 

--- a/services/ansibler/Dockerfile
+++ b/services/ansibler/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux \
 
 RUN set -eux \
 	# ansible 9.6.0 includes ansible-core 2.16.7 and ansible-community 9.6.0
-	&& pip3 install --no-cache-dir --no-binary pyyaml ansible~=9.0 \
+	&& pip3 install --no-cache-dir --no-binary pyyaml ansible==9.6.0 \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
@@ -97,6 +97,7 @@ RUN set -eux \
 	libgcc \
 	py3-pip \
 	python3 \
+	openssh-client \
 	# Issue: #76 yaml required for 'libyaml = True' (faster startup time)
 	yaml \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \

--- a/services/ansibler/Dockerfile
+++ b/services/ansibler/Dockerfile
@@ -20,14 +20,96 @@ WORKDIR /go/services/ansibler/server
 #Compile the golang code, CGO_ENABLE=0 removes cross compile dependencies
 RUN CGO_ENABLED=0 go build
 
-#Use alpine based ansible image
-FROM docker.io/cytopia/ansible:2.13-0.50
+# Ansible installation: https://github.com/cytopia/docker-ansible/blob/master/Dockerfiles/Dockerfile-base
+FROM docker.io/library/alpine:3.16 AS builder
+
+RUN set -eux \
+	&& apk add --update --no-cache \
+		# build tools
+		coreutils \
+		g++ \
+		gcc \
+		make \
+		musl-dev \
+		openssl-dev \
+		python3-dev \
+		# misc tools
+		bc \
+		libffi-dev \
+		libxml2-dev \
+		libxslt-dev \
+		py3-pip \
+		python3 \
+# Fix: ansible --version: libyaml = True
+# https://www.jeffgeerling.com/blog/2021/ansible-might-be-running-slow-if-libyaml-not-available
+	&& apk add --update --no-cache \
+		py3-yaml \
+	&& python3 -c 'import _yaml'
+
+# Pip required tools
+RUN set -eux \
+	&& pip3 install --no-cache-dir --no-compile \
+		wheel
+RUN set -eux \
+	&& pip3 install --no-cache-dir --no-compile \
+		Jinja2 \
+		MarkupSafe \
+		PyNaCl \
+		bcrypt \
+		cffi \
+		cryptography \
+		pycparser
+
+RUN set -eux \
+	# ansible 9.6.0 includes ansible-core 2.16.7 and ansible-community 9.6.0
+	pip3 install --no-cache-dir --no-binary pyyaml ansible~=9.0 \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
+# Python packages (copied to final image)
+RUN set -eux \
+	&& pip3 install --no-cache-dir --no-compile \
+		junit-xml \
+		lxml \
+		paramiko \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
+# Clean-up some site-packages to safe space
+RUN set -eux \
+	&& pip3 uninstall --yes \
+		setuptools \
+		wheel \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
+FROM alpine:3.16
 #Add repository label
 LABEL org.opencontainers.image.source "https://github.com/berops/claudie"
 #Add image name as a label
-LABEL org.opencontainers.image.base.name "docker.io/cytopia/ansible:2.13-0.50"
+LABEL org.opencontainers.image.base.name "alpine:3.16"
 #Add description to the image
 LABEL org.opencontainers.image.description "Image for Ansibler from Claudie"
+
+RUN set -eux \
+	&& apk add --no-cache \
+# Issue: #85 libgcc required for ansible-vault
+		libgcc \
+		py3-pip \
+		python3 \
+# Issue: #76 yaml required for 'libyaml = True' (faster startup time)
+		yaml \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf \
+	\
+	&& ln -s /usr/bin/python3 /usr/bin/python
+
+COPY --from=builder /usr/lib/python3.10/site-packages/ /usr/lib/python3.10/site-packages/
+COPY --from=builder /usr/bin/ansible* /usr/bin/
+
+# Pre-compile Python for better performance
+RUN set -eux \
+	&& python3 -m compileall -j 0 /usr/lib/python3.10
 
 #Copy the binaries to empty base image
 COPY --from=build /go/services/ansibler/server/server /bin/services/ansibler/server/server

--- a/services/ansibler/Dockerfile
+++ b/services/ansibler/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.2 AS build
+FROM docker.io/library/golang:1.22.2 AS go_builder
 
 ARG TARGETARCH
 
@@ -21,44 +21,44 @@ WORKDIR /go/services/ansibler/server
 RUN CGO_ENABLED=0 go build
 
 # Ansible installation: https://github.com/cytopia/docker-ansible/blob/master/Dockerfiles/Dockerfile-base
-FROM docker.io/library/alpine:3.16 AS builder
+FROM docker.io/library/alpine:3.16 AS ansible_builder
 
 RUN set -eux \
 	&& apk add --update --no-cache \
-		# build tools
-		coreutils \
-		g++ \
-		gcc \
-		make \
-		musl-dev \
-		openssl-dev \
-		python3-dev \
-		# misc tools
-		bc \
-		libffi-dev \
-		libxml2-dev \
-		libxslt-dev \
-		py3-pip \
-		python3 \
-# Fix: ansible --version: libyaml = True
-# https://www.jeffgeerling.com/blog/2021/ansible-might-be-running-slow-if-libyaml-not-available
+	# build tools
+	coreutils \
+	g++ \
+	gcc \
+	make \
+	musl-dev \
+	openssl-dev \
+	python3-dev \
+	# misc tools
+	bc \
+	libffi-dev \
+	libxml2-dev \
+	libxslt-dev \
+	py3-pip \
+	python3 \
+	# Fix: ansible --version: libyaml = True
+	# https://www.jeffgeerling.com/blog/2021/ansible-might-be-running-slow-if-libyaml-not-available
 	&& apk add --update --no-cache \
-		py3-yaml \
+	py3-yaml \
 	&& python3 -c 'import _yaml'
 
 # Pip required tools
 RUN set -eux \
 	&& pip3 install --no-cache-dir --no-compile \
-		wheel
+	wheel
 RUN set -eux \
 	&& pip3 install --no-cache-dir --no-compile \
-		Jinja2 \
-		MarkupSafe \
-		PyNaCl \
-		bcrypt \
-		cffi \
-		cryptography \
-		pycparser
+	Jinja2 \
+	MarkupSafe \
+	PyNaCl \
+	bcrypt \
+	cffi \
+	cryptography \
+	pycparser
 
 RUN set -eux \
 	# ansible 9.6.0 includes ansible-core 2.16.7 and ansible-community 9.6.0
@@ -69,17 +69,17 @@ RUN set -eux \
 # Python packages (copied to final image)
 RUN set -eux \
 	&& pip3 install --no-cache-dir --no-compile \
-		junit-xml \
-		lxml \
-		paramiko \
+	junit-xml \
+	lxml \
+	paramiko \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 # Clean-up some site-packages to safe space
 RUN set -eux \
 	&& pip3 uninstall --yes \
-		setuptools \
-		wheel \
+	setuptools \
+	wheel \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
@@ -93,27 +93,27 @@ LABEL org.opencontainers.image.description "Image for Ansibler from Claudie"
 
 RUN set -eux \
 	&& apk add --no-cache \
-# Issue: #85 libgcc required for ansible-vault
-		libgcc \
-		py3-pip \
-		python3 \
-# Issue: #76 yaml required for 'libyaml = True' (faster startup time)
-		yaml \
+	# Issue: #85 libgcc required for ansible-vault
+	libgcc \
+	py3-pip \
+	python3 \
+	# Issue: #76 yaml required for 'libyaml = True' (faster startup time)
+	yaml \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf \
 	\
 	&& ln -s /usr/bin/python3 /usr/bin/python
 
-COPY --from=builder /usr/lib/python3.10/site-packages/ /usr/lib/python3.10/site-packages/
-COPY --from=builder /usr/bin/ansible* /usr/bin/
+COPY --from=ansible_builder /usr/lib/python3.10/site-packages/ /usr/lib/python3.10/site-packages/
+COPY --from=ansible_builder /usr/bin/ansible* /usr/bin/
 
 # Pre-compile Python for better performance
 RUN set -eux \
 	&& python3 -m compileall -j 0 /usr/lib/python3.10
 
 #Copy the binaries to empty base image
-COPY --from=build /go/services/ansibler/server/server /bin/services/ansibler/server/server
-COPY --from=build /go/services/ansibler/server/ansible-playbooks /bin/services/ansibler/server/ansible-playbooks
+COPY --from=go_builder /go/services/ansibler/server/server /bin/services/ansibler/server/server
+COPY --from=go_builder /go/services/ansibler/server/ansible-playbooks /bin/services/ansibler/server/ansible-playbooks
 
 RUN apk update && apk add -q bash
 

--- a/services/ansibler/server/ansible-playbooks/wireguard/tasks/configure.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard/tasks/configure.yml
@@ -48,6 +48,12 @@
 - name: Set MTU size for wg0
   ansible.builtin.shell: ifconfig {{ wg_interface_name }} mtu {{ mtu_size }}
 
+- name: Ensure file /etc/dhcp/dhclient.conf exists
+  ansible.builtin.copy:
+    content: ""
+    dest: /etc/dhcp/dhclient.conf
+    force: false
+
 - name: Make MTU change persistent across reboots
   ansible.builtin.blockinfile:
     path: /etc/dhcp/dhclient.conf

--- a/services/ansibler/server/ansible-playbooks/wireguard/tasks/install.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard/tasks/install.yml
@@ -3,7 +3,7 @@
   ansible.builtin.apt:
     pkg:
       - wireguard
-      - python3-pip
+      - pipx
       - net-tools
     state: present
     update_cache: true
@@ -12,7 +12,7 @@
   register: res
   until: res is not failed
 
-- name: Install wireguard via pip
-  ansible.builtin.pip:
+- name: Install wireguard via pipx
+  community.general.pipx:
     name: wireguard
 ...

--- a/services/ansibler/server/ansible-playbooks/wireguard/tasks/kill_unattended_upgrades.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard/tasks/kill_unattended_upgrades.yml
@@ -16,10 +16,6 @@
     enabled: false
   when: |
     unattended_upgrades_service_exists is not failed
-    and
-    ansible_distribution == 'Ubuntu'
-    and
-    ansible_distribution_version == '22.04'
 
 - name: "Make sure unattended upgrades package is not installed"
   ansible.builtin.apt:
@@ -28,8 +24,4 @@
     purge: true
     update_cache: true
     force_apt_get: true
-  when: |
-    ansible_distribution == 'Ubuntu'
-    and
-    ansible_distribution_version == '22.04'
 ...

--- a/services/ansibler/templates/nginx.goyml
+++ b/services/ansibler/templates/nginx.goyml
@@ -8,6 +8,11 @@
         name: nginx
         state: latest
         update_cache: yes
+    - name: install stream module for nginx
+      ansible.builtin.apt:
+        name: libnginx-mod-stream 
+        state: present
+        update_cache: true
     - name: copy config files
       copy:
         src: lb.conf


### PR DESCRIPTION
This PR adds support for Ubuntu 24.04 in Azure and Hetzner.

Support for Ubuntu 24.04 in GCP, OCI, AWS, and Genesis Cloud hasn't been implemented yet, because new changes in their TF files will trigger instances re-creation after the user upgrades the Claudie version. On top of that re-creation of AWS instances breaks an entire cluster, because Claudie won't be able to connect to these AWS instances using SSH to Install VPN.

For now, we decided to avoid another breaking change and started searching for a new way to add changes in TF files to avoid re-creations of the VM instances.