### PR TITLE
mention Claudie's Slack channel in the docs.claudie.io homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,5 @@ See more in How Claudie works sections.
 ## What to do next
 
 In case you are not sure where to go next, you can just simply start with our [Getting Started Guide](./getting-started/get-started-using-claudie.md) or read our documentation [sitemap](./sitemap/sitemap.md).
+
+If you need help or want to have a chat with us, feel free to join our channel on [kubernetes Slack workspace](https://kubernetes.slack.com/archives/C05SW4GKPL3) (get invite [here](https://communityinviter.com/apps/kubernetes/community)).


### PR DESCRIPTION
The only mention of our Slack channel used to be in README.md. This PR introduces our Slack channel in the homepage of [docs.claudie.io](docs.claudie.io) also