### PR TITLE
Add version matrix to the docs

### DIFF
--- a/docs/CHANGELOG/changelog-0.7.x.md
+++ b/docs/CHANGELOG/changelog-0.7.x.md
@@ -58,8 +58,8 @@ Kubernetes version 1.24 is no longer supported.
 1.25.x 1.26.x 1.27.x are the currently supported versions.
 
 ## Bugfixes
-* Static Loadbalancer metadata secret https://github.com/berops/claudie/pull/1249
-* Update healthcheck endpoints https://github.com/berops/claudie/pull/1245
+* Static Loadbalancer metadata secret [#1249](https://github.com/berops/claudie/pull/1249)
+* Update healthcheck endpoints [#1245](https://github.com/berops/claudie/pull/1245)
 
 ## v0.7.2
 ### Features

--- a/docs/CHANGELOG/changelog-0.7.x.md
+++ b/docs/CHANGELOG/changelog-0.7.x.md
@@ -52,7 +52,7 @@ Before upgrading Claudie, upgrade Longhorn to 1.6.x as per [this guide](https://
 ## v0.7.1
 
 Migrate from the legacy package repositories `apt.kubernetes.io, yum.kubernetes.io` to the Kubernetes community-hosted repositories `pkgs.k8s.io`.
-A detailed how to can be found in https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/
+A detailed how to can be found in [https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/)
 
 Kubernetes version 1.24 is no longer supported.
 1.25.x 1.26.x 1.27.x are the currently supported versions.

--- a/docs/CHANGELOG/changelog-0.8.x.md
+++ b/docs/CHANGELOG/changelog-0.8.x.md
@@ -1,6 +1,6 @@
 # Claudie `v0.8`
 
-!!! warning "Due to updating terraform files the `v0.8.x` clusters build with claudie version `v0.7.x` will be forced to be recreated. 
+!!! warning "Due to updating terraform files the `v0.8.x` clusters build with claudie version `v0.7.x` will be forced to be recreated."
 
 Nodepool/cluster names that do not meet the required length of 14 characters for nodepool names and 28 characters for cluster names must be adjusted or the new length validation will fail. You can achieve a rolling update by adding new nodepools with the new names and then removing the old nodepools before updating to version 0.8. 
 

--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -367,7 +367,7 @@ Collection of data used to define a Kubernetes cluster.
 
   Kubernetes version of the cluster.
 
-  Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.5`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.5/architecture/compatibility/supported-versions/#supported-kubernetes-versions).
+  Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.8`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.8/architecture/compatibility/supported-versions/#supported-kubernetes-versions).
 
 - `network`
 

--- a/docs/sitemap/sitemap.md
+++ b/docs/sitemap/sitemap.md
@@ -78,3 +78,7 @@ Claudie doesn't deploy Node-Local-DNS in the default mode, thus you have to inst
 ## Command Cheat Sheet
 
 The "Command Cheat Sheet" section contains a useful `kubectl` commands to interact with Claudie.
+
+## Version matrix
+
+In this section, you can find supported Kubernetes and OS versions for the latest Claudie versions.

--- a/docs/sitemap/sitemap.md
+++ b/docs/sitemap/sitemap.md
@@ -71,6 +71,10 @@ In this section we walk you through the setup of Claudie's Prometheus metrics to
 
 This section describes how to execute updates, such as OS or kubernetes version, in Claudie.
 
+## Deploying Node-Local-DNS
+
+Claudie doesn't deploy Node-Local-DNS in the default mode, thus you have to install it independently. This section provides a step-by-step guide on how to do it.
+
 ## Command Cheat Sheet
 
 The "Command Cheat Sheet" section contains a useful `kubectl` commands to interact with Claudie.

--- a/docs/sitemap/sitemap.md
+++ b/docs/sitemap/sitemap.md
@@ -71,6 +71,6 @@ In this section we walk you through the setup of Claudie's Prometheus metrics to
 
 This section describes how to execute updates, such as OS or kubernetes version, in Claudie.
 
-# Command Cheat Sheet
+## Command Cheat Sheet
 
 The "Command Cheat Sheet" section contains a useful `kubectl` commands to interact with Claudie.

--- a/docs/version-matrix/version-matrix.md
+++ b/docs/version-matrix/version-matrix.md
@@ -1,0 +1,11 @@
+# Version matrix
+
+In the following table, you can find the supported Kubernetes and OS versions for the latest Claudie versions.
+
+| Claudie Version | Kubernetes versions | OS versions |
+| --------------- | ------------------- | ----------- |
+| v0.6.x | 1.24.x, 1.25.x, 1.26.x | Ubuntu 22.04 |
+| v0.7.0 | 1.24.x, 1.25.x, 1.26.x | Ubuntu 22.04 |
+| v0.7.1-x | 1.25.x, 1.26.x, 1.27.x | Ubuntu 22.04 |
+| v0.8.0 | 1.25.x, 1.26.x, 1.27.x | Ubuntu 22.04 |
+| v0.8.1 | 1.27.x, 1.28.x, 1.29.x | Ubuntu 22.04 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
   - Updating Claudie: update/update.md
   - Deploying Node-Local-DNS: node-local-dns/node-local-dns.md
   - Command Cheat Sheet: commands/commands.md
+  - Version Matrix: version-matrix/version-matrix.md
 
 extra:
   version:


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1419

adds version matrix of the supported Kubernetes and OS versions for the latest Claudie versions in the docs.