### PR TITLE
Fix: Deletion process in case of failure of spawning infra before acquiring lock

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -74,4 +74,4 @@ images:
 - name: ghcr.io/berops/claudie/scheduler
   newTag: 64a899c-2860
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 64a899c-2860
+  newTag: e683e59-2891

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -74,4 +74,4 @@ images:
 - name: ghcr.io/berops/claudie/scheduler
   newTag: a1636e2-2892
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: a1636e2-2892
+  newTag: 915fee3-2905

--- a/services/terraformer/server/adapters/outbound/s3_adapter.go
+++ b/services/terraformer/server/adapters/outbound/s3_adapter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/smithy-go"
 	"github.com/berops/claudie/internal/envs"
 )
 
@@ -106,12 +105,9 @@ func (s *S3Adapter) Stat(ctx context.Context, projectName, clusterId, keyFormat 
 		Key:    &key,
 	})
 	if err != nil {
-		var apiError smithy.APIError
-		if errors.As(err, &apiError) {
-			var notFound *types.NotFound
-			if errors.As(apiError, &notFound) {
-				return ErrKeyNotExists
-			}
+		var notFound *types.NotFound
+		if errors.As(err, &notFound) {
+			return ErrKeyNotExists
 		}
 		return fmt.Errorf("failed to check existence of object %s: %w", key, err)
 	}

--- a/services/terraformer/server/adapters/outbound/s3_adapter.go
+++ b/services/terraformer/server/adapters/outbound/s3_adapter.go
@@ -2,9 +2,12 @@ package outboundAdapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/berops/claudie/internal/envs"
 )
 
@@ -103,6 +106,13 @@ func (s *S3Adapter) Stat(ctx context.Context, projectName, clusterId, keyFormat 
 		Key:    &key,
 	})
 	if err != nil {
+		var apiError smithy.APIError
+		if errors.As(err, &apiError) {
+			var notFound *types.NotFound
+			if errors.As(apiError, &notFound) {
+				return ErrKeyNotExists
+			}
+		}
 		return fmt.Errorf("failed to check existence of object %s: %w", key, err)
 	}
 	return nil

--- a/services/terraformer/server/domain/usecases/destroy_infrastructure.go
+++ b/services/terraformer/server/domain/usecases/destroy_infrastructure.go
@@ -66,10 +66,10 @@ func (u *Usecases) DestroyInfrastructure(ctx context.Context, request *pb.Destro
 		// After the infrastructure is destroyed, we need to delete the Terraform state file from MinIO
 		// and Terraform state-lock file from DynamoDB.
 		if err := u.DynamoDB.DeleteLockFile(ctx, request.ProjectName, cluster.Id(), keyFormatLockFile); err != nil {
-			logger.Warn().Msgf("Failedd to delete lock file for %q, assumming it was deleted/not created", cluster.Id())
+			logger.Warn().Msgf("Failed to delete lock file for %q, assumming it was deleted/not created", cluster.Id())
 		}
 		if err := u.StateStorage.DeleteStateFile(ctx, request.ProjectName, cluster.Id(), keyFormatStateFile); err != nil {
-			logger.Warn().Msgf("Failedd to delete state file for %q, assumming it was deleted/not created", cluster.Id())
+			logger.Warn().Msgf("Failed to delete state file for %q, assumming it was deleted/not created", cluster.Id())
 		}
 		logger.Info().Msg("Successfully deleted Terraform state and state-lock files")
 
@@ -77,10 +77,10 @@ func (u *Usecases) DestroyInfrastructure(ctx context.Context, request *pb.Destro
 		// there are additional DNS related Terraform state and state-lock files.
 		if _, ok := cluster.(*loadbalancer.LBcluster); ok {
 			if err := u.DynamoDB.DeleteLockFile(ctx, request.ProjectName, cluster.Id(), dnsKeyFormatLockFile); err != nil {
-				logger.Warn().Msgf("Failedd to delete lock file for %q-dns, assumming it was deleted/not created", cluster.Id())
+				logger.Warn().Msgf("Failed to delete lock file for %q-dns, assumming it was deleted/not created", cluster.Id())
 			}
 			if err := u.StateStorage.DeleteStateFile(ctx, request.ProjectName, cluster.Id(), dnsKeyFormatStateFile); err != nil {
-				logger.Warn().Msgf("Failedd to delete state file for %q-dns, assumming it was deleted/not created", cluster.Id())
+				logger.Warn().Msgf("Failed to delete state file for %q-dns, assumming it was deleted/not created", cluster.Id())
 			}
 			logger.Info().Msg("Successfully deleted DNS related Terraform state and state-lock files")
 		}

--- a/services/terraformer/server/domain/usecases/destroy_infrastructure.go
+++ b/services/terraformer/server/domain/usecases/destroy_infrastructure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb"
 	outboundAdapters "github.com/berops/claudie/services/terraformer/server/adapters/outbound"
@@ -67,10 +66,10 @@ func (u *Usecases) DestroyInfrastructure(ctx context.Context, request *pb.Destro
 		// After the infrastructure is destroyed, we need to delete the Terraform state file from MinIO
 		// and Terraform state-lock file from DynamoDB.
 		if err := u.DynamoDB.DeleteLockFile(ctx, request.ProjectName, cluster.Id(), keyFormatLockFile); err != nil {
-			return err
+			logger.Warn().Msgf("Failedd to delete lock file for %q, assumming it was deleted/not created", cluster.Id())
 		}
 		if err := u.StateStorage.DeleteStateFile(ctx, request.ProjectName, cluster.Id(), keyFormatStateFile); err != nil {
-			return err
+			logger.Warn().Msgf("Failedd to delete state file for %q, assumming it was deleted/not created", cluster.Id())
 		}
 		logger.Info().Msg("Successfully deleted Terraform state and state-lock files")
 
@@ -78,10 +77,10 @@ func (u *Usecases) DestroyInfrastructure(ctx context.Context, request *pb.Destro
 		// there are additional DNS related Terraform state and state-lock files.
 		if _, ok := cluster.(*loadbalancer.LBcluster); ok {
 			if err := u.DynamoDB.DeleteLockFile(ctx, request.ProjectName, cluster.Id(), dnsKeyFormatLockFile); err != nil {
-				return err
+				logger.Warn().Msgf("Failedd to delete lock file for %q-dns, assumming it was deleted/not created", cluster.Id())
 			}
 			if err := u.StateStorage.DeleteStateFile(ctx, request.ProjectName, cluster.Id(), dnsKeyFormatStateFile); err != nil {
-				return err
+				logger.Warn().Msgf("Failedd to delete state file for %q-dns, assumming it was deleted/not created", cluster.Id())
 			}
 			logger.Info().Msg("Successfully deleted DNS related Terraform state and state-lock files")
 		}


### PR DESCRIPTION
Closes: https://github.com/berops/claudie/issues/1462

On deletion If we don't find the respective statefiles, locks it assumes that they were not created or were deleted and simply log a WARN message about this state.

Further, fixes a bug where the `ErrKeyNotExists` was not correctly returned when the Object was missing from the external storage.