### PR TITLE
use az sponsorship subscription in e2e

### DIFF
--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -44,21 +44,21 @@ spec:
       secretRef:
         name: aws-secret
         namespace: e2e-secrets
-    - name: azure-1
+    - name: azure-sponsor-1
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
         path: "templates/terraformer/azure"
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
-    - name: azure-2
+    - name: azure-sponsor-2
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
         path: "templates/terraformer/azure"
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
   nodePools:
     dynamic:
@@ -166,7 +166,7 @@ spec:
 
       - name: azr-ctrl-nodes
         providerSpec:
-          name: azure-2
+          name: azure-sponsor-2
           region: West Europe
           zone: "1"
         count: 2
@@ -183,7 +183,7 @@ spec:
             ["test-set1"]        
       - name: azr-cmpt-nodes
         providerSpec:
-          name: azure-1
+          name: azure-sponsor-1
           region: Germany West Central
           zone: "1"
         count: 2

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -167,7 +167,7 @@ spec:
       - name: azr-ctrl-nodes
         providerSpec:
           name: azure-sponsor-2
-          region: West Europe
+          region: Germany West Central
           zone: "1"
         count: 2
         serverType: Standard_B2s

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -145,7 +145,7 @@ spec:
       - name: azr-ctrl-nodes
         providerSpec:
           name: azure-sponsor-2
-          region: West Europe
+          region: Germany West Central
           zone: "1"
         count: 2
         serverType: Standard_B2s

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -29,15 +29,15 @@ spec:
       secretRef:
         name: aws-secret
         namespace: e2e-secrets
-    - name: azure-1
+    - name: azure-sponsor-1
       providerType: azure
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
-    - name: azure-2
+    - name: azure-sponsor-2
       providerType: azure
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
   nodePools:
     dynamic:
@@ -144,7 +144,7 @@ spec:
 
       - name: azr-ctrl-nodes
         providerSpec:
-          name: azure-2
+          name: azure-sponsor-2
           region: West Europe
           zone: "1"
         count: 2
@@ -161,7 +161,7 @@ spec:
               ["test-set1-new"]
       - name: azr-cmpt-nodes
         providerSpec:
-          name: azure-1
+          name: azure-sponsor-1
           region: Germany West Central
           zone: "1"
         count: 3

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -29,10 +29,10 @@ spec:
       secretRef:
         name: aws-secret
         namespace: e2e-secrets
-    - name: azure-1
+    - name: azure-sponsor-1
       providerType: azure
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
   nodePools:
     dynamic:
@@ -104,7 +104,7 @@ spec:
 
       - name: azr-ldbl-nodes
         providerSpec:
-          name: azure-1
+          name: azure-sponsor-1
           region: West Europe
           zone: "3"
         count: 1

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -105,7 +105,7 @@ spec:
       - name: azr-ldbl-nodes
         providerSpec:
           name: azure-sponsor-1
-          region: West Europe
+          region: Germany West Central
           zone: "3"
         count: 1
         serverType: Standard_B2s

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -110,7 +110,7 @@ spec:
       - name: azr-ldbl-nodes
         providerSpec:
           name: azure-sponsor-1
-          region: West Europe
+          region: Germany West Central
           zone: "3"
         count: 2
         serverType: Standard_B2s

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -29,7 +29,12 @@ spec:
       secretRef:
         name: aws-secret
         namespace: e2e-secrets
-    - name: azure-1
+    - name: azure-sponsor-1
+      providerType: azure
+      secretRef:
+        name: azure-sponsorship-secret
+        namespace: e2e-secrets
+    - name: azure-payed-1
       providerType: azure
       secretRef:
         name: azure-secret
@@ -104,7 +109,7 @@ spec:
 
       - name: azr-ldbl-nodes
         providerSpec:
-          name: azure-1
+          name: azure-sponsor-1
           region: West Europe
           zone: "3"
         count: 2
@@ -150,7 +155,7 @@ spec:
           - apiserver-lb-hetzner
         dns:
           dnsZone: azure.e2e.claudie.io
-          provider: azure-1
+          provider: azure-payed-1
         targetedK8s: ts2-htz-cluster-test-set-no2
         pools:
           - gcp-ldbl-nodes

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -29,10 +29,10 @@ spec:
       secretRef:
         name: aws-secret
         namespace: e2e-secrets
-    - name: azure-1
+    - name: azure-sponsor-1
       providerType: azure
       secretRef:
-        name: azure-secret
+        name: azure-sponsorship-secret
         namespace: e2e-secrets
   nodePools:
     dynamic:
@@ -104,7 +104,7 @@ spec:
 
       - name: azr-ldbl-nodes
         providerSpec:
-          name: azure-1
+          name: azure-sponsor-1
           region: West Europe
           zone: "3"
         count: 2

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -105,7 +105,7 @@ spec:
       - name: azr-ldbl-nodes
         providerSpec:
           name: azure-sponsor-1
-          region: West Europe
+          region: Germany West Central
           zone: "3"
         count: 2
         serverType: Standard_B2s


### PR DESCRIPTION
This PR uses AZ sponsorship subscription in e2e tests for nodepools and Pay-As-You-Go for hostnames.