### PR TITLE
add GCP metadata server IP and hostnames to no proxy envs

### DIFF
--- a/manifests/claudie/.env
+++ b/manifests/claudie/.env
@@ -1,8 +1,8 @@
 GOLANG_LOG=info
 
 # enum: default, on, off. Otherwise default
-HTTP_PROXY_MODE=on
-HTTP_PROXY_URL=http://proxy.claudie.io:2052
+HTTP_PROXY_MODE=default
+HTTP_PROXY_URL=http://proxy.claudie.io:8880
 
 TERRAFORMER_HOSTNAME=terraformer
 TERRAFORMER_PORT=50052

--- a/manifests/claudie/.env
+++ b/manifests/claudie/.env
@@ -1,8 +1,8 @@
 GOLANG_LOG=info
 
 # enum: default, on, off. Otherwise default
-HTTP_PROXY_MODE=default
-HTTP_PROXY_URL=http://proxy.claudie.io:8880
+HTTP_PROXY_MODE=on
+HTTP_PROXY_URL=http://proxy.claudie.io:2052
 
 TERRAFORMER_HOSTNAME=terraformer
 TERRAFORMER_PORT=50052

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 26c600d-2977
+  newTag: 177226a-2978
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 26c600d-2977
+  newTag: 177226a-2978
 - name: ghcr.io/berops/claudie/kuber
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/manager

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e908bac-2979
+  newTag: baa744e-2980
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e908bac-2979
+  newTag: baa744e-2980
 - name: ghcr.io/berops/claudie/kuber
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/manager

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 177226a-2978
+  newTag: e908bac-2979
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 177226a-2978
+  newTag: e908bac-2979
 - name: ghcr.io/berops/claudie/kuber
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/manager

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 4abc255-2969
+  newTag: 26c600d-2977
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 4abc255-2969
+  newTag: 26c600d-2977
 - name: ghcr.io/berops/claudie/kuber
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/manager

--- a/services/ansibler/server/domain/usecases/update_no_proxy_envs.go
+++ b/services/ansibler/server/domain/usecases/update_no_proxy_envs.go
@@ -134,7 +134,8 @@ func createNoProxyList(desiredNodePools []*spec.NodePool, desiredLbs []*spec.LBc
 	}
 
 	// if "svc" isn't in noProxyList the admission webhooks will fail, because they will be routed to proxy
-	noProxyList = fmt.Sprintf("%s,%s,", noProxyList, "svc")
+	// "metadata,metadata.google.internal,169.254.169.254,metadata.google.internal." are required for GCP VMs
+	noProxyList = fmt.Sprintf("%s,svc,metadata,metadata.google.internal,169.254.169.254,metadata.google.internal.,", noProxyList)
 
 	return noProxyList
 }

--- a/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
+++ b/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
@@ -187,7 +187,8 @@ func (k *KubeEleven) generateTemplateData() templateData {
 		}
 		// data.NoProxy has to terminate with the comma
 		// if "svc" isn't in NoProxy the admission webhooks will fail, because they will be routed to proxy
-		data.NoProxy = fmt.Sprintf("%s,svc,", strings.Join(noProxy, ","))
+		// metadata,metadata.google.internal,169.254.169.254,metadata.google.internal. are required for GCP VMs
+		data.NoProxy = fmt.Sprintf("%s,svc,metadata,metadata.google.internal,169.254.169.254,metadata.google.internal.,", strings.Join(noProxy, ","))
 
 		data.HttpProxyUrl = utils.GetEnvDefault("HTTP_PROXY_URL", defaulHttpProxyUrl)
 	}

--- a/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
+++ b/services/kube-eleven/server/domain/utils/kube-eleven/kube_eleven.go
@@ -187,7 +187,7 @@ func (k *KubeEleven) generateTemplateData() templateData {
 		}
 		// data.NoProxy has to terminate with the comma
 		// if "svc" isn't in NoProxy the admission webhooks will fail, because they will be routed to proxy
-		// metadata,metadata.google.internal,169.254.169.254,metadata.google.internal. are required for GCP VMs
+		// "metadata,metadata.google.internal,169.254.169.254,metadata.google.internal." are required for GCP VMs
 		data.NoProxy = fmt.Sprintf("%s,svc,metadata,metadata.google.internal,169.254.169.254,metadata.google.internal.,", strings.Join(noProxy, ","))
 
 		data.HttpProxyUrl = utils.GetEnvDefault("HTTP_PROXY_URL", defaulHttpProxyUrl)


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1514

This supports building K8s clusters with GCP VMs using an HTTP proxy.

When using an HTTP Proxy this `metadata,metadata.google.internal,169.254.169.254,metadata.google.internal.` has to be in the no proxy envs. Otherwise Claudie fails to build the k8s cluster.

This PR also contains an update of `.env` file, cause it should run the e2e tests with proxy mode turned on and using an HTTP proxy that supports access to a limited set of domains. Once the e2e tests finish successfully the changes in the `.env` file will be reverted.
