### PR TITLE
wait until kube-apiserver is healthy after static pods restarts

### DIFF
--- a/manifests/claudie/.env
+++ b/manifests/claudie/.env
@@ -1,8 +1,8 @@
 GOLANG_LOG=info
 
 # enum: default, on, off. Otherwise default
-HTTP_PROXY_MODE=default
-HTTP_PROXY_URL=http://proxy.claudie.io:8880
+HTTP_PROXY_MODE=on
+HTTP_PROXY_URL=http://proxy.claudie.io:2052
 
 TERRAFORMER_HOSTNAME=terraformer
 TERRAFORMER_PORT=50052

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 164b19f-2981
+  newTag: 30e7bb0-2982
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: baa744e-2980
+  newTag: 164b19f-2981
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: f047e95-2985
+  newTag: c4c6405-2986
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 30e7bb0-2982
+  newTag: 66921de-2984
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 66921de-2984
+  newTag: f047e95-2985
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 4abc255-2969
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -38,4 +38,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 4abc255-2969
+  newTag: c4c6405-2986

--- a/services/ansibler/server/ansible-playbooks/update-noproxy-envs.yml
+++ b/services/ansibler/server/ansible-playbooks/update-noproxy-envs.yml
@@ -10,3 +10,16 @@
     - name: Update NO_PROXY and no_proxy in static pods
       ansible.builtin.shell: |
         NO_PROXY="{{ no_proxy }}" no_proxy="{{ no_proxy }}" kubeadm init phase control-plane all --apiserver-advertise-address {{ private_ip }} --apiserver-extra-args profiling=false --patches .
+
+    - name: Try 10 times to check kube-apiserver health
+      ansible.builtin.uri:
+        url: "https://localhost:6443/readyz"
+        method: GET
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      register: api_response
+      retries: 10
+      delay: 10
+      until: api_response.status == 200

--- a/services/testing-framework/test_autoscaler.go
+++ b/services/testing-framework/test_autoscaler.go
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 500Mi`
 	// Time in which Autoscaler should trigger scale up
-	scaleUpTimeout = 180 // 3 mins
+	scaleUpTimeout = 900 // 30 mins
 	// Time in which Autoscaler should trigger scale down
 	scaleDownTimeout = 2400 // 40 mins
 )


### PR DESCRIPTION
closes https://github.com/berops/claudie/issues/1519 https://github.com/berops/claudie/issues/1515

This PR adds a task at the end of `update-no-proxy-envs.yml` playbook. This task waits until `kube-apiserver` is healthy again after updating no proxy envs in static pods. Thanks to that `kube-eleven` won't fail in leader election or control plane node removal.