### PR TITLE
Feat/init-process

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 81359ea-3001
+  newTag: 3a04655-3002
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 81359ea-3001
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/builder
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/manager
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/builder
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/manager
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 2bded6d-3003
+  newTag: c41f1c4-3005
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 81359ea-3001
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 3a04655-3002
+  newTag: 2bded6d-3003
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 81359ea-3001
 - name: ghcr.io/berops/claudie/builder

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: c41f1c4-3005
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/builder
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/manager
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 81359ea-3001
+  newTag: 6b57934-3007

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 2bded6d-3003
+  newTag: c41f1c4-3005

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 6b57934-3007
+  newTag: ab3d058-3009

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: c41f1c4-3005
+  newTag: 6b57934-3007

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 81359ea-3001
+  newTag: 2bded6d-3003

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ab3d058-3009
+  newTag: b8120f2-3011

--- a/manifests/testing-framework/test-sets/rolling-update/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/1.yaml
@@ -78,10 +78,6 @@ spec:
         count: 2
         serverType: Standard_B2s
         image: Canonical:ubuntu-24_04-lts:server:latest
-        taints:
-          - key: test
-            value: test
-            effect: NoSchedule
         labels:
           test-set: rolling-update-test
         annotations:

--- a/manifests/testing-framework/test-sets/rolling-update/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/1.yaml
@@ -104,9 +104,9 @@ spec:
         network: 192.168.2.0/24
         pools:
           control:
-            - azr-ctrl-nodes
-          compute:
             - static-pool-01
+          compute:
+            - azr-ctrl-nodes
   loadBalancers:
     roles:
       - name: port1
@@ -114,13 +114,13 @@ spec:
         port: 6443
         targetPort: 6443
         targetPools:
-          - azr-ctrl-nodes
+          - static-pool-01
       - name: port2
         protocol: tcp
         port: 6448
         targetPort: 6448
         targetPools:
-          - static-pool-01
+          - azr-ctrl-nodes
     clusters:
       - name: ts-rolling-update-lbpools001
         roles:

--- a/manifests/testing-framework/test-sets/rolling-update/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/2.yaml
@@ -78,10 +78,6 @@ spec:
         count: 2
         serverType: Standard_B2s
         image: Canonical:ubuntu-24_04-lts:server:latest
-        taints:
-          - key: test
-            value: test
-            effect: NoSchedule
         labels:
           test-set: rolling-update-test
         annotations:

--- a/manifests/testing-framework/test-sets/rolling-update/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/2.yaml
@@ -104,9 +104,9 @@ spec:
         network: 192.168.2.0/24
         pools:
           control:
-            - azr-ctrl-nodes
-          compute:
             - static-pool-01
+          compute:
+            - azr-ctrl-nodes
   loadBalancers:
     roles:
       - name: port1
@@ -114,13 +114,13 @@ spec:
         port: 6443
         targetPort: 6443
         targetPools:
-          - azr-ctrl-nodes
+          - static-pool-01
       - name: port2
         protocol: tcp
         port: 6448
         targetPort: 6448
         targetPools:
-          - static-pool-01
+          - azr-ctrl-nodes
     clusters:
       - name: ts-rolling-update-lbpools001
         roles:

--- a/services/ansibler/Dockerfile
+++ b/services/ansibler/Dockerfile
@@ -23,65 +23,16 @@ RUN CGO_ENABLED=0 go build
 # Ansible installation: https://github.com/cytopia/docker-ansible/blob/master/Dockerfiles/Dockerfile-base
 FROM docker.io/library/alpine:3.16 AS ansible_builder
 
-RUN set -eux \
-	&& apk add --update --no-cache \
-	# build tools
-	coreutils \
-	g++ \
-	gcc \
-	make \
-	musl-dev \
-	openssl-dev \
-	python3-dev \
-	# misc tools
-	bc \
-	libffi-dev \
-	libxml2-dev \
-	libxslt-dev \
-	py3-pip \
-	python3 \
-	# Fix: ansible --version: libyaml = True
-	# https://www.jeffgeerling.com/blog/2021/ansible-might-be-running-slow-if-libyaml-not-available
-	&& apk add --update --no-cache \
-	py3-yaml \
-	&& python3 -c 'import _yaml'
-
-# Pip required tools
-RUN set -eux \
-	&& pip3 install --no-cache-dir --no-compile \
-	wheel
-RUN set -eux \
-	&& pip3 install --no-cache-dir --no-compile \
-	Jinja2 \
-	MarkupSafe \
-	PyNaCl \
-	bcrypt \
-	cffi \
-	cryptography \
-	pycparser
-
-RUN set -eux \
-	# ansible 10.1.0 includes ansible-core 2.17 and ansible-community 9.6.0
-	&& pip3 install --no-cache-dir --no-binary pyyaml ansible==10.1.0 \
-	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
-	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
-
-# Python packages (copied to final image)
-RUN set -eux \
-	&& pip3 install --no-cache-dir --no-compile \
-	junit-xml \
-	lxml \
-	paramiko \
-	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
-	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
-
-# Clean-up some site-packages to safe space
-RUN set -eux \
-	&& pip3 uninstall --yes \
-	setuptools \
-	wheel \
-	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
-	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+# Install required packages, including Python3 and Ansible
+RUN apk add --no-cache \
+    bash \
+    python3 \
+    py3-pip \
+    openssh-client \
+    libgcc \
+    yaml \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && pip3 install --no-cache-dir ansible==10.1.0
 
 FROM alpine:3.16
 #Add repository label
@@ -93,6 +44,9 @@ LABEL org.opencontainers.image.description "Image for Ansibler from Claudie"
 
 RUN set -eux \
 	&& apk add --no-cache \
+    # tini init system for cleaning up zombie processes left by spawned ansible playbooks \
+    # https://github.com/berops/claudie/issues/1317
+    tini \
 	# Issue: #85 libgcc required for ansible-vault
 	libgcc \
 	py3-pip \
@@ -119,5 +73,6 @@ RUN apk update && apk add -q bash
 
 #Run server
 WORKDIR /bin
-ENTRYPOINT [ "./services/ansibler/server/server" ]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD [ "./services/ansibler/server/server" ]
 #NOTE: We cannot use scratch image for our dockerfile since we are using shell commands to execute commands inside the code

--- a/services/builder/domain/usecases/config_processor_v2.go
+++ b/services/builder/domain/usecases/config_processor_v2.go
@@ -191,6 +191,10 @@ func (u *Usecases) executeUpdateTask(te *managerclient.NextTaskResponse) (*spec.
 			return ctx.DesiredCluster, ctx.DesiredLoadbalancers, err
 		}
 
+		if err := u.Kuber.CiliumRolloutRestart(ctx.DesiredCluster, u.Kuber.GetClient()); err != nil {
+			return ctx.DesiredCluster, ctx.DesiredLoadbalancers, err
+		}
+
 		return ctx.DesiredCluster, ctx.DesiredLoadbalancers, nil
 	}
 

--- a/services/testing-framework/test_autoscaler.go
+++ b/services/testing-framework/test_autoscaler.go
@@ -152,19 +152,18 @@ func testAutoscaler(ctx context.Context, config *spec.Config) error {
 
 	log.Info().Msgf("Config %s has successfully passed autoscaling test [2/3]", config.Name)
 
-	err = waitForDoneOrError(ctx, manager, testset{Config: config.Name, Set: "autoscaling", Manifest: "scale-up-test"})
+	done, err := waitForDoneOrError(ctx, manager, testset{
+		Config:   config.Name,
+		Set:      "autoscaling",
+		Manifest: "scale-up-test",
+	})
 	if err != nil {
 		return err
 	}
 
 	// Test longhorn.
 	// Get new config from DB with updated counts.
-	resp, err := manager.GetConfig(ctx, &managerclient.GetConfigRequest{Name: config.Name})
-	if err != nil {
-		return fmt.Errorf("error while retrieving config %s from DB : %w", config.Name, err)
-	}
-
-	if err := testLonghornDeployment(ctx, resp.Config); err != nil {
+	if err := testLonghornDeployment(ctx, done); err != nil {
 		return err
 	}
 
@@ -204,18 +203,16 @@ func testAutoscaler(ctx context.Context, config *spec.Config) error {
 
 	log.Info().Msgf("Config %s has successfully passed autoscaling test [3/3]", config.Name)
 
-	err = waitForDoneOrError(ctx, manager, testset{Config: config.Name, Set: "autoscaling", Manifest: "scale-down-test"})
+	done, err = waitForDoneOrError(ctx, manager, testset{
+		Config:   config.Name,
+		Set:      "autoscaling",
+		Manifest: "scale-down-test",
+	})
 	if err != nil {
 		return err
 	}
 
-	// Get new config from DB with updated counts.
-	resp, err = manager.GetConfig(ctx, &managerclient.GetConfigRequest{Name: config.Name})
-	if err != nil {
-		return fmt.Errorf("error while retrieving config %s from DB : %w", config.Name, err)
-	}
-
-	return testLonghornDeployment(ctx, resp.Config)
+	return testLonghornDeployment(ctx, done)
 }
 
 // applyDeployment applies specified deployment into specified cluster.

--- a/services/testing-framework/test_longhorn.go
+++ b/services/testing-framework/test_longhorn.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	maxLonghornCheck = 6 * 60 // max allowed time for pods of longhorn-system to be ready [seconds]
-	sleepSecPods     = 20     // seconds for one cycle of longhorn checks (the node and pod checks)
+	maxLonghornCheck = 12 * 60 // max allowed time for pods of longhorn-system to be ready [seconds]
+	sleepSecPods     = 20      // seconds for one cycle of longhorn checks (the node and pod checks)
 )
 
 type KubectlOutputJSON struct {

--- a/services/testing-framework/test_longhorn.go
+++ b/services/testing-framework/test_longhorn.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	maxLonghornCheck = 12 * 60 // max allowed time for pods of longhorn-system to be ready [seconds]
+	maxLonghornCheck = 14 * 60 // max allowed time for pods of longhorn-system to be ready [seconds]
 	sleepSecPods     = 20      // seconds for one cycle of longhorn checks (the node and pod checks)
 )
 

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	maxTimeout     = 24_500  // max allowed time for one manifest to finish in [seconds]
-	sleepSec       = 30      // seconds for one cycle of config check
+	sleepSec       = 2       // seconds for one cycle of config check
 	maxTimeoutSave = 60 * 12 // max allowed time for config to be found in the database
 )
 

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -62,7 +62,7 @@ func waitForDoneOrError(ctx context.Context, manager managerclient.CrudAPI, set 
 				}
 			}
 
-			if res.Config.Manifest.State == spec.Manifest_Error {
+			if res.Config.Manifest.State == spec.Manifest_Error && bytes.Equal(res.Config.Manifest.LastAppliedChecksum, res.Config.Manifest.Checksum) {
 				var err error
 
 				for cluster, state := range res.Config.Clusters {

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	maxTimeout     = 24_500  // max allowed time for one manifest to finish in [seconds]
-	sleepSec       = 2       // seconds for one cycle of config check
+	sleepSec       = 10      // seconds for one cycle of config check
 	maxTimeoutSave = 60 * 12 // max allowed time for config to be found in the database
 )
 

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -107,6 +107,11 @@ func waitForDoneOrError(ctx context.Context, manager managerclient.CrudAPI, set 
 					return res.Config, nil
 				}
 
+				// In case a test-set contains static nodepools and the test set performs
+				// a rolling update the static pools needs to be placed first in the input manifest.
+				// As a rolling update appends new nodepools and skips over static nodepool the
+				// order between the current and desired state will be different and fails the
+				// below check, but the end state does match
 				for c, s := range res.Config.Clusters {
 					equal := proto.Equal(s.Current, s.Desired)
 					if !equal {

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"time"
 
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb/spec"
 	managerclient "github.com/berops/claudie/services/manager/client"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/rs/zerolog/log"
 


### PR DESCRIPTION
When executing ansible paybooks multiple child processes are spawned as described in issue https://github.com/berops/claudie/issues/1317. The problem is that these processes are not correctly cleaned up after the playbook stops executing inside a docker environment. It unclear why the subprocesses are not correctly terminated, to address this issue the init system was added to the docker container for ansible.

The init process adopts, these "oprhaned children" left by ansible and cleans them up so that we do not eventually run out of resources on the docker image.

closes https://github.com/berops/claudie/issues/1317