### PR TITLE
fix: controller status logging

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -61,9 +61,9 @@ images:
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/builder
-  newTag: b8120f2-3011
+  newTag: e003164-3013
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: b8120f2-3011
+  newTag: e003164-3013
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: b8120f2-3011
 - name: ghcr.io/berops/claudie/kuber

--- a/services/builder/domain/usecases/config_processor_v2.go
+++ b/services/builder/domain/usecases/config_processor_v2.go
@@ -81,6 +81,8 @@ func (u *Usecases) TaskProcessor(wg *sync.WaitGroup) error {
 func (u *Usecases) processTaskEvent(t *managerclient.NextTaskResponse) (*spec.Clusters, error) {
 	metrics.TasksProcessedCounter.Inc()
 
+	t.State.Description = t.Event.Description
+
 	var (
 		err error
 		k8s *spec.K8Scluster

--- a/services/claudie-operator/pkg/controller/controller.go
+++ b/services/claudie-operator/pkg/controller/controller.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"gopkg.in/yaml.v3"
-
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -228,7 +227,9 @@ func (r *InputManifestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: REQUEUE_DELETE}, nil
 	}
 
-	if configState == spec.Manifest_Pending || configState == spec.Manifest_Scheduled {
+	provisioning := configState == spec.Manifest_Pending || configState == spec.Manifest_Scheduled
+	provisioning = provisioning || manifestRescheduled
+	if provisioning {
 		// CREATE LOGIC
 		// Call create config if it not present in DB
 		if !configExists {


### PR DESCRIPTION
K8s Controller was not correctly reading the status of the manifest when multiple stages are being processed, i.e. rolling update.