### PR TITLE
chore: remove dangling directories left after nodepool errors

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -132,7 +132,7 @@ jobs:
               TAG=${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
               echo "Setting new tag for autoscaler adapter to $TAG"
               sed -i "s/image: ghcr.io\/berops\/claudie\/autoscaler-adapter/&:$TAG/" services/kuber/templates/cluster-autoscaler.goyaml
-              NEW_SERVICES+=(kuber)
+              NEW_SERVICES+=(autoscaler-adapter)
             fi
           fi
 

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -129,10 +129,7 @@ jobs:
             # Check if kuber is going to be built, if so, insert latest tag and add to build.
 
             if [[ "${NEW_SERVICES[*]}" =~ "kuber" ]]; then
-              sudo apt update && sudo apt install -y wget tar
-              wget -q https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64.tar.gz -O - |\
-              tar xz && mv yq_linux_amd64 yq
-              TAG=$(./yq eval '.images[-1].newTag' manifests/claudie/kustomization.yaml)
+              TAG=${SHORT_GITHUB_SHA}-${GITHUB_RUN_NUMBER}
               echo "Setting new tag for autoscaler adapter to $TAG"
               sed -i "s/image: ghcr.io\/berops\/claudie\/autoscaler-adapter/&:$TAG/" services/kuber/templates/cluster-autoscaler.goyaml
               NEW_SERVICES+=(kuber)

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -65,8 +65,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: fbe30b9-3018
+  newTag: 1d72578-3019
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: fbe30b9-3018
+  newTag: 1d72578-3019

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -67,8 +67,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 89ff66f-3015
+  newTag: 9d56fa8-3016
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 89ff66f-3015
+  newTag: 9d56fa8-3016

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,8 +58,6 @@ kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
   newTag: 89ff66f-3015
-- name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/builder
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/claudie-operator

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -58,6 +58,8 @@ kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
   newTag: 89ff66f-3015
+- name: ghcr.io/berops/claudie/autoscaler-adapter
+  newTag: 00db53e-3021
 - name: ghcr.io/berops/claudie/builder
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/claudie-operator
@@ -65,8 +67,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 206fea7-3020
+  newTag: 00db53e-3021
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 206fea7-3020
+  newTag: 00db53e-3021

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -67,8 +67,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 9d56fa8-3016
+  newTag: e4fdc18-3017
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 9d56fa8-3016
+  newTag: e4fdc18-3017

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -67,8 +67,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e4fdc18-3017
+  newTag: fbe30b9-3018
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e4fdc18-3017
+  newTag: fbe30b9-3018

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -65,8 +65,8 @@ images:
 - name: ghcr.io/berops/claudie/kube-eleven
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 1d72578-3019
+  newTag: 206fea7-3020
 - name: ghcr.io/berops/claudie/manager
   newTag: 89ff66f-3015
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 1d72578-3019
+  newTag: 206fea7-3020

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: fbe30b9-3018
+  newTag: 1d72578-3019

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 1d72578-3019
+  newTag: 206fea7-3020

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 206fea7-3020
+  newTag: 00db53e-3021

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 89ff66f-3015
+  newTag: fbe30b9-3018

--- a/services/kuber/server/domain/usecases/cilium_rollout_restart.go
+++ b/services/kuber/server/domain/usecases/cilium_rollout_restart.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"fmt"
+
 	"github.com/berops/claudie/internal/kubectl"
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb"
@@ -14,7 +15,7 @@ func (u *Usecases) CiliumRolloutRestart(request *pb.CiliumRolloutRestartRequest)
 	logger.Info().Msgf("Performing a rollout of the cilium daemonset")
 	kc := kubectl.Kubectl{
 		Kubeconfig:        request.Cluster.Kubeconfig,
-		MaxKubectlRetries: 3,
+		MaxKubectlRetries: 5,
 	}
 
 	if err := kc.RolloutRestart("daemonset", "cilium", "-n kube-system"); err != nil {

--- a/services/terraformer/server/domain/utils/loadbalancer/dns.go
+++ b/services/terraformer/server/domain/utils/loadbalancer/dns.go
@@ -78,6 +78,10 @@ func (d DNS) CreateDNSRecords(logger zerolog.Logger) (string, error) {
 			return "", err
 		}
 
+		if err := os.RemoveAll(dnsDir); err != nil {
+			return "", fmt.Errorf("error while removing files in dir %q: %w", dnsDir, err)
+		}
+
 		sublogger.Info().Msg("Old DNS records were successfully destroyed")
 	}
 

--- a/services/testing-framework/test_autoscaler.go
+++ b/services/testing-framework/test_autoscaler.go
@@ -67,7 +67,7 @@ spec:
               memory: 500Mi`
 	scaleInogoreTimeout = 300 // 5 mins
 	// Time in which Autoscaler should trigger scale up
-	scaleUpTimeout = 600 // 10 mins
+	scaleUpTimeout = 1200 // 20 mins
 	// Time in which Autoscaler should trigger scale down
 	scaleDownTimeout = 2400 // 40 mins
 )


### PR DESCRIPTION
On error, the directories where templates are generate are left as be. This poses an issue with rolling update when an invalid repository is used where the invalid templates will be left in that directory and any subsequent retries will fail until the invalid templates are removed manually.

This PR simply deleted the directory both on successfully generating the template and also when errored.