### PR TITLE
feat: add support for alternative names

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 4577dc2-3035
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 4577dc2-3035
+  newTag: 79cda35-3040
 - name: ghcr.io/berops/claudie/kuber
   newTag: 4577dc2-3035
 - name: ghcr.io/berops/claudie/manager

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 4577dc2-3035
+  newTag: 79cda35-3040

--- a/services/kube-eleven/server/domain/utils/kube-eleven/types.go
+++ b/services/kube-eleven/server/domain/utils/kube-eleven/types.go
@@ -27,6 +27,7 @@ type (
 	// the Kubeone files from templates.
 	templateData struct {
 		APIEndpoint       string
+		AlternativeNames  []string
 		KubernetesVersion string
 		ClusterName       string
 		UtilizeHttpProxy  bool

--- a/services/kube-eleven/templates/kubeone.tpl
+++ b/services/kube-eleven/templates/kubeone.tpl
@@ -24,6 +24,10 @@ cloudProvider:
 apiEndpoint:
   host: '{{ .APIEndpoint }}'
   port: 6443
+  alternativeNames:
+  {{- range $server := .AlternativeNames }}
+    - "{{ $server}}"
+  {{- end }}
 
 controlPlane:
   hosts:

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -220,7 +220,7 @@ func validateKubeconfigAlternativeNames(clusters map[string]*spec.ClusterState) 
 			}
 
 			if !bytes.Equal(nodes, output) {
-				return fmt.Errorf("cluster %q does not have kubeconfig signed for all control plane nodes")
+				return fmt.Errorf("cluster %q does not have kubeconfig signed for all control plane nodes", c)
 			}
 		}
 	}

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -5,16 +5,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/berops/claudie/internal/kubectl"
-	"gopkg.in/yaml.v3"
 	"time"
 
+	"github.com/berops/claudie/internal/kubectl"
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb/spec"
 	managerclient "github.com/berops/claudie/services/manager/client"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/rs/zerolog/log"
+
+	"gopkg.in/yaml.v3"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -203,7 +204,6 @@ func validateKubeconfigAlternativeNames(clusters map[string]*spec.ClusterState) 
 
 		var output []byte
 		for _, kubeconfig := range kubeconfigs {
-			// check number of nodes in nodes.longhorn.io
 			k := kubectl.Kubectl{
 				Kubeconfig:        kubeconfig,
 				MaxKubectlRetries: 5,


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1538

This PR introduces alternative names that are used for the generated kubeconfig.

What this means, is that in addition to the selected api endpoint (Whether it is a loadbalancer or a control plane node), **All of the control plane nodes will be a valid endpoint for the kubeconfig to be used on.**