### PR TITLE
feat: allow to overwrite default labels for static nodepools

### DIFF
--- a/internal/nodes/metadata.go
+++ b/internal/nodes/metadata.go
@@ -1,10 +1,11 @@
 package nodes
 
 import (
+	"strings"
+
 	"github.com/berops/claudie/internal/utils"
 	"github.com/berops/claudie/proto/pb/spec"
 	k8sV1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 type LabelKey string

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/builder
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/kuber
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/manager
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -51,4 +51,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: a58723d-3042
+  newTag: 4bbf272-3067


### PR DESCRIPTION
This PR allows to overwrite default labels for static nodes. 
Further, if only the labels, annotations, taints were changed the config was not rescheduled, this PR also introduces a changes that fixes this.

Closes https://github.com/berops/claudie/issues/1545