### PR TITLE
update kubeone version & adjust ansible-playbook

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: f95dd2b-3176
+  newTag: bd26f53-3179
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: f95dd2b-3176
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: f95dd2b-3176
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: f95dd2b-3176
+  newTag: bd26f53-3179
 - name: ghcr.io/berops/claudie/kuber
   newTag: f95dd2b-3176
 - name: ghcr.io/berops/claudie/manager

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,7 +57,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 6928ace-3165
+  newTag: 93b845e-3178
 - name: ghcr.io/berops/claudie/autoscaler-adapter
   newTag: 6928ace-3165
 - name: ghcr.io/berops/claudie/builder
@@ -65,7 +65,7 @@ images:
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: 6928ace-3165
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 6928ace-3165
+  newTag: 93b845e-3178
 - name: ghcr.io/berops/claudie/kuber
   newTag: 6928ace-3165
 - name: ghcr.io/berops/claudie/manager

--- a/services/ansibler/server/ansible-playbooks/update-proxy-envs-on-nodes.yml
+++ b/services/ansibler/server/ansible-playbooks/update-proxy-envs-on-nodes.yml
@@ -9,6 +9,7 @@
         state: present
         regexp: '^{{ item.name }}='
         line: '{{ item.name }}="{{ item.value }}"'
+        backrefs: yes
       loop:
         - { name: 'HTTP_PROXY', value: '{{ http_proxy_url }}' }
         - { name: 'HTTPS_PROXY', value: '{{ http_proxy_url }}' }

--- a/services/kube-eleven/Dockerfile
+++ b/services/kube-eleven/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 
 # download and unzip kube-one binary
 RUN apt-get -qq update && apt-get -qq install unzip
-RUN KUBEONE_V=1.8.1 && \
+RUN KUBEONE_V=1.9.0 && \
     wget -q https://github.com/kubermatic/kubeone/releases/download/v${KUBEONE_V}/kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip && \
     unzip -qq kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip -d kubeone_dir
 


### PR DESCRIPTION
adds `backrefs` to the update proxy envs ansible playbook. Without this the environment variables would be appended to the end of the file each time and after 5 runes the entire /etc/environment file would be cluttered with these variables. With `backrefs` they will be overwritten every time.

Closes https://github.com/berops/claudie/issues/1598
Closes https://github.com/berops/claudie/issues/1365

Based on the Kubeone 1.9 release docs, there does seem not to be any backwards incompatibility issues