### PR TITLE
chore: improve validation error msg

### DIFF
--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -89,6 +89,8 @@ func prettyPrintValidationError(err error) error {
 			nerr = fmt.Errorf("field '%s' is required to have a valid proxy mode value of \"on\", \"off\", \"default\"", err.StructField())
 		case "semver2":
 			nerr = fmt.Errorf("field '%s' is required to follow semantic version 2.0, ref: https://semver.org/", err.StructField())
+		case "required_without":
+			nerr = fmt.Errorf("'%s' needs to be set if '%s' is not specified", err.Field(), err.Param())
 		default:
 			nerr = err
 		}

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/builder
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 8169839-3184
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/manager
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -91,4 +91,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 06cb96b-3180
+  newTag: ff165cb-3185


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1484

Validation does not allow a nodepool count to be 0, thus the above issue description does no longer apply, however this PR introduces a more readable error to be printed.