### PR TITLE
skip ping if node has no ip

### DIFF
--- a/internal/clusters/ping4.go
+++ b/internal/clusters/ping4.go
@@ -124,13 +124,18 @@ func ping4(logger zerolog.Logger, conn *icmp.PacketConn, id, seq int, dst *net.U
 // Ping pings a single IPv4 address with the requested amount of retries.
 // An error is returned when more then count/2 packets are lost.
 func Ping(logger zerolog.Logger, count int, dst string) error {
+	dstAddr := &net.UDPAddr{IP: net.ParseIP(dst)}
+	if dstAddr.IP == nil {
+		logger.Warn().Msgf("Received invalid IP address to ping %q, skipping unreachability check", dst)
+		return nil
+	}
+
 	conn, err := icmp.ListenPacket("udp4", "0.0.0.0")
 	if err != nil {
 		return fmt.Errorf("failed to listen for icmp packets: %w", err)
 	}
 	defer conn.Close()
 
-	dstAddr := &net.UDPAddr{IP: net.ParseIP(dst)}
 	id := os.Getpid() & 0xffff // 16bit id
 	lost := 0
 

--- a/internal/clusters/ping4_test.go
+++ b/internal/clusters/ping4_test.go
@@ -250,3 +250,53 @@ func TestPingAll(t *testing.T) {
 		})
 	}
 }
+
+func TestPing(t *testing.T) {
+	logger := zerolog.New(os.Stdout)
+	type args struct {
+		count int
+		dst   string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ok-empty",
+			args: args{
+				count: 5,
+				dst:   "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ok-localhost",
+			args: args{
+				count: 5,
+				dst:   "127.0.0.1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail-invalid",
+			args: args{
+				count: 5,
+				dst:   "0.0.0.0",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := Ping(logger, tt.args.count, tt.args.dst)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Ping() = %v want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/clusters/ping4_test.go
+++ b/internal/clusters/ping4_test.go
@@ -252,6 +252,10 @@ func TestPingAll(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("skipping ping tests")
+	}
+
 	logger := zerolog.New(os.Stdout)
 	type args struct {
 		count int

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/builder
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/manager
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -57,18 +57,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/builder
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/manager
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -90,4 +90,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 817fd38-3296
+  newTag: 52c9e17-3303

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -90,4 +90,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e62b72f-3291
+  newTag: 817fd38-3296

--- a/services/manager/internal/service/existing_state.go
+++ b/services/manager/internal/service/existing_state.go
@@ -25,7 +25,7 @@ func backwardsCompatibility(c *spec.Config) {
 		)
 
 		for i, current := range currentLbs {
-			// TODO: remove in future versions, currently only for backwards compatiblity.
+			// TODO: remove in future versions, currently only for backwards compatibility.
 			// version 0.9.7 introced additional role settings, which may not be set in the
 			// current state. To have backwards compatibility add defaults to the current state.
 			for _, role := range current.Roles {

--- a/services/manager/internal/service/existing_state.go
+++ b/services/manager/internal/service/existing_state.go
@@ -25,6 +25,21 @@ func backwardsCompatibility(c *spec.Config) {
 		)
 
 		for i, current := range currentLbs {
+			// TODO: remove in future versions, currently only for backwards compatiblity.
+			// version 0.9.7 introced additional role settings, which may not be set in the
+			// current state. To have backwards compatibility add defaults to the current state.
+			for _, role := range current.Roles {
+				if role.Settings == nil {
+					log.Info().
+						Str("cluster", current.GetClusterInfo().Id()).
+						Msg("detected loadbalancer build with version older than 0.9.7, settings default role settings for its current state")
+
+					role.Settings = &spec.Role_Settings{
+						ProxyProtocol: true,
+					}
+				}
+			}
+
 			if current.IsApiEndpoint() {
 				anyApiServerLoadBalancerSelected = true
 				break


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1690

If node does not have an IP address assigned, skip Pinging the node. This may happen if for example the terraformer service gets OOM killed or force killed before it returnes the nodes with ips, so the current state will have no IPs to ping on subsequent changes