### PR TITLE
fix panic caused by nil DNS struct

### DIFF
--- a/services/builder/domain/usecases/kube_eleven_caller.go
+++ b/services/builder/domain/usecases/kube_eleven_caller.go
@@ -43,7 +43,7 @@ func (u *Usecases) destroyK8sCluster(ctx *builder.Context) error {
 	u.updateTaskWithDescription(ctx, spec.Workflow_KUBE_ELEVEN, fmt.Sprintf("%s destroying kubernetes cluster", description))
 
 	var lbApiEndpoint string
-	if ep := clusters.FindAssignedLbApiEndpoint(ctx.CurrentLoadbalancers); ep != nil {
+	if ep := clusters.FindAssignedLbApiEndpoint(ctx.CurrentLoadbalancers); ep != nil && ep.Dns != nil {
 		lbApiEndpoint = ep.Dns.Endpoint
 	}
 


### PR DESCRIPTION
*Description*
Fixes a potential panic during cluster deletion when the DNS field of a LoadBalancer is nil.

Currently, if a cluster is built with invalid DNS input (such as an invalid API key or zone), the DNS field of the LoadBalancer can be nil. This causes a panic when attempting to delete the cluster, as the deletion process tries to access ep.Dns.Endpoint without checking if ep.Dns is valid.

This PR adds a condition to ensure ep.Dns is not nil before attempting to access ep.Dns.Endpoint. This ensures that the deletion process works correctly, even when the infrastructure is only partially built.

fixes: #1722 