### PR TITLE
fix partial dns apply & target destroy empty list

### DIFF
--- a/services/terraformer/server/domain/utils/terraform/terraform.go
+++ b/services/terraformer/server/domain/utils/terraform/terraform.go
@@ -150,6 +150,10 @@ func (t *Terraform) Destroy() error {
 }
 
 func (t *Terraform) DestroyTarget(targets []string) error {
+	if len(targets) == 0 {
+		return nil
+	}
+
 	if err := t.SpawnProcessLimit.Acquire(context.Background(), 1); err != nil {
 		return fmt.Errorf("failed to prepare terraform destroy target process: %w", err)
 	}


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1705

Adds a guard for the terraform target destroys that check if there are actual any selected targets to destroys, which would otherwise trigger an unwanted full terraform destroy.

Fixes partial dns apply, by reverting to the current state on failure.