### PR TITLE
add timeouts to package installs

### DIFF
--- a/services/ansibler/server/ansible-playbooks/longhorn-req.yml
+++ b/services/ansibler/server/ansible-playbooks/longhorn-req.yml
@@ -16,12 +16,28 @@
         name: open-iscsi
         state: present
         update_cache: true
+      retries: 2
+      delay: 10
+      register: res
+      until: res is not failed
+      # open-iscsi packages are few hundred Kibs in size
+      # having a timeout of 8 mins with 2 retries is generous.
+      async: 480
+      poll: 5
 
     - name: install nfs-common
       ansible.builtin.apt:
         name: nfs-common
         state: present
         update_cache: true
+      retries: 2
+      delay: 10
+      register: res
+      until: res is not failed
+      # nfs-common packages are few hundred Kibs in size
+      # having a timeout of 8 mins with 2 retries generous.
+      async: 480
+      poll: 5
 
     - name: Update /etc/multipath.conf with blacklist configuration
       blockinfile:

--- a/services/ansibler/server/ansible-playbooks/wireguard/tasks/install.yml
+++ b/services/ansibler/server/ansible-playbooks/wireguard/tasks/install.yml
@@ -3,16 +3,14 @@
   ansible.builtin.apt:
     pkg:
       - wireguard
-      - pipx
       - net-tools
     state: present
     update_cache: true
-  retries: 10
+  retries: 2
   delay: 10
   register: res
   until: res is not failed
-
-- name: Install wireguard via pipx
-  community.general.pipx:
-    name: wireguard
-...
+  # wireguard packages are few hundred Kibs in size
+  # having a timeout of 8 mins with 2 retries is generous.
+  async: 480
+  poll: 5


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1575

Adds a timeout of 8mins for tasks that install packages.


Additionally, removed duplicate install of wireguard via pipx which was not utilized anywhere