### PR TITLE
decrease the cloudflare tf version

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -71,4 +71,4 @@ images:
 - name: ghcr.io/berops/claudie/manager
   newTag: 6223444-3450
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 216e0cb-3452
+  newTag: 8110681-3469

--- a/services/terraformer/server/domain/utils/templates/providers.tpl
+++ b/services/terraformer/server/domain/utils/templates/providers.tpl
@@ -33,7 +33,7 @@ terraform {
     {{- if .Cloudflare }}
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "5.7.1"
+      version = "4.52.1"
     }
     {{- end }}
     {{- if .HetznerDNS }}


### PR DESCRIPTION
The backwards incompatible change for the cloudflare provider (i.e removing cloudflare_record resource and replacing it with cloudflare_dns_record) needs to be  handled in a separate issue https://github.com/berops/claudie/issues/1788

Currently I have rolled back to the latest version `4.x` that was released 6 days ago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Downgraded the Cloudflare Terraform provider version in configuration templates.
  * Updated the container image tag for the Terraformer component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->