### PR TITLE
Update providers.tpl

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -71,4 +71,4 @@ images:
 - name: ghcr.io/berops/claudie/manager
   newTag: 3cf51a2-3473
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 3cf51a2-3473
+  newTag: cb9e1df-3486

--- a/services/terraformer/server/domain/utils/templates/providers.tpl
+++ b/services/terraformer/server/domain/utils/templates/providers.tpl
@@ -27,7 +27,7 @@ terraform {
     {{- if .Azure }}
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.37.0"
+      version = "3.107.0"
     }
     {{- end }}
     {{- if .Cloudflare }}


### PR DESCRIPTION
Downgrade to the latest azurerm version that supports `enable_accelerated_networking `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Azure provider version used for Terraform from 4.37.0 to 3.107.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->