### PR TITLE
chore: update e2e-tests with new template version

### DIFF
--- a/manifests/testing-framework/test-sets/autoscaling-1/1.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/1.yaml
@@ -7,7 +7,7 @@ spec:
     - name: gcp-1
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:
@@ -16,7 +16,7 @@ spec:
     - name: gcp-2
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:

--- a/manifests/testing-framework/test-sets/autoscaling-1/2.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/2.yaml
@@ -7,7 +7,7 @@ spec:
     - name: gcp-1
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:
@@ -16,7 +16,7 @@ spec:
     - name: gcp-2
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:

--- a/manifests/testing-framework/test-sets/autoscaling-1/3.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/3.yaml
@@ -7,7 +7,7 @@ spec:
     - name: gcp-1
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:
@@ -16,7 +16,7 @@ spec:
     - name: gcp-2
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       providerType: gcp
       secretRef:

--- a/manifests/testing-framework/test-sets/autoscaling-2/1.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-2/1.yaml
@@ -7,7 +7,7 @@ spec:
     - name: aws-1
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/aws"
       providerType: aws
       secretRef:
@@ -16,7 +16,7 @@ spec:
     - name: aws-2
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/aws"
       providerType: aws
       secretRef:

--- a/manifests/testing-framework/test-sets/autoscaling-2/2.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-2/2.yaml
@@ -8,7 +8,7 @@ spec:
       templates:
         repository: "https://github.com/berops/claudie-config"
         # performs a rolling update
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/aws"
       providerType: aws
       secretRef:
@@ -18,7 +18,7 @@ spec:
       templates:
         repository: "https://github.com/berops/claudie-config"
         # performs a rolling update
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/aws"
       providerType: aws
       secretRef:

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/8.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/8.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/1.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/10.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/10.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/2.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/3.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/4.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/4.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/5.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/5.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/6.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/6.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/7.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/7.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/8.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/8.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/9.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/9.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-secret

--- a/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret

--- a/manifests/testing-framework/test-sets/rolling-update/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -26,7 +26,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -35,7 +35,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-secret
@@ -44,7 +44,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1"
+        tag: "v0.9.8"
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/rolling-update/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -26,7 +26,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.1" # no change to dns.
+        tag: "v0.9.8" # no change to dns.
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -35,7 +35,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-secret
@@ -44,7 +44,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: "v0.9.8"
+        tag: "v0.9.11"
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-1/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-1/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-1/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-1/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-3/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-3/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-3/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-3/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -26,7 +26,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -17,7 +17,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -26,7 +26,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -62,7 +62,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -62,7 +62,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret
@@ -62,7 +62,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-secret

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: azure
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/azure"
       secretRef:
         name: azure-sponsorship-secret

--- a/manifests/testing-framework/test-sets/test-set3/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret
@@ -26,7 +26,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -35,7 +35,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -44,7 +44,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -53,7 +53,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret

--- a/manifests/testing-framework/test-sets/test-set3/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret

--- a/manifests/testing-framework/test-sets/test-set3/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetznerdns
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetznerdns"
       secretRef:
         name: hetznerdns-secret
@@ -26,7 +26,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -35,7 +35,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret

--- a/manifests/testing-framework/test-sets/test-set3/4.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/4.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret
@@ -17,7 +17,7 @@ spec:
       providerType: hetzner
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/hetzner"
       secretRef:
         name: hetzner-secret
@@ -26,7 +26,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret

--- a/manifests/testing-framework/test-sets/test-set4/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret

--- a/manifests/testing-framework/test-sets/test-set4/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -17,7 +17,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret
@@ -26,7 +26,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/test-set4/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: oci
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/oci"
       secretRef:
         name: oci-secret
@@ -17,7 +17,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret
@@ -26,7 +26,7 @@ spec:
       providerType: gcp
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/gcp"
       secretRef:
         name: gcp-secret

--- a/manifests/testing-framework/test-sets/test-set5/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/1.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -17,7 +17,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret

--- a/manifests/testing-framework/test-sets/test-set5/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/2.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -17,7 +17,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret

--- a/manifests/testing-framework/test-sets/test-set5/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/3.yaml
@@ -8,7 +8,7 @@ spec:
       providerType: aws
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/aws"
       secretRef:
         name: aws-secret
@@ -17,7 +17,7 @@ spec:
       providerType: cloudflare
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.9.8
+        tag: v0.9.11
         path: "templates/terraformer/cloudflare"
       secretRef:
         name: cloudflare-secret


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version tags for provider templates across all test manifests to newer releases, ensuring all providers reference the latest available versions.
  * No changes were made to configuration, structure, or other manifest content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->