### PR TITLE
fix tofu command retries

### DIFF
--- a/internal/command/cmd_test.go
+++ b/internal/command/cmd_test.go
@@ -12,19 +12,19 @@ func TestCmd(t *testing.T) {
 	cmd1 := Cmd{"sleep 2 && ls", nil, "", nil, nil, 1}
 	err := cmd1.RetryCommand(1)
 	require.Error(t, err)
-	_, err = cmd1.RetryCommandWithOutput(1)
+	_, err = cmd1.RetryCommandWithCombinedOutput(1)
 	require.Error(t, err)
 	//high commandTimeout - pass
 	cmd2 := Cmd{"sleep 2 && ls", nil, "", nil, nil, 3}
 	err = cmd2.RetryCommand(1)
 	require.NoError(t, err)
-	_, err = cmd2.RetryCommandWithOutput(1)
+	_, err = cmd2.RetryCommandWithCombinedOutput(1)
 	require.NoError(t, err)
 	//no commandTimeout - pass
 	cmd3 := Cmd{"sleep 2 && ls", nil, "", nil, nil, 0}
 	err = cmd3.RetryCommand(1)
 	require.NoError(t, err)
-	_, err = cmd3.RetryCommandWithOutput(1)
+	_, err = cmd3.RetryCommandWithCombinedOutput(1)
 	require.NoError(t, err)
 }
 

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -287,7 +287,7 @@ func (k Kubectl) runWithOutput(command string, options ...string) ([]byte, error
 			retryCount = defaultMaxKubectlRetries
 		}
 		cmd := comm.Cmd{Command: command, Options: options, Dir: k.Directory, CommandTimeout: kubectlTimeout}
-		result, err = cmd.RetryCommandWithOutput(retryCount)
+		result, err = cmd.RetryCommandWithCombinedOutput(retryCount)
 		if err != nil {
 			return result, err
 		}

--- a/services/terraformer/server/domain/utils/tofu/terraform.go
+++ b/services/terraformer/server/domain/utils/tofu/terraform.go
@@ -215,13 +215,13 @@ func (t *Terraform) StateList() ([]string, error) {
 		retryCmd := comm.Cmd{
 			Command: "tofu state list",
 			Dir:     t.Directory,
-			Stdout:  cmd.Stdout,
-			Stderr:  cmd.Stderr,
 		}
-		if err := retryCmd.RetryCommand(maxTfCommandRetryCount); err != nil {
+
+		out, err = retryCmd.RetryCommandWithOutput(maxTfCommandRetryCount)
+		if err != nil {
 			return nil, fmt.Errorf("failed to execute cmd: %s: %w", retryCmd.Command, err)
 		}
-		return nil, err
+		// fallthrough
 	}
 
 	r := bytes.Split(out, []byte("\n"))
@@ -240,5 +240,19 @@ func (t *Terraform) Output(resourceName string) (string, error) {
 	cmd := exec.Command("tofu", "output", "-json", resourceName)
 	cmd.Dir = t.Directory
 	out, err := cmd.CombinedOutput()
-	return string(out), err
+	if err != nil {
+		log.Warn().Msgf("Error encountered while executing %s from %s: %v", cmd, t.Directory, err)
+		cmd := fmt.Sprintf("tofu output -json %s", resourceName)
+		retryCmd := comm.Cmd{
+			Command: cmd,
+			Dir:     t.Directory,
+		}
+
+		out, err = retryCmd.RetryCommandWithCombinedOutput(maxTfCommandRetryCount)
+		if err != nil {
+			return "", fmt.Errorf("failed to execute cmd: %s: %w", retryCmd.Command, err)
+		}
+		// fallthrough
+	}
+	return string(out), nil
 }


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/1821

when the retry block, of one of the below changed tofu commands, was executed, the logic of handling the retries was wrong.

For the state list, the retries simply returned the first error and didn't even return the fetched state list (if successful on retries). This was fixed