### PR TITLE
Docs/claudie in custom NS

### DIFF
--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -54,8 +54,8 @@ By default, when following the [Getting Started](../getting-started/get-started-
      ```bash
      sed -i 's/claudie-operator-role-binding/claudie-operator-role-binding-new-namespace/g' claudie.yaml
      ```
-     2.6. Once you’ve created claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
+     2.6. Once you’ve updated claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
     ```bash
     kubectl create namespace new-namespace
-    kubectl apply -f claudie.yaml -n new-namespace
+    kubectl apply -f claudie.yaml
     ```

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -44,7 +44,14 @@ By default, when following the [Getting Started](../getting-started/get-started-
         - name: CLAUDIE_NAMESPACES
           value: "new-namespace"
      ```
-     2.5. Once you’ve created claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
+     2.5. To ensure the `ClusterRoleBinding` is correctly applied to the specified `ServiceAccount`, make sure the `ClusterRoleBinding` has a unique name. Modify the name of the `ClusterRoleBinding` resource in the `claudie.yaml`.
+     
+     Using linux terminal you can use sed utility:
+
+     ```bash
+     sed -i 's/claudie-operator-role-binding/claudie-operator-role-binding-new-namespace/g' claudie.yaml
+     ```
+     2.6. Once you’ve created claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
     ```bash
     kubectl create namespace new-namespace
     kubectl apply -f claudie.yaml -n brando

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -48,9 +48,9 @@ By default, when following the [Getting Started](../getting-started/get-started-
           value: "new-namespace"
      ```
     !!! danger "Updating CLAUDIE_NAMESPACES variable"
-        If there already exist Claudie cluster, make sure to also update the deployment of the existing Claudie operator to reflect the correct namespace.
+        If there already exists a Claudie cluster, make sure to also update the deployment of the existing Claudie operator to reflect the correct namespace.
 
-        If the `CLAUDIE_NAMESPACE` environment variable is not set in the operator, multiple Claudie instances may pick up the same InputManifests, which can lead to the cluster being unintentionally rebuilt. This can result in unexpected behavior and potentially break your Kubernetes cluster.
+        If the `CLAUDIE_NAMESPACES` environment variable is not set in the operator, multiple Claudie instances may pick up the same InputManifests, which can lead to the cluster being unintentionally rebuilt. This can result in unexpected behavior and potentially break your Kubernetes cluster.
 
      2.5. To ensure the `ClusterRoleBinding` is correctly applied to the specified `ServiceAccount`, make sure the `ClusterRoleBinding` has a unique name. Modify the name of the `ClusterRoleBinding` resource in the `claudie.yaml`.
      

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -47,6 +47,11 @@ By default, when following the [Getting Started](../getting-started/get-started-
         - name: CLAUDIE_NAMESPACES
           value: "new-namespace"
      ```
+    !!! danger "Updating CLAUDIE_NAMESPACES variable"
+        If there already exist Claudie cluster, make sure to also update the deployment of the existing Claudie operator to reflect the correct namespace.
+
+        If the `CLAUDIE_NAMESPACE` environment variable is not set in the operator, multiple Claudie instances may pick up the same InputManifests, which can lead to the cluster being unintentionally rebuilt. This can result in unexpected behavior and potentially break your Kubernetes cluster.
+
      2.5. To ensure the `ClusterRoleBinding` is correctly applied to the specified `ServiceAccount`, make sure the `ClusterRoleBinding` has a unique name. Modify the name of the `ClusterRoleBinding` resource in the `claudie.yaml`.
      
      Using linux terminal you can use sed utility:

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -1,0 +1,46 @@
+# Deploying Claudie in custom namespace
+
+By default, when following the [Getting Started](../getting-started/get-started-using-claudie.md#install-claudie) guide, Claudie is deployed in the claudie namespace. However, you may want to deploy it into a custom namespace for reasons such as organizational structure, environment isolation or others.
+
+## Modifiing claudie.yaml bundle
+
+1. Download the latest claudie.yaml 
+    ```bash
+    wget https://github.com/berops/claudie/releases/latest/download/claudie.yaml
+    ```
+2. Before applying the manifest, make the following changes:
+   
+    2.1. Replace every occurrence of `namespace: claudie` with your desired namespace (e.g., new-namespace). 
+   Using linux terminal you can use sed utility:
+   ```bash
+    sed -i 's/namespace: claudie/namespace: new-namespace/' claudie.yaml
+   ```
+    2.2. For DNS Names within Certificate resource, `kind: Certificate`, ensure the dnsNames reflect the new namespace:
+   ```yaml
+   spec:
+       dnsNames:
+       - claudie-operator.new-namespace
+       - claudie-operator.new-namespace.svc
+       - claudie-operator.new-namespace.svc.cluster
+       - claudie-operator.new-namespace.svc.cluster.local
+   ```
+   Using linux terminal you can use sed utility:
+   ```bash
+   sed -i 's/\(claudie-operator\)\.claudie/\1.new-namespace/g'
+   ```
+   2.3. Replace annotations `cert-manager.io/inject-ca-from: claudie/claudie-webhook-certificate` in ValidatingWebhookConfiguration resource, `kind: ValidatingWebhookConfiguration`, so that is contains name of your new namespace
+    ```yaml
+    annotations:
+        cert-manager.io/inject-ca-from: new-namespace/claudie-webhook-certificate
+    ```
+    Using linux terminal you can use sed utility:
+
+    ```bash
+    sed -i 's/cert-manager\.io\/inject-ca-from: claudie\//cert-manager.io\/inject-ca-from: new-namespace\//g' claudie.yaml
+    ```
+     2.4. Once you’ve updated claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
+    ```bash
+    kubectl create namespace new-namespace
+    kubectl apply -f https://github.com/berops/claudie/releases/latest/download/claudie.yaml
+    kubectl apply -f claudie.yaml
+    ```

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -1,8 +1,8 @@
-# Deploying Claudie in custom namespace
+# Deploying Claudie in a custom namespace
 
-By default, when following the [Getting Started](../getting-started/get-started-using-claudie.md#install-claudie) guide, Claudie is deployed in the claudie namespace. However, you may want to deploy it into a custom namespace for reasons such as organizational structure, environment isolation or others.
+By default, when following the [Getting Started](../getting-started/get-started-using-claudie.md#install-claudie) guide, Claudie is deployed in the `claudie` namespace. However, you may want to deploy it into a custom namespace for reasons such as organizational structure, environment isolation or others.
 
-## Modifiing claudie.yaml bundle
+## Modifiyng claudie.yaml bundle
 
 1. Download the latest claudie.yaml 
     ```bash
@@ -38,9 +38,14 @@ By default, when following the [Getting Started](../getting-started/get-started-
     ```bash
     sed -i 's/cert-manager\.io\/inject-ca-from: claudie\//cert-manager.io\/inject-ca-from: new-namespace\//g' claudie.yaml
     ```
-     2.4. Once you’ve updated claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
+     2.4. To restrict the namespaces monitored by the Claudie operator (as defined in `claudie.yaml`), add the `CLAUDIE_NAMESPACES` environment variable to the claudie-operator deployment.
+     ```yaml
+     env:
+        - name: CLAUDIE_NAMESPACES
+          value: "new-namespace"
+     ```
+     2.5. Once you’ve created claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
     ```bash
     kubectl create namespace new-namespace
-    kubectl apply -f https://github.com/berops/claudie/releases/latest/download/claudie.yaml
-    kubectl apply -f claudie.yaml
+    kubectl apply -f claudie.yaml -n brando
     ```

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -26,7 +26,7 @@ By default, when following the [Getting Started](../getting-started/get-started-
    ```
    Using linux terminal you can use sed utility:
    ```bash
-   sed -i 's/\(claudie-operator\)\.claudie/\1.new-namespace/g'
+   sed -i 's/\(claudie-operator\)\.claudie/\1.new-namespace/g' claudie.yaml
    ```
    2.3. Replace annotations `cert-manager.io/inject-ca-from: claudie/claudie-webhook-certificate` in ValidatingWebhookConfiguration resource, `kind: ValidatingWebhookConfiguration`, so that is contains name of your new namespace
     ```yaml

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -28,15 +28,18 @@ By default, when following the [Getting Started](../getting-started/get-started-
    ```bash
    sed -i 's/\(claudie-operator\)\.claudie/\1.new-namespace/g' claudie.yaml
    ```
-   2.3. Replace annotations `cert-manager.io/inject-ca-from: claudie/claudie-webhook-certificate` in ValidatingWebhookConfiguration resource, `kind: ValidatingWebhookConfiguration`, so that is contains name of your new namespace
+   2.3. Replace annotations `cert-manager.io/inject-ca-from: claudie/claudie-webhook-certificate` and name `name: claudie-webhook` in ValidatingWebhookConfiguration resource, `kind: ValidatingWebhookConfiguration`, so that is contains name of your new namespace
     ```yaml
     annotations:
         cert-manager.io/inject-ca-from: new-namespace/claudie-webhook-certificate
+    ...
+    name: claudie-webhook-new-namespace
     ```
     Using linux terminal you can use sed utility:
 
     ```bash
     sed -i 's/cert-manager\.io\/inject-ca-from: claudie\//cert-manager.io\/inject-ca-from: new-namespace\//g' claudie.yaml
+    sed -i 's/claudie-webhook$/claudie-webhook-new-namespace/g' claudie.yaml
     ```
      2.4. To restrict the namespaces monitored by the Claudie operator (as defined in `claudie.yaml`), add the `CLAUDIE_NAMESPACES` environment variable to the claudie-operator deployment.
      ```yaml

--- a/docs/input-manifest/claudie-custom-ns.md
+++ b/docs/input-manifest/claudie-custom-ns.md
@@ -57,5 +57,5 @@ By default, when following the [Getting Started](../getting-started/get-started-
      2.6. Once you’ve created claudie.yaml, create your custom namespace and apply the manifest. Make sure Cert Manager is already deployed in your cluster
     ```bash
     kubectl create namespace new-namespace
-    kubectl apply -f claudie.yaml -n brando
+    kubectl apply -f claudie.yaml -n new-namespace
     ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ nav:
       - Custom Settings example: input-manifest/example-settings.md
       - External Templates: input-manifest/external-templates.md
       - API reference: input-manifest/api-reference.md
-      - Claudie custom namespace: input-manifest/claudie-custom-ns.md
+      - Claudie in custom namespace: input-manifest/claudie-custom-ns.md
   - How Claudie works:
       - Claudie Workflow: claudie-workflow/claudie-workflow.md
       - Claudie Storage solution: storage/storage-solution.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Custom Settings example: input-manifest/example-settings.md
       - External Templates: input-manifest/external-templates.md
       - API reference: input-manifest/api-reference.md
+      - Claudie custom namespace: input-manifest/claudie-custom-ns.md
   - How Claudie works:
       - Claudie Workflow: claudie-workflow/claudie-workflow.md
       - Claudie Storage solution: storage/storage-solution.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ nav:
       - Custom Settings example: input-manifest/example-settings.md
       - External Templates: input-manifest/external-templates.md
       - API reference: input-manifest/api-reference.md
-      - Claudie in custom namespace: input-manifest/claudie-custom-ns.md
+      - Claudie in a custom namespace: input-manifest/claudie-custom-ns.md
   - How Claudie works:
       - Claudie Workflow: claudie-workflow/claudie-workflow.md
       - Claudie Storage solution: storage/storage-solution.md


### PR DESCRIPTION
Added new section how to create claudie in new custom named namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step guide for deploying Claudie into a custom Kubernetes namespace: update namespace references, adjust Certificate DNS names and webhook annotations/names, add a CLAUDIE_NAMESPACES environment variable to scope operator monitoring, and ensure ClusterRoleBinding names are unique. Notes Cert-Manager as a prerequisite.
  * Updated site navigation to add “Claudie in a custom namespace” under Input manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->