### PR TITLE
Update changelog-0.9.x.md

### DIFF
--- a/docs/CHANGELOG/changelog-0.9.x.md
+++ b/docs/CHANGELOG/changelog-0.9.x.md
@@ -324,7 +324,7 @@ kubernetes:
 - Concurrency limits are now configurable [#1838](https://github.com/berops/claudie/pull/1838)
 - Autoscaled nodepools are now limited to 256 nodes [#1839](https://github.com/berops/claudie/pull/1839)
 - Metadata secret will now be updated after node deletion [#1841](https://github.com/berops/claudie/pull/1841)
-- Builder TTL has been increased to 42 hours, as 2 hours is a small amount of time to react to issues [#1850](https://github.com/berops/claudie/pull/1850)
+- Builder TTL has been made configurable via the `BUILDER_TTL` env, with a default value of 2 hours [#1850](https://github.com/berops/claudie/pull/1850)
 
 ## Bug fixes
 - Prometheus metric for currently deleted nodes has been fixed [#1849](https://github.com/berops/claudie/pull/1849)

--- a/docs/CHANGELOG/changelog-0.9.x.md
+++ b/docs/CHANGELOG/changelog-0.9.x.md
@@ -324,7 +324,7 @@ kubernetes:
 - Concurrency limits are now configurable [#1838](https://github.com/berops/claudie/pull/1838)
 - Autoscaled nodepools are now limited to 256 nodes [#1839](https://github.com/berops/claudie/pull/1839)
 - Metadata secret will now be updated after node deletion [#1841](https://github.com/berops/claudie/pull/1841)
-- Builder TTL has been increased to 42 hours, as 2 hours is a small amount of time to react to issues [#1841](https://github.com/berops/claudie/pull/1850)
+- Builder TTL has been increased to 42 hours, as 2 hours is a small amount of time to react to issues [#1850](https://github.com/berops/claudie/pull/1850)
 
 ## Bug fixes
 - Prometheus metric for currently deleted nodes has been fixed [#1849](https://github.com/berops/claudie/pull/1849)

--- a/docs/CHANGELOG/changelog-0.9.x.md
+++ b/docs/CHANGELOG/changelog-0.9.x.md
@@ -317,3 +317,14 @@ kubernetes:
 - Retries were added to reading the output from OpenTofu, which could occasionally fail. [#1824](https://github.com/berops/claudie/pull/1824)
 - Increased concurrency limits to decrease the build time of larger clusters. This change also affects Claudie's memory requirements, which should fit within 8 GB. [#1819](https://github.com/berops/claudie/pull/1819)
 - For autoscaled events, Terraformer will now skip refreshing the LoadBalancers and DNS infrastructure, if present. [#1830](https://github.com/berops/claudie/pull/1830)
+
+## v0.9.13
+
+## What's Changed
+- Concurrency limits are now configurable [#1838](https://github.com/berops/claudie/pull/1838)
+- Autoscaled nodepools are now limited to 256 nodes [#1839](https://github.com/berops/claudie/pull/1839)
+- Metadata secret will now be updated after node deletion [#1841](https://github.com/berops/claudie/pull/1841)
+- Builder TTL has been increased to 42 hours, as 2 hours is a small amount of time to react to issues [#1841](https://github.com/berops/claudie/pull/1850)
+
+## Bug fixes
+- Prometheus metric for currently deleted nodes has been fixed [#1849](https://github.com/berops/claudie/pull/1849)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for v0.9.13 describing: configurable concurrency limits; autoscaled nodepools capped at 256 nodes; metadata secret updated after node deletion; builder TTL configurable via BUILDER_TTL (default 2 hours).
  * Documented a bug fix improving accuracy of the Prometheus metric for currently deleted nodes.
  * Clarified these are documentation-only updates with no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->