### PR TITLE
Modify pipeline to copy llms into rootdir of website

### DIFF
--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -65,12 +65,18 @@ jobs:
       # The llms files need to be located in the root path of a website 
       - name: Copy llms files to root of gh-pages
         run: |
+          set -e
           git checkout gh-pages
 
           cp latest/{llms-full.txt,llms.txt} .
 
           git add llms-full.txt llms.txt
-          git commit -m "Add llms files to root"
-          git push origin gh-pages
+
+          if git commit -m "Add llms files to root"; then
+            echo "Committed llms files to root"
+            git push origin gh-pages
+          else
+            echo "No changes to commit for llms files"
+          fi
 
           git checkout -

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -114,12 +114,18 @@ jobs:
       # The llms files need to be located in the root path of a website 
       - name: Copy llms files to root of gh-pages
         run: |
+          set -e
           git checkout gh-pages
 
           cp latest/{llms-full.txt,llms.txt} .
 
           git add llms-full.txt llms.txt
-          git commit -m "Add llms files to root"
-          git push origin gh-pages
+
+          if git commit -m "Add llms files to root"; then
+            echo "Committed llms files to root"
+            git push origin gh-pages
+          else
+            echo "No changes to commit for llms files"
+          fi
 
           git checkout -


### PR DESCRIPTION
Based on [standardise](https://llmstxt.org/) on using of llms files , the llms files should be located in rootdir of webpage.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation deployment now automatically copies the latest reference files into the published docs root after each docs release, ensuring the public docs include up-to-date reference lists.
  * No functional or public API changes; this only affects how documentation artifacts are published and kept consistent across versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->