### PR TITLE
fix: Remove broken 'Custom Settings example' link from docs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,6 @@ nav:
           - On Premise: input-manifest/providers/on-prem.md
       - Example yaml file: input-manifest/example.md
       - GPUs example: input-manifest/gpu-example.md
-      - Custom Settings example: input-manifest/example-settings.md
       - External Templates: input-manifest/external-templates.md
       - API reference: input-manifest/api-reference.md
       - Claudie in a custom namespace: input-manifest/claudie-custom-ns.md


### PR DESCRIPTION
## Summary
Removes the broken 'Custom Settings example' navigation link that was causing a 404 error.

## Changes
- Removed the non-existent  link from mkdocs.yml navigation

## Context
The 'Custom Settings example' link was pointing to a file that never existed in the repository. Settings documentation is already available in:
- [example.md](docs/input-manifest/example.md)
- [api-reference.md](docs/input-manifest/api-reference.md)

## Testing
- [x] Documentation builds successfully without 404 errors
- [x] Navigation menu no longer shows the broken link
- [x] Users can access existing settings documentation through other navigation items

Fixes #1937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Custom Settings example entry from the Input Manifest navigation section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->