### PR TITLE
docs: add GPU support column to supported providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Before you begin, please make sure you have the following prerequisites installe
    | [AWS](https://docs.claudie.io/latest/input-manifest/providers/aws/)               | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
    | [Azure](https://docs.claudie.io/latest/input-manifest/providers/azure/)           | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
    | [GCP](https://docs.claudie.io/latest/input-manifest/providers/gcp/)               | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark: | :x:                |
-   | [OCI](https://docs.claudie.io/latest/input-manifest/providers/oci/)               | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark: | N/A                |
-   | [Hetzner](https://docs.claudie.io/latest/input-manifest/providers/hetzner/)       | :heavy_check_mark: | :heavy_check_mark: | N/A               | N/A                |
+   | [OCI](https://docs.claudie.io/latest/input-manifest/providers/oci/)               | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
+   | [Hetzner](https://docs.claudie.io/latest/input-manifest/providers/hetzner/)       | :heavy_check_mark: | :heavy_check_mark: | N/A               | :heavy_check_mark: |
    | [Cloudflare](https://docs.claudie.io/latest/input-manifest/providers/cloudflare/) | N/A                | :heavy_check_mark: |:heavy_check_mark: | N/A                |
-   | [Openstack](https://docs.claudie.io/latest/input-manifest/providers/openstack/)   | :heavy_check_mark: | N/A                | N/A               | N/A                |
+   | [Openstack](https://docs.claudie.io/latest/input-manifest/providers/openstack/)   | :heavy_check_mark: | N/A                | N/A               | :heavy_check_mark: |
 
-> **Note:** `N/A` indicates that the given feature is not applicable for the provider or has not been tested yet.
+> **Note:** `N/A` indicates that the given feature is not applicable for the provider.
 
 For adding support for other cloud providers, open an issue or propose a PR.
 


### PR DESCRIPTION
Fixes #1942

Adds a GPU support column to the supported providers table
to clearly indicate which providers support GPU nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a GPU column to the Supported Providers table with per-provider GPU indicators in the header and rows.
  * Updated each provider’s GPU status (supported, unsupported, or N/A) while preserving Node Pools, DNS, and DNS healthchecks information.
  * Clarified that "N/A" denotes non-applicable or untested GPU support and adjusted table formatting for alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->