### PR TITLE
fix: restore zone attribute to Hetzner pools in test sets

### DIFF
--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -32,6 +33,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         serverType: cpx22
         image: ubuntu-24.04
         storageDiskSize: 50

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -32,6 +33,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         serverType: cpx22
         image: ubuntu-24.04
         storageDiskSize: 50

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -32,6 +33,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         serverType: cpx22
         image: ubuntu-24.04
         storageDiskSize: 50

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -32,6 +33,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         serverType: cpx22
         image: ubuntu-24.04
         storageDiskSize: 50

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
@@ -27,6 +27,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
@@ -27,6 +27,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
@@ -27,6 +27,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/8.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/8.yaml
@@ -27,6 +27,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -40,6 +41,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         serverType: cpx22
         image: ubuntu-24.04
         storageDiskSize: 50

--- a/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
@@ -65,6 +65,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -100,6 +101,7 @@ spec:
         providerSpec:
           name: hetzner-2
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
@@ -29,6 +29,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/rolling-update/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/1.yaml
@@ -87,6 +87,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/rolling-update/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/2.yaml
@@ -87,6 +87,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
@@ -28,6 +28,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
@@ -28,6 +28,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
@@ -19,6 +19,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
@@ -47,6 +47,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
@@ -46,6 +46,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -82,6 +82,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -94,6 +95,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -82,6 +82,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 2
         serverType: cpx22
         image: ubuntu-24.04
@@ -94,6 +95,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -73,6 +73,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -104,6 +105,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -82,6 +82,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -113,6 +114,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 2
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -73,6 +73,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04
@@ -104,6 +105,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: fsn1
+          zone: fsn1-dc14
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set3/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/1.yaml
@@ -91,6 +91,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 2
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set3/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/2.yaml
@@ -28,6 +28,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set3/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/3.yaml
@@ -47,6 +47,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04

--- a/manifests/testing-framework/test-sets/test-set3/4.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/4.yaml
@@ -37,6 +37,7 @@ spec:
         providerSpec:
           name: hetzner-1
           region: nbg1
+          zone: nbg1-dc3
         count: 1
         serverType: cpx22
         image: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Restores the `zone` field to Hetzner node pool definitions in test sets
- Returning zones due to incompatibility with the v0.9.15 template which is currently used in the testing framework

## Zone mapping
- `region: fsn1` → `zone: fsn1-dc14`
- `region: nbg1` → `zone: nbg1-dc3`

## Test plan
- [ ] Verify test sets work with v0.9.15 template

🤖 Generated with [Claude Code](https://claude.com/claude-code)