### PR TITLE
docs: highlight GPU/AI workload capabilities on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ See more in How Claudie works sections.
 
 !!! tip "AI/ML Ready Infrastructure"
 
-    Claudie lets you build GPU clusters that span multiple cloud providers, combining cost-effective GPU instances from different vendors into a single Kubernetes cluster. Pair it with the NVIDIA GPU Operator and Cluster Autoscaler for production-ready AI/ML workloads.
+    Claudie lets you build GPU clusters that span multiple cloud providers, combining cost-effective GPU instances from different vendors into a single Kubernetes cluster. It comes with the NVIDIA GPU Operator and Cluster Autoscaler for scalable production-ready AI/ML workloads.
 
 ## What to do next
 


### PR DESCRIPTION
Add GPU & AI/ML use case, feature bullet, and AI/ML Ready Infrastructure callout to the landing page.

Closes #1963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GPU and AI/ML workload capabilities to documentation, including multi-cloud GPU node provisioning, NVIDIA GPU Operator support, and GPU-aware cluster scaling.
  * Introduced AI/ML Ready Infrastructure guidance for deploying multi-cloud GPU clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->