### PR TITLE
Add support for Exoscale provider

### DIFF
--- a/docs/CHANGELOG/changelog-0.10.x.md
+++ b/docs/CHANGELOG/changelog-0.10.x.md
@@ -27,6 +27,8 @@
 
 - DynamoDB was removed in favor of native locking supported by newer versions of OpenTofu which ship with Claudie `v0.10.x`
 
+- Support for [Exoscale](https://www.exoscale.com/)
+
 ## Deployment
 
 To deploy Claudie `v0.10.X`, please:
@@ -107,6 +109,8 @@ To further harden Claudie, you may want to deploy our pre-defined network polici
 - Claudie will no longer expect NGINX to be installed on existing clusters [#1980](https://github.com/berops/claudie/pull/1980)
 
 - Part of the reconciliation loop is to refresh the current state infrastructure periodically after no tasks have been identified [#1979](https://github.com/berops/claudie/pull/1979)
+
+- Added support for a new provider [Exoscale](https://www.exoscale.com/)
 
 ## Bug fixes
 


### PR DESCRIPTION
Added support for Exoscale as a new provider in Claudie v0.10.x.