### PR TITLE
chore: Bump cert-manager dependency in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Before you begin, please make sure you have the following prerequisites installe
 
 2. Claudie requires the installation of cert-manager in your Management Cluster. To install cert-manager, use the following command:
     ```bash
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
     ```
 
 

--- a/docs/creating-claudie-backup/creating-claudie-backup.md
+++ b/docs/creating-claudie-backup/creating-claudie-backup.md
@@ -82,7 +82,7 @@ We expect that your default `kubeconfig` points to the new Management Cluster, i
 1. Repeat the step to install Velero, but now on the new Management Cluster.
 2. Install cert manager to the new Management Cluster by executing:
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
 ```
 3. To restore the state that was stored in the S3 bucket execute
 ```bash

--- a/docs/getting-started/detailed-guide.md
+++ b/docs/getting-started/detailed-guide.md
@@ -54,7 +54,7 @@ This detailed guide for Claudie serves as a resource for providing an overview o
 4. One of the prerequisites is `cert-manager`, deploy it with the following command:
 
     ```bash
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
     ```
 
 5. Download latest Claudie release:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -139,7 +139,7 @@ Before you begin, please make sure you have the following prerequisites installe
 
 
 ```
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
 
 ```
 
@@ -383,7 +383,7 @@ For adding support for other cloud providers, open an issue or propose a PR.
 04. One of the prerequisites is `cert-manager`, deploy it with the following command:
 
     ```
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
 
     ```
 
@@ -4927,7 +4927,7 @@ We expect that your default `kubeconfig` points to the new Management Cluster, i
 2. Install cert manager to the new Management Cluster by executing:
 
 ```
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
 
 ```
 


### PR DESCRIPTION
This has been neglected for a long time...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated cert-manager installation version from v1.12.0 to v1.19.3 across all documentation resources, including the main README file, detailed getting-started guides, backup and recovery procedures, and comprehensive reference documentation. Users following standard installation instructions will now download and deploy this newer, updated version of cert-manager in their deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->