### PR TITLE
chore: fix v0.10.1 changelog description

### DIFF
--- a/docs/CHANGELOG/changelog-0.10.x.md
+++ b/docs/CHANGELOG/changelog-0.10.x.md
@@ -126,4 +126,4 @@ To further harden Claudie, you may want to deploy our pre-defined network polici
 
 ## Bug fixes
 
-- Fixed GCP autoscaler adapter crashing when the `zone` field is omitted from the InputManifest. The adapter now defaults to `{region}-b` for machine type lookups and uses aggregated list requests [#1989](https://github.com/berops/claudie/pull/1989)
+- Fixed GCP autoscaler adapter crashing when the `zone` field is omitted from the InputManifest. The adapter now uses aggregated list requests to query machine types across all zones [#1989](https://github.com/berops/claudie/pull/1989)


### PR DESCRIPTION
## Summary
- Fixes the v0.10.1 changelog entry for the GCP autoscaler adapter bug fix to accurately describe the change (uses aggregated list requests, not a region-b default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GCP autoscaler adapter now correctly queries machine types across all available zones instead of falling back to a single zone when zone information is omitted from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->