### PR TITLE
chore: Update Roadmap with features for v0.10.0

### DIFF
--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,9 +1,6 @@
 # Roadmap for Claudie
 
 Planned features (sorted by priority from highest):
-- [ ] Reconciliation loop
-- [ ] Event-based messaging for better parallelism
-- [ ] OpenTofu provider caching
 - [ ] Allow different OpenTofu template versions for a single provider
 
 Unplanned features (wishlist; talk to us for prioritization):
@@ -13,11 +10,18 @@ Unplanned features (wishlist; talk to us for prioritization):
 - [ ] Support for Spot & preemptible instances
 - [ ] Roadwarrior/Edge mode (on-prem node behind a NAT)
 
+v0.10.0:
+- [x] Reconciliation loop
+- [x] Event-based messaging for better parallelism
+- [x] OpenTofu provider caching
+
 v0.9.14:
 - [x] Support for OpenStack provider
 - [x] Support for OVH provider
+
 v0.9.0:
 - [x] Override for all OpenTofu templates
+
 v0.8.1:
 - [x] Support for more cloud providers
     - [x] OCI


### PR DESCRIPTION
Major features were delivered in `v0.10.0`. Update the roadmap accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap with v0.10.0 details, including reconciliation loop, event-based messaging improvements, and OpenTofu provider caching.
  * Expanded cloud provider support documentation across multiple versions.
  * Added v0.9.14 and v0.9.0 version entries to the roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->