### PR TITLE
chore: Reorganize docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
       - Sitemap: sitemap/sitemap.md
   - Guides:
       - Quick start: getting-started/get-started-using-claudie.md
-      - Detailed start: getting-started/detailed-guide.md
+      - Detailed guide: getting-started/detailed-guide.md
       - Use cases: use-cases/use-cases.md
       - Updating Claudie: update/update.md
       - Creating backups: creating-claudie-backup/creating-claudie-backup.md


### PR DESCRIPTION
Reorganize docs within chapters/categories.
Unify upper/lower-case titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized navigation: consolidated top-level “Guides” with quick start, detailed guide, use cases, updating, backups, GPU example, hardening, monitoring, HTTP proxy, Example InputManifest, and troubleshooting
  * Moved previous Guides and Reference content into a renamed top-level “Project” section (FAQ, version matrix, command cheat sheet, latency notes, roadmap, contributing, changelog)
  * Replaced “Example yaml file” with “External templates” and “Example InputManifest”
  * Standardized casing and item titles for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->