### PR TITLE
fix: deletion of zero sized nodepools

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/kuber
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/manager
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: fe5a65d-4071
+  newTag: c71fbb0-4077

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -82,6 +82,18 @@ func DeleteNodes(logger zerolog.Logger, tracker Tracker) {
 	}
 
 	if len(master) == 0 && len(worker) == 0 {
+		if d.KDeleteNodes.WithNodePool {
+			logger.
+				Info().
+				Msgf("Removing nodepool %q with 0 nodes", d.KDeleteNodes.Nodepool)
+
+			k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, d.KDeleteNodes.Nodepool)
+
+			update := tracker.Result.Update()
+			update.Kubernetes(k8s)
+			update.Commit()
+		}
+
 		return
 	}
 


### PR DESCRIPTION
If a nodepool was scheduled that had 0 nodes, the actual deletion of the nodepool from the current state would be skipped resulting in an infinite loop of scheduling its deletion. This PR adds an explicit deletion from the current state even if the nodepool is zero-sized if a deletion for it has been scheduled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure nodepool entries are removed from cluster configuration and the updated Kubernetes state is persisted when removing nodes and no masters/workers remain.
* **Chores**
  * Bumped container image tags for several components (including testing framework and core services) to a new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->