### PR TITLE
chore: update mongodb to 6.0

### DIFF
--- a/manifests/claudie/mongo/mongodb.yaml
+++ b/manifests/claudie/mongo/mongodb.yaml
@@ -26,7 +26,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/db
-          image: mongo:5
+          image: mongo:6
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
MongoDB needs to be updated always one major version at a time.

Thus this PR is only a single part of https://github.com/berops/claudie/issues/2051 which updates mongo from 5.0 to 6.0. Looking at the changes there were no incompatible changes that would affect claudie.

Since this will require manual steps the next claudie release needs to bump the minor version.
(Backups of Mongo will need to be done before upgrading)

After deploying the new version with updated mongodb the maintainer needs to:

1. Check if the version running in the primary replica is `6.0` via

```
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand({ buildInfo: 1 }).version"
```


2. Set the feature set of version 6.0
```
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand({ setFeatureCompatibilityVersion: '6.0' })"
```

This command must perform writes to an internal system collection. If for any reason the command does not complete successfully, you can safely retry the command as the operation is idempotent.

3. Verify the command successfully updated the feature set.

```
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })"
```


I have tested this locally and after the upgrade made changes to the an InputManifest and everything worked as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB to version 6 for improved stability and access to the latest database features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->