### PR TITLE
feat: add upgrade-lock label to skip node drain during rolling updates

### DIFF
--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -105,3 +105,40 @@ The same concept applies to changing the server type of a dynamic nodepool.
 ```
 
 When re-applied this will trigger a new workflow for the cluster that will result in the updated server type of the nodepool.
+
+## Protecting Stateful Workloads with the Upgrade-Lock Label
+
+When Claudie rolls out a new nodepool during an update, it drains the old nodes one-by-one before deleting them. For stateless workloads this is fine, but for StatefulSets with large datasets (e.g. MongoDB, PostgreSQL, Elasticsearch) replication to the newly created nodes can take longer than the 30-minute drain timeout. If Claudie force-deletes a node while replication is still in progress, the last healthy replica may be lost and data corruption can occur.
+
+Claudie cannot determine automatically when a StatefulSet has finished replicating — every stateful workload is different and there is no universal health API. Instead, Claudie hands control over to the operator via a **node label**: any node carrying the `claudie.io/upgrade-lock` label is **skipped** during the drain phase of a rolling update.
+
+### Workflow
+
+1. **Before triggering the update**, mark the nodes you want to protect:
+    ```bash
+    kubectl label node <node-name> claudie.io/upgrade-lock=true
+    ```
+    The value can be anything — Claudie only checks whether the label key is present.
+
+2. **Apply your updated InputManifest**. Claudie will:
+    - Provision the new nodes
+    - Drain and delete all old nodes that are **not** labeled
+    - Skip the labeled nodes and log `node <name> has upgrade-lock label, skipping drain`
+    - Keep the DELETE_NODES task in a retry loop, rechecking the label every ~25 seconds
+
+3. **Verify your workload is safe to move.** Check that your StatefulSet has fully replicated data to pods on the new nodes. Use whatever tool is appropriate for your workload (e.g. `mongosh rs.status()`, `pg_stat_replication`, cluster health APIs, etc.).
+
+4. **Remove the label when it is safe to proceed**:
+    ```bash
+    kubectl label node <node-name> claudie.io/upgrade-lock-
+    ```
+    Claudie's next retry (within ~30 seconds) will detect the removal, drain the node, and complete the rolling update.
+
+### Important notes
+
+- The label is a **coordination signal** only — it tells Claudie to wait. It does not affect pod scheduling on its own. If you also want to prevent new pods from landing on the locked node, apply your own `NoSchedule` taint independently.
+- The label is preserved across Claudie's reconciliation cycles. You can apply it before or during an update without it being removed by Claudie.
+- Claudie's retry loop runs indefinitely while the label is present — there is no timeout. Remember to remove the label when you are ready, otherwise the cluster build will never complete.
+- Log evidence to look for in the kuber service:
+    - `node <name> has upgrade-lock label, skipping drain` — the skip is working
+    - `nodes with claudie.io/upgrade-lock label skipped, waiting for operator to remove label` — Claudie is in the retry loop

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -124,7 +124,7 @@ Claudie cannot determine automatically when a StatefulSet has finished replicati
     - Provision the new nodes
     - Drain and delete all old nodes that are **not** labeled
     - Skip the labeled nodes and log `node <name> has upgrade-lock label, skipping drain`
-    - Keep the DELETE_NODES task in a retry loop, rechecking the label every ~25 seconds
+    - Keep the DELETE_NODES task in a retry loop, rechecking the label on each reconcile cycle
 
 3. **Verify your workload is safe to move.** Check that your StatefulSet has fully replicated data to pods on the new nodes. Use whatever tool is appropriate for your workload (e.g. `mongosh rs.status()`, `pg_stat_replication`, cluster health APIs, etc.).
 
@@ -132,7 +132,7 @@ Claudie cannot determine automatically when a StatefulSet has finished replicati
     ```bash
     kubectl label node <node-name> claudie.io/upgrade-lock-
     ```
-    Claudie's next retry (within ~30 seconds) will detect the removal, drain the node, and complete the rolling update.
+    Claudie's next reconcile cycle will detect the removal, drain the node, and complete the rolling update.
 
 ### Important notes
 

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -4,6 +4,7 @@ package kubectl
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -150,6 +151,9 @@ func (k *Kubectl) KubectlTaint(nodeName string, key, value, effect string) error
 }
 
 // KubectlNodeHasLabel checks whether the node has a label with the given key, regardless of value.
+// It fetches the full labels map as JSON and tests key presence in Go so that label keys with
+// dots and slashes are handled uniformly, and the check returns true even when the label value
+// is an empty string.
 func (k *Kubectl) KubectlNodeHasLabel(nodeName, labelKey string) (bool, error) {
 	arg, cleanup, err := k.getKubeconfig()
 	if err != nil {
@@ -157,15 +161,23 @@ func (k *Kubectl) KubectlNodeHasLabel(nodeName, labelKey string) (bool, error) {
 	}
 	defer cleanup()
 
-	command := fmt.Sprintf(
-		`kubectl get node %s -o jsonpath='{.metadata.labels.%s}' %s`,
-		nodeName, strings.ReplaceAll(labelKey, ".", `\.`), arg,
-	)
+	command := fmt.Sprintf(`kubectl get node %s -o json %s`, nodeName, arg)
 	out, err := k.runWithOutput(command)
 	if err != nil {
 		return false, err
 	}
-	return len(strings.TrimSpace(string(out))) > 0, nil
+
+	var node struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &node); err != nil {
+		return false, fmt.Errorf("failed to parse node %q labels: %w", nodeName, err)
+	}
+
+	_, ok := node.Metadata.Labels[labelKey]
+	return ok, nil
 }
 
 // KubectlDrain runs kubectl drain in k.Directory, on a specified node with flags --ignore-daemonsets --delete-emptydir-data

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -149,6 +149,25 @@ func (k *Kubectl) KubectlTaint(nodeName string, key, value, effect string) error
 	return k.run(command)
 }
 
+// KubectlNodeHasLabel checks whether the node has a label with the given key, regardless of value.
+func (k *Kubectl) KubectlNodeHasLabel(nodeName, labelKey string) (bool, error) {
+	arg, cleanup, err := k.getKubeconfig()
+	if err != nil {
+		return false, err
+	}
+	defer cleanup()
+
+	command := fmt.Sprintf(
+		`kubectl get node %s -o jsonpath='{.metadata.labels.%s}' %s`,
+		nodeName, strings.ReplaceAll(labelKey, ".", `\.`), arg,
+	)
+	out, err := k.runWithOutput(command)
+	if err != nil {
+		return false, err
+	}
+	return len(strings.TrimSpace(string(out))) > 0, nil
+}
+
 // KubectlDrain runs kubectl drain in k.Directory, on a specified node with flags --ignore-daemonsets --delete-emptydir-data
 // example: kubectl drain node1 -> k.KubectlDrain("node1")
 // If the timeout expires before the command finishes the [context.DeadlineExceeded] error is returned.

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/manager
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/kuber
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/manager
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/manager
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: d9754c7-4083
+  newTag: e40c0ac-4087

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ccc8651-4088
+  newTag: e5337ca-4089

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e40c0ac-4087
+  newTag: ccc8651-4088

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -23,7 +23,13 @@ const (
 	UnreachableNodesPingCount = clusters.PingRetryCount + 3
 
 	drainTimeout = 30 * time.Minute
+
+	upgradeLockLabelKey = "claudie.io/upgrade-lock"
 )
+
+// ErrUpgradeLocked is returned when one or more nodes were skipped during
+// drain because they have the claudie.io/upgrade-lock label set by the operator.
+var ErrUpgradeLocked = errors.New("nodes with claudie.io/upgrade-lock label skipped, waiting for operator to remove label")
 
 // etcdMemberList wraps parsed structures that are
 // needed from the output of the `etcdctl member list`
@@ -129,6 +135,7 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 		}
 	}
 	var errDel error
+	var locked bool
 
 	// Remove master nodes sequentially to minimise risk of faults in etcd
 	for _, master := range d.masterNodes {
@@ -136,6 +143,14 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 			logger.
 				Warn().
 				Msgf("Node with name %s not found in cluster", master.k8sName)
+			continue
+		}
+
+		if hasLock, err := kubectl.KubectlNodeHasLabel(master.k8sName, upgradeLockLabelKey); err != nil {
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, proceeding with drain", master.k8sName)
+		} else if hasLock {
+			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", master.k8sName)
+			locked = true
 			continue
 		}
 
@@ -205,6 +220,14 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 			logger.
 				Warn().
 				Msgf("Node with name %s not found in cluster", worker.k8sName)
+			continue
+		}
+
+		if hasLock, err := kubectl.KubectlNodeHasLabel(worker.k8sName, upgradeLockLabelKey); err != nil {
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, proceeding with drain", worker.k8sName)
+		} else if hasLock {
+			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", worker.k8sName)
+			locked = true
 			continue
 		}
 
@@ -280,6 +303,9 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 		}
 	}
 
+	if locked {
+		return errors.Join(errDel, ErrUpgradeLocked)
+	}
 	return errDel
 }
 

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -146,9 +146,15 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 			continue
 		}
 
-		if hasLock, err := kubectl.KubectlNodeHasLabel(master.k8sName, upgradeLockLabelKey); err != nil {
-			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, proceeding with drain", master.k8sName)
-		} else if hasLock {
+		hasLock, err := kubectl.KubectlNodeHasLabel(master.k8sName, upgradeLockLabelKey)
+		if err != nil {
+			// Fail closed: treat the node as locked so the task is retried
+			// instead of draining on a transient kubectl failure.
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", master.k8sName)
+			locked = true
+			continue
+		}
+		if hasLock {
 			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", master.k8sName)
 			locked = true
 			continue
@@ -223,9 +229,15 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 			continue
 		}
 
-		if hasLock, err := kubectl.KubectlNodeHasLabel(worker.k8sName, upgradeLockLabelKey); err != nil {
-			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, proceeding with drain", worker.k8sName)
-		} else if hasLock {
+		hasLock, err := kubectl.KubectlNodeHasLabel(worker.k8sName, upgradeLockLabelKey)
+		if err != nil {
+			// Fail closed: treat the node as locked so the task is retried
+			// instead of draining on a transient kubectl failure.
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", worker.k8sName)
+			locked = true
+			continue
+		}
+		if hasLock {
 			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", worker.k8sName)
 			locked = true
 			continue


### PR DESCRIPTION
## Summary

Adds an operator-controlled "pause button" for Claudie rolling updates. Any node labeled with `claudie.io/upgrade-lock` is skipped during the DELETE_NODES drain phase, and Claudie keeps retrying until the operator removes the label.

Closes #2021.

## Solution

When the operator applies the label `claudie.io/upgrade-lock` to a node, Claudie's DeleteNodes loop skips cordon/drain on that node, returns `ErrUpgradeLocked`, and relies on the existing task-retry mechanism to reschedule DELETE_NODES until the label is removed.

### Why a label and not a taint

The original design used a taint, but testing on a live cluster showed that Claudie's PATCH_NODES stage uses `"replace"` on `/spec/taints`, which wipes the entire taints array on every reconcile. The operator-applied taint never survived long enough for DELETE_NODES to see it.

Labels use a per-key JSON patch (`replace /metadata/labels/<key>`), so operator-applied labels are preserved across reconciles. Using a label also matches the semantics better: the upgrade-lock is a coordination signal with Claudie, not a scheduling rule. Operators who want additional scheduling protection can apply their own taints independently.

## Operator workflow

```bash
# Before triggering an update
kubectl label node <node-name> claudie.io/upgrade-lock=true

# Apply updated InputManifest
kubectl apply -f manifest.yaml

# Claudie drains unlabeled nodes, skips labeled ones, and retries
# Verify replication/health on your workload

# Release the node when safe
kubectl label node <node-name> claudie.io/upgrade-lock-
```

## Testing

End-to-end validated on a live Hetzner cluster (1 control-plane + 2 workers, template tag bumped v0.10.0 -> v0.11.0):

- Label survived all reconcile cycles (TERRAFORMER, ANSIBLER, KUBE_ELEVEN, PATCH_NODES)
- DELETE_NODES logged `node <name> has upgrade-lock label, skipping drain`
- `ErrUpgradeLocked` rescheduled the task, observed retries every ~25s
- Unlabeled peer worker was drained and deleted normally
- After removing the label, the next retry cleanly drained and deleted the locked node
- No cluster impact from the skip; DONE state reached after unlock

## Test plan

- [x] Builds clean (`go build ./...`)
- [x] End-to-end rolling update on live Hetzner cluster with one worker locked
- [x] Verified unlabeled peer drained, labeled peer skipped
- [x] Verified label removal triggers drain on next retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using an upgrade-lock node label: rollout behavior, expected logs, and operator steps to apply/remove the label.

* **New Features**
  * Nodes labeled with the upgrade-lock are skipped during drain/deletion and deferred for retry until the label is removed.

* **Chores**
  * Updated manifest image tags for multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->