### PR TITLE
fix: apply NAT hairpin workaround to OpenStack providers

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/manager
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/manager
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 1e48366-4093
+  newTag: 80c26c3-4096

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e5337ca-4089
+  newTag: 1e48366-4093

--- a/services/ansibler/ansible-playbooks/nat-hairpin-fix.yml
+++ b/services/ansibler/ansible-playbooks/nat-hairpin-fix.yml
@@ -3,7 +3,7 @@
   gather_facts: true
   become: true
   tasks:
-    - name: Add iptables DNAT for CloudRift peer nodes
+    - name: Add iptables DNAT for same-provider peer nodes
       ansible.builtin.iptables:
         table: nat
         chain: OUTPUT
@@ -11,7 +11,13 @@
         jump: DNAT
         to_destination: "{{ hostvars[item].ansible_default_ipv4.address }}"
       loop: "{{ groups['all'] | difference([inventory_hostname]) }}"
-      when: ansible_host.split('.')[0:3] | join('.') == hostvars[item].ansible_host.split('.')[0:3] | join('.')
+      when: hostvars[inventory_hostname].hairpin_group == hostvars[item].hairpin_group
+
+    - name: Ensure /etc/iptables directory exists
+      ansible.builtin.file:
+        path: /etc/iptables
+        state: directory
+        mode: "0755"
 
     - name: Save iptables rules
       ansible.builtin.shell: iptables-save > /etc/iptables/rules.v4

--- a/services/ansibler/internal/worker/service/task_install_vpn.go
+++ b/services/ansibler/internal/worker/service/task_install_vpn.go
@@ -20,9 +20,19 @@ import (
 )
 
 const (
-	wireguardPlaybook       = "../../ansible-playbooks/wireguard.yml"
-	cloudriftNATFixPlaybook = "../../ansible-playbooks/cloudrift-nat-fix.yml"
+	wireguardPlaybook     = "../../ansible-playbooks/wireguard.yml"
+	natHairpinFixPlaybook = "../../ansible-playbooks/nat-hairpin-fix.yml"
 )
+
+// hairpinNATProviders lists cloud providers whose same-project, floating-IP
+// traffic hairpins through a NAT gateway that can rewrite the source port,
+// breaking WireGuard tunnels between peers on the same network. The fix
+// (see fixHairpinNAT) installs local DNAT rules so peers reach each other
+// over private IPs instead of the public hairpin path.
+var hairpinNATProviders = map[string]struct{}{
+	"cloudrift": {},
+	"openstack": {},
+}
 
 type VPNInfo struct {
 	ClusterNetwork string
@@ -164,15 +174,15 @@ func installWireguardVPN(clusterID string, vpnInfo *VPNInfo, processLimit *semap
 		}
 	}
 
-	// Fix CloudRift NAT before WireGuard so that peer public IPs are
+	// Fix hairpin NAT before WireGuard so that peer public IPs are
 	// redirected to LAN IPs, allowing the WireGuard tunnel to establish
 	// and kubeadm join to reach the API server.
-	if err := fixCloudRiftNAT(vpnInfo, clusterID, clusterDirectory, processLimit); err != nil {
-		return fmt.Errorf("error while fixing CloudRift NAT for %s : %w", clusterDirectory, err)
+	if err := fixHairpinNAT(vpnInfo, clusterID, clusterDirectory, processLimit); err != nil {
+		return fmt.Errorf("error while fixing hairpin NAT for %s : %w", clusterDirectory, err)
 	}
 
-	// Regenerate the full inventory since fixCloudRiftNAT overwrites it
-	// with CloudRift-only nodes.
+	// Regenerate the full inventory since fixHairpinNAT overwrites it
+	// with hairpin-provider-only nodes.
 	if err := utils.GenerateInventoryFile(templates.AllNodesInventoryTemplate, clusterDirectory, data); err != nil {
 		return fmt.Errorf("error while recreating inventory file for %s : %w", clusterDirectory, err)
 	}
@@ -191,24 +201,30 @@ func installWireguardVPN(clusterID string, vpnInfo *VPNInfo, processLimit *semap
 	return nil
 }
 
-// fixCloudRiftNAT adds iptables OUTPUT DNAT rules on CloudRift nodes so that
-// peer public IPs are redirected to their LAN IPs (discovered via Ansible
-// gather_facts). This works around CloudRift's local gateway sending TCP RST
-// instead of hairpinning traffic between VMs on the same subnet. Must run
+// fixHairpinNAT adds iptables OUTPUT DNAT rules on nodes of providers whose
+// floating-IP hairpin path can rewrite the source port (see hairpinNATProviders),
+// so that peer public IPs are redirected to their LAN IPs (discovered via Ansible
+// gather_facts). This works around provider-side NAT behavior (CloudRift's local
+// gateway sending TCP RST, OpenStack Neutron's SNAT port randomization) that
+// otherwise breaks WireGuard tunnels between VMs on the same subnet. Must run
 // before WireGuard so that the tunnel endpoints resolve over the LAN, and
 // before KubeEleven so that kubeadm join can reach the API server.
-func fixCloudRiftNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, processLimit *semaphore.Weighted) error {
-	var cloudriftInfos []*NodepoolsInfo
+func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, processLimit *semaphore.Weighted) error {
+	var hairpinInfos []*NodepoolsInfo
 
 	for _, npi := range vpnInfo.NodepoolsInfos {
 		var dynPools []*spec.NodePool
 		for _, np := range npi.Nodepools.Dynamic {
-			if dyn := np.GetDynamicNodePool(); dyn != nil && dyn.Provider.CloudProviderName == "cloudrift" {
+			dyn := np.GetDynamicNodePool()
+			if dyn == nil {
+				continue
+			}
+			if _, ok := hairpinNATProviders[dyn.Provider.CloudProviderName]; ok {
 				dynPools = append(dynPools, np)
 			}
 		}
 		if len(dynPools) > 0 {
-			cloudriftInfos = append(cloudriftInfos, &NodepoolsInfo{
+			hairpinInfos = append(hairpinInfos, &NodepoolsInfo{
 				Nodepools:      NodePools{Dynamic: dynPools},
 				ClusterID:      npi.ClusterID,
 				ClusterNetwork: npi.ClusterNetwork,
@@ -216,9 +232,9 @@ func fixCloudRiftNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, proce
 		}
 	}
 
-	// Count total CloudRift nodes; need at least 2 for cross-node NAT to matter.
+	// Count total affected nodes; need at least 2 for cross-node NAT to matter.
 	var totalNodes int
-	for _, npi := range cloudriftInfos {
+	for _, npi := range hairpinInfos {
 		for _, np := range npi.Nodepools.Dynamic {
 			totalNodes += len(np.Nodes)
 		}
@@ -227,20 +243,20 @@ func fixCloudRiftNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, proce
 		return nil
 	}
 
-	data := AllNodesInventoryData{NodepoolsInfo: cloudriftInfos}
-	if err := utils.GenerateInventoryFile(templates.AllNodesInventoryTemplate, clusterDirectory, data); err != nil {
-		return fmt.Errorf("error while creating CloudRift NAT inventory file for %s : %w", clusterDirectory, err)
+	data := AllNodesInventoryData{NodepoolsInfo: hairpinInfos}
+	if err := utils.GenerateInventoryFile(templates.NatHairpinInventoryTemplate, clusterDirectory, data); err != nil {
+		return fmt.Errorf("error while creating hairpin NAT inventory file for %s : %w", clusterDirectory, err)
 	}
 
 	ansible := utils.Ansible{
-		Playbook:          cloudriftNATFixPlaybook,
+		Playbook:          natHairpinFixPlaybook,
 		Inventory:         utils.InventoryFileName,
 		Directory:         clusterDirectory,
 		SpawnProcessLimit: processLimit,
 	}
 
-	if err := ansible.RunAnsiblePlaybook(fmt.Sprintf("CloudRift NAT fix - %s", clusterID)); err != nil {
-		return fmt.Errorf("error while running CloudRift NAT fix ansible for %s : %w", clusterDirectory, err)
+	if err := ansible.RunAnsiblePlaybook(fmt.Sprintf("NAT hairpin fix - %s", clusterID)); err != nil {
+		return fmt.Errorf("error while running NAT hairpin fix ansible for %s : %w", clusterDirectory, err)
 	}
 
 	return nil

--- a/services/ansibler/internal/worker/service/task_install_vpn.go
+++ b/services/ansibler/internal/worker/service/task_install_vpn.go
@@ -242,7 +242,7 @@ func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, process
 			if dyn == nil {
 				continue
 			}
-			key := dyn.Provider.SpecName + "__" + npi.ClusterID
+			key := dyn.Provider.SpecName + "__" + npi.ClusterID + "__" + dyn.Region
 			groupCounts[key] += len(np.Nodes)
 		}
 	}

--- a/services/ansibler/internal/worker/service/task_install_vpn.go
+++ b/services/ansibler/internal/worker/service/task_install_vpn.go
@@ -216,9 +216,6 @@ func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, process
 		var dynPools []*spec.NodePool
 		for _, np := range npi.Nodepools.Dynamic {
 			dyn := np.GetDynamicNodePool()
-			if dyn == nil {
-				continue
-			}
 			if _, ok := hairpinNATProviders[dyn.Provider.CloudProviderName]; ok {
 				dynPools = append(dynPools, np)
 			}
@@ -239,9 +236,6 @@ func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, process
 	for _, npi := range hairpinInfos {
 		for _, np := range npi.Nodepools.Dynamic {
 			dyn := np.GetDynamicNodePool()
-			if dyn == nil {
-				continue
-			}
 			key := dyn.Provider.SpecName + "__" + npi.ClusterID + "__" + dyn.Region
 			groupCounts[key] += len(np.Nodes)
 		}

--- a/services/ansibler/internal/worker/service/task_install_vpn.go
+++ b/services/ansibler/internal/worker/service/task_install_vpn.go
@@ -232,14 +232,28 @@ func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, process
 		}
 	}
 
-	// Count total affected nodes; need at least 2 for cross-node NAT to matter.
-	var totalNodes int
+	// Count nodes per hairpin group (specName + clusterID) — DNAT rules only
+	// fire between peers in the same group, so the fix is only useful if at
+	// least one group has 2+ nodes.
+	groupCounts := make(map[string]int)
 	for _, npi := range hairpinInfos {
 		for _, np := range npi.Nodepools.Dynamic {
-			totalNodes += len(np.Nodes)
+			dyn := np.GetDynamicNodePool()
+			if dyn == nil {
+				continue
+			}
+			key := dyn.Provider.SpecName + "__" + npi.ClusterID
+			groupCounts[key] += len(np.Nodes)
 		}
 	}
-	if totalNodes < 2 {
+	hasPair := false
+	for _, n := range groupCounts {
+		if n >= 2 {
+			hasPair = true
+			break
+		}
+	}
+	if !hasPair {
 		return nil
 	}
 

--- a/services/ansibler/internal/worker/service/task_install_vpn.go
+++ b/services/ansibler/internal/worker/service/task_install_vpn.go
@@ -232,9 +232,9 @@ func fixHairpinNAT(vpnInfo *VPNInfo, clusterID, clusterDirectory string, process
 		}
 	}
 
-	// Count nodes per hairpin group (specName + clusterID) — DNAT rules only
-	// fire between peers in the same group, so the fix is only useful if at
-	// least one group has 2+ nodes.
+	// Count nodes per hairpin group (specName + clusterID + region). DNAT
+	// rules only fire between peers in the same group, so the fix is only
+	// useful if at least one group has 2+ nodes.
 	groupCounts := make(map[string]int)
 	for _, npi := range hairpinInfos {
 		for _, np := range npi.Nodepools.Dynamic {

--- a/services/ansibler/templates/nat-hairpin-inventory.goini
+++ b/services/ansibler/templates/nat-hairpin-inventory.goini
@@ -3,7 +3,7 @@
     {{- range $nodepool := $nodepoolInfo.Nodepools.Dynamic }}
         {{- $dyn := $nodepool.GetDynamicNodePool }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes" hairpin_group={{ $dyn.Provider.SpecName }}__{{ $nodepoolInfo.ClusterID }}
+{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes" hairpin_group={{ $dyn.Provider.SpecName }}__{{ $nodepoolInfo.ClusterID }}__{{ $dyn.Region }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/nat-hairpin-inventory.goini
+++ b/services/ansibler/templates/nat-hairpin-inventory.goini
@@ -1,0 +1,9 @@
+[dynamic]
+{{- range $nodepoolInfo := .NodepoolsInfo }}
+    {{- range $nodepool := $nodepoolInfo.Nodepools.Dynamic }}
+        {{- $dyn := $nodepool.GetDynamicNodePool }}
+        {{- range $node :=  $nodepool.Nodes }}
+{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes" hairpin_group={{ $dyn.Provider.SpecName }}__{{ $nodepoolInfo.ClusterID }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/ansibler/templates/templates.go
+++ b/services/ansibler/templates/templates.go
@@ -6,6 +6,9 @@ var (
 	//go:embed all-node-inventory.goini
 	AllNodesInventoryTemplate string
 
+	//go:embed nat-hairpin-inventory.goini
+	NatHairpinInventoryTemplate string
+
 	//go:embed deploy-envoy.goyml
 	EnvoyTemplate string
 


### PR DESCRIPTION
Closes #2064

## What this does

Extends the existing Cloudrift NAT hairpin fix to also cover OpenStack, so that WireGuard tunnels between OpenStack nodes in the same project stay stable instead of churning under Neutron's source-port randomization.

## How

- Renames `services/ansibler/ansible-playbooks/cloudrift-nat-fix.yml` to `nat-hairpin-fix.yml`.
- Adds a `file: state=directory` step to ensure `/etc/iptables` exists before `iptables-save` writes to it. Some OpenStack images (for example Cleura's Ubuntu 24.04) don't ship the directory.
- Renames `fixCloudRiftNAT` to `fixHairpinNAT` in `services/ansibler/internal/worker/service/task_install_vpn.go` and gates it on a provider set `{cloudrift, openstack}`.
- Matches peers by a new `hairpin_group` host variable with the shape `specName + clusterID + region`. DNAT rules are installed only between peers that share the same group, which is also the same private Neutron network in Claudie's OpenStack template. `region` is part of the key because one OpenStack provider can span multiple regions, each on its own private network with the same `10.0.0.0/16` CIDR, and cross-region LAN IPs are not mutually reachable.
- Adds a dedicated inventory template `nat-hairpin-inventory.goini` that emits the `hairpin_group` host var.
- Counts nodes per `hairpin_group` in the early-exit check, so the playbook runs only when at least one group has a peer pair.

No changes to `claudie-config` templates or any other service.

## Verification

Validated against two OpenStack providers (Cleura Fra1 and OVH GRA9 + SBG5) plus AWS, across four builds:

### 1. Cleura + AWS (7 nodes)

1 Cleura control + 2 AWS control + 3 Cleura compute + 1 AWS compute. Cleura floating IPs came from two `/24` pools in the same project (`89.46.80.0/24` for control, `91.123.203.0/24` for computes).

- Cluster reaches `DONE` in ~10 minutes, all 7 nodes `Ready`.
- `fixHairpinNAT` installs 3 DNAT rules on every Cleura node, including the control node that landed in a different `/24` from the computes.
- All 6 WireGuard peer endpoints on the Cleura control stay at `:51820` both at steady state and under 5 minutes of cross-node pod-to-pod traffic (DaemonSet nginx + busybox client loop). No randomized ports.
- 49 pod-to-pod curls from a client pod on the Cleura control to all 7 nginx pods succeed (100%).

### 2. OVH (2 nodes)

1 OVH control + 1 OVH compute in GRA9. Single-provider smoke test.

- Cluster reaches `DONE`, both nodes `Ready`.
- Bidirectional DNAT mesh installed (1 rule per node).
- WG peer endpoint stable at `:51820`, handshakes under 10 s.

### 3. OVH + Cleura + AWS (8 nodes, tri-cloud)

1 OVH control + 1 Cleura control + 1 AWS control + 4 OVH compute + 1 Cleura compute. OVH floating IPs came from two disjoint `/24` pools (`57.128.55.0/24` for `ovh-cmp-01`, `145.239.127.0/24` for the other 4 OVH nodes); OVH's `Ext-Net` in GRA9 has 62 subnets, so cross-pool allocation is common.

- Cluster reaches `DONE`, all 8 nodes `Ready`.
- Two independent DNAT meshes built in the same ansibler run, keyed by `hairpin_group`:
  - 5-node OVH mesh (4 rules per node)
  - 2-node Cleura mesh (1 rule per node)
- On `ovh-cmp-01` (the cross-pool node at `57.128.55.13`), all 4 DNAT rules to the `145.239.127.x` peers are installed.
- All 7 WG peer endpoints on `ovh-cmp-01` are at `:51820`, handshakes under 1 min.
- AWS node sees no DNAT rules, as expected.

### 4. OVH cross-region (4 nodes, GRA9 + SBG5)

One `ovh-1` provider, 1 control + 1 compute in GRA9, 2 compute in SBG5. Same provider, two regions, each with its own private `10.0.0.0/16` network.

- Cluster reaches `DONE`, all 4 nodes `Ready`.
- Playbook installs exactly 4 DNAT rule changes total, one per same-region peer direction.
- `iptables -t nat -S OUTPUT` on the GRA9 control shows exactly 1 DNAT rule (to the GRA9 compute's LAN IP) and zero rules for the two SBG5 peers.
- Same pattern on an SBG5 compute: 1 DNAT rule to the other SBG5 compute, zero for GRA9 peers.
- Cross-region WG peers use floating IPs as expected; the fix deliberately leaves cross-region traffic alone.

Cloudrift code path is untouched beyond the rename; the same playbook now serves three providers with provider-identity plus region scoping.

## Risk / rollback

- Cloudrift clusters are affected only by the rename plus the `/etc/iptables` mkdir step. The mkdir is idempotent and the file write was already conditional on the directory existing on Cloudrift images, so behavior there is unchanged.
- For OpenStack providers without the hairpin bug, the DNAT rules route same-provider peer traffic over the LAN instead of through the floating IP. Both paths work, so at worst this is a minor routing optimisation; no correctness regression expected.
- To revert, drop this commit - no migrations or state changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Generalized NAT hairpin fix that targets providers by provider/cluster/region groups and runs only where groups have 2+ nodes.
  * More accurate matching so DNAT rules apply only between hosts in the same hairpin group.
  * Added a generated inventory for hairpin-targeted hosts.

* **Bug Fixes**
  * Ensure firewall rules directory exists before saving iptables rules.

* **Chores**
  * Updated deployment image tags used when rendering manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->