### PR TITLE
feat: add historical counters for self canceling autoscaling

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -1,87 +1,71 @@
 namespace: claudie
 resources:
-- crd
-- ns.yaml
-- operator.yaml
-- terraformer.yaml
-- ansibler.yaml
-- kube-eleven.yaml
-- kuber.yaml
-- manager.yaml
-- cluster-rbac
-- mongo
-- minio
-- nats
+  - crd
+  - ns.yaml
+  - operator.yaml
+  - terraformer.yaml
+  - ansibler.yaml
+  - kube-eleven.yaml
+  - kuber.yaml
+  - manager.yaml
+  - cluster-rbac
+  - mongo
+  - minio
+  - nats
 
 # Alter ValidatingWebhookConfiguration and Certificate fields, so they will match the generated namespace
 replacements:
-- source:
-    fieldPath: metadata.name
-    kind: Namespace
-  targets:
-  - fieldPaths:
-    - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
-    - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: claudie-webhook
-- source:
-    fieldPath: metadata.name
-    kind: Namespace
-  targets:
-  - fieldPaths:
-    - metadata.annotations.cert-manager\.io/inject-ca-from
-    options:
-      delimiter: /
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: claudie-webhook
-  - fieldPaths:
-    - spec.dnsNames.*
-    options:
-      delimiter: .
-      index: 1
-    select:
-      kind: Certificate
-      name: claudie-webhook-certificate
+  - source:
+      fieldPath: metadata.name
+      kind: Namespace
+    targets:
+      - fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+          - webhooks.*.clientConfig.service.namespace
+        select:
+          kind: ValidatingWebhookConfiguration
+          name: claudie-webhook
+  - source:
+      fieldPath: metadata.name
+      kind: Namespace
+    targets:
+      - fieldPaths:
+          - metadata.annotations.cert-manager\.io/inject-ca-from
+        options:
+          delimiter: /
+        select:
+          kind: ValidatingWebhookConfiguration
+          name: claudie-webhook
+      - fieldPaths:
+          - spec.dnsNames.*
+        options:
+          delimiter: .
+          index: 1
+        select:
+          kind: Certificate
+          name: claudie-webhook-certificate
 
 configMapGenerator:
-- envs:
-  - .env
-  name: env
-  options:
-    labels:
-      app.kubernetes.io/part-of: claudie
+  - envs:
+      - .env
+    name: env
+    options:
+      labels:
+        app.kubernetes.io/part-of: claudie
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: ghcr.io/berops/claudie/ansibler
-<<<<<<< HEAD
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/kuber
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/manager
-  newTag: 24e565e-4105
-- name: ghcr.io/berops/claudie/terraformer
-  newTag: 24e565e-4105
-=======
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/kuber
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/manager
-  newTag: 4a5f28e-4103
-- name: ghcr.io/berops/claudie/terraformer
-  newTag: 4a5f28e-4103
->>>>>>> master
+  - name: ghcr.io/berops/claudie/ansibler
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/autoscaler-adapter
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/claudie-operator
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/kube-eleven
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/kuber
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/manager
+    newTag: 4a5f28e-4103
+  - name: ghcr.io/berops/claudie/terraformer
+    newTag: 4a5f28e-4103

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/manager
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/manager
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/manager
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/manager
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -1,71 +1,71 @@
 namespace: claudie
 resources:
-  - crd
-  - ns.yaml
-  - operator.yaml
-  - terraformer.yaml
-  - ansibler.yaml
-  - kube-eleven.yaml
-  - kuber.yaml
-  - manager.yaml
-  - cluster-rbac
-  - mongo
-  - minio
-  - nats
+- crd
+- ns.yaml
+- operator.yaml
+- terraformer.yaml
+- ansibler.yaml
+- kube-eleven.yaml
+- kuber.yaml
+- manager.yaml
+- cluster-rbac
+- mongo
+- minio
+- nats
 
 # Alter ValidatingWebhookConfiguration and Certificate fields, so they will match the generated namespace
 replacements:
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
-          - webhooks.*.clientConfig.service.namespace
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - metadata.annotations.cert-manager\.io/inject-ca-from
-        options:
-          delimiter: /
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-      - fieldPaths:
-          - spec.dnsNames.*
-        options:
-          delimiter: .
-          index: 1
-        select:
-          kind: Certificate
-          name: claudie-webhook-certificate
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - metadata.annotations.cert-manager\.io/inject-ca-from
+    options:
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+  - fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: .
+      index: 1
+    select:
+      kind: Certificate
+      name: claudie-webhook-certificate
 
 configMapGenerator:
-  - envs:
-      - .env
-    name: env
-    options:
-      labels:
-        app.kubernetes.io/part-of: claudie
+- envs:
+  - .env
+  name: env
+  options:
+    labels:
+      app.kubernetes.io/part-of: claudie
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: ghcr.io/berops/claudie/ansibler
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/autoscaler-adapter
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/claudie-operator
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/kube-eleven
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/kuber
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/manager
-    newTag: 4a5f28e-4103
-  - name: ghcr.io/berops/claudie/terraformer
-    newTag: 4a5f28e-4103
+- name: ghcr.io/berops/claudie/ansibler
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/autoscaler-adapter
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/claudie-operator
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/kube-eleven
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/kuber
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/manager
+  newTag: e3b6a75-4110
+- name: ghcr.io/berops/claudie/terraformer
+  newTag: e3b6a75-4110

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/manager
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -1,71 +1,71 @@
 namespace: claudie
 resources:
-  - crd
-  - ns.yaml
-  - operator.yaml
-  - terraformer.yaml
-  - ansibler.yaml
-  - kube-eleven.yaml
-  - kuber.yaml
-  - manager.yaml
-  - cluster-rbac
-  - mongo
-  - minio
-  - nats
+- crd
+- ns.yaml
+- operator.yaml
+- terraformer.yaml
+- ansibler.yaml
+- kube-eleven.yaml
+- kuber.yaml
+- manager.yaml
+- cluster-rbac
+- mongo
+- minio
+- nats
 
 # Alter ValidatingWebhookConfiguration and Certificate fields, so they will match the generated namespace
 replacements:
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
-          - webhooks.*.clientConfig.service.namespace
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - metadata.annotations.cert-manager\.io/inject-ca-from
-        options:
-          delimiter: /
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-      - fieldPaths:
-          - spec.dnsNames.*
-        options:
-          delimiter: .
-          index: 1
-        select:
-          kind: Certificate
-          name: claudie-webhook-certificate
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - metadata.annotations.cert-manager\.io/inject-ca-from
+    options:
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+  - fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: .
+      index: 1
+    select:
+      kind: Certificate
+      name: claudie-webhook-certificate
 
 configMapGenerator:
-  - envs:
-      - .env
-    name: env
-    options:
-      labels:
-        app.kubernetes.io/part-of: claudie
+- envs:
+  - .env
+  name: env
+  options:
+    labels:
+      app.kubernetes.io/part-of: claudie
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: ghcr.io/berops/claudie/ansibler
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/autoscaler-adapter
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/claudie-operator
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/kube-eleven
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/kuber
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/manager
-    newTag: 80c26c3-4096
-  - name: ghcr.io/berops/claudie/terraformer
-    newTag: 80c26c3-4096
+- name: ghcr.io/berops/claudie/ansibler
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/autoscaler-adapter
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/claudie-operator
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/kube-eleven
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/kuber
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/manager
+  newTag: 24e565e-4105
+- name: ghcr.io/berops/claudie/terraformer
+  newTag: 24e565e-4105

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/manager
-  newTag: 14dd509-4116
+  newTag: 9868502-4117
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 14dd509-4116
+  newTag: 9868502-4117

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e5337ca-4089
+  newTag: 28ae08f-4098

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 7aa048d-4114
+  newTag: 14dd509-4116

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -2,91 +2,91 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: claudie
 resources:
-  - testing-framework.yaml
+- testing-framework.yaml
 
 secretGenerator:
-  - files:
-      - test-sets/test-set1/1.yaml
-      - test-sets/test-set1/2.yaml
-    name: test-set1
-  - files:
-      - test-sets/test-set2/1.yaml
-      - test-sets/test-set2/2.yaml
-      - test-sets/test-set2/3.yaml
-    name: test-set2
-  - files:
-      - test-sets/test-set3/1.yaml
-      - test-sets/test-set3/2.yaml
-      - test-sets/test-set3/3.yaml
-      - test-sets/test-set3/4.yaml
-    name: test-set3
-  - files:
-      - test-sets/test-set4/1.yaml
-      - test-sets/test-set4/2.yaml
-      - test-sets/test-set4/3.yaml
-    name: test-set4
-  - files:
-      - test-sets/test-set5/1.yaml
-      - test-sets/test-set5/2.yaml
-      - test-sets/test-set5/3.yaml
-    name: test-set5
-  - files:
-      - test-sets/rolling-update/1.yaml
-      - test-sets/rolling-update/2.yaml
-    name: rolling-update
-  - files:
-      - test-sets/rolling-update-2/1.yaml
-      - test-sets/rolling-update-2/2.yaml
-    name: rolling-update-2
-  - files:
-      - test-sets/autoscaling-1/1.yaml
-      - test-sets/autoscaling-1/2.yaml
-      - test-sets/autoscaling-1/3.yaml
-    name: autoscaling-1
-  - files:
-      - test-sets/autoscaling-2/1.yaml
-      - test-sets/autoscaling-2/2.yaml
-    name: autoscaling-2
-  - files:
-      - test-sets/proxy-with-hetzner/1.yaml
-      - test-sets/proxy-with-hetzner/2.yaml
-      - test-sets/proxy-with-hetzner/3.yaml
-      - test-sets/proxy-with-hetzner/4.yaml
-      - test-sets/proxy-with-hetzner/5.yaml
-      - test-sets/proxy-with-hetzner/6.yaml
-      - test-sets/proxy-with-hetzner/7.yaml
-    name: proxy-with-hetzner
-  - files:
-      - test-sets/proxy-without-hetzner/1.yaml
-      - test-sets/proxy-without-hetzner/2.yaml
-      - test-sets/proxy-without-hetzner/3.yaml
-      - test-sets/proxy-without-hetzner/4.yaml
-      - test-sets/proxy-without-hetzner/5.yaml
-      - test-sets/proxy-without-hetzner/6.yaml
-      - test-sets/proxy-without-hetzner/7.yaml
-      - test-sets/proxy-without-hetzner/8.yaml
-      - test-sets/proxy-without-hetzner/9.yaml
-      - test-sets/proxy-without-hetzner/10.yaml
-    name: proxy-without-hetzner
-  - files:
-      - test-sets/succeeds-on-last-1/1.yaml
-      - test-sets/succeeds-on-last-1/2.yaml
-    name: succeeds-on-last-1
-  - files:
-      - test-sets/succeeds-on-last-2/1.yaml
-      - test-sets/succeeds-on-last-2/2.yaml
-      - test-sets/succeeds-on-last-2/3.yaml
-    name: succeeds-on-last-2
-  - files:
-      - test-sets/succeeds-on-last-3/1.yaml
-      - test-sets/succeeds-on-last-3/2.yaml
-    name: succeeds-on-last-3
-  - files:
-      - test-sets/succeeds-on-last-4/1.yaml
-      - test-sets/succeeds-on-last-4/2.yaml
-      - test-sets/succeeds-on-last-4/3.yaml
-    name: succeeds-on-last-4
+- files:
+  - test-sets/test-set1/1.yaml
+  - test-sets/test-set1/2.yaml
+  name: test-set1
+- files:
+  - test-sets/test-set2/1.yaml
+  - test-sets/test-set2/2.yaml
+  - test-sets/test-set2/3.yaml
+  name: test-set2
+- files:
+  - test-sets/test-set3/1.yaml
+  - test-sets/test-set3/2.yaml
+  - test-sets/test-set3/3.yaml
+  - test-sets/test-set3/4.yaml
+  name: test-set3
+- files:
+  - test-sets/test-set4/1.yaml
+  - test-sets/test-set4/2.yaml
+  - test-sets/test-set4/3.yaml
+  name: test-set4
+- files:
+  - test-sets/test-set5/1.yaml
+  - test-sets/test-set5/2.yaml
+  - test-sets/test-set5/3.yaml
+  name: test-set5
+- files:
+  - test-sets/rolling-update/1.yaml
+  - test-sets/rolling-update/2.yaml
+  name: rolling-update
+- files:
+  - test-sets/rolling-update-2/1.yaml
+  - test-sets/rolling-update-2/2.yaml
+  name: rolling-update-2
+- files:
+  - test-sets/autoscaling-1/1.yaml
+  - test-sets/autoscaling-1/2.yaml
+  - test-sets/autoscaling-1/3.yaml
+  name: autoscaling-1
+- files:
+  - test-sets/autoscaling-2/1.yaml
+  - test-sets/autoscaling-2/2.yaml
+  name: autoscaling-2
+- files:
+  - test-sets/proxy-with-hetzner/1.yaml
+  - test-sets/proxy-with-hetzner/2.yaml
+  - test-sets/proxy-with-hetzner/3.yaml
+  - test-sets/proxy-with-hetzner/4.yaml
+  - test-sets/proxy-with-hetzner/5.yaml
+  - test-sets/proxy-with-hetzner/6.yaml
+  - test-sets/proxy-with-hetzner/7.yaml
+  name: proxy-with-hetzner
+- files:
+  - test-sets/proxy-without-hetzner/1.yaml
+  - test-sets/proxy-without-hetzner/2.yaml
+  - test-sets/proxy-without-hetzner/3.yaml
+  - test-sets/proxy-without-hetzner/4.yaml
+  - test-sets/proxy-without-hetzner/5.yaml
+  - test-sets/proxy-without-hetzner/6.yaml
+  - test-sets/proxy-without-hetzner/7.yaml
+  - test-sets/proxy-without-hetzner/8.yaml
+  - test-sets/proxy-without-hetzner/9.yaml
+  - test-sets/proxy-without-hetzner/10.yaml
+  name: proxy-without-hetzner
+- files:
+  - test-sets/succeeds-on-last-1/1.yaml
+  - test-sets/succeeds-on-last-1/2.yaml
+  name: succeeds-on-last-1
+- files:
+  - test-sets/succeeds-on-last-2/1.yaml
+  - test-sets/succeeds-on-last-2/2.yaml
+  - test-sets/succeeds-on-last-2/3.yaml
+  name: succeeds-on-last-2
+- files:
+  - test-sets/succeeds-on-last-3/1.yaml
+  - test-sets/succeeds-on-last-3/2.yaml
+  name: succeeds-on-last-3
+- files:
+  - test-sets/succeeds-on-last-4/1.yaml
+  - test-sets/succeeds-on-last-4/2.yaml
+  - test-sets/succeeds-on-last-4/3.yaml
+  name: succeeds-on-last-4
 
 images:
-  - name: ghcr.io/berops/claudie/testing-framework
-    newTag: 4a5f28e-4103
+- name: ghcr.io/berops/claudie/testing-framework
+  newTag: e3b6a75-4110

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 14dd509-4116
+  newTag: 9868502-4117

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 28ae08f-4098
+  newTag: f3e82c7-4101

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -2,91 +2,91 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: claudie
 resources:
-  - testing-framework.yaml
+- testing-framework.yaml
 
 secretGenerator:
-  - files:
-      - test-sets/test-set1/1.yaml
-      - test-sets/test-set1/2.yaml
-    name: test-set1
-  - files:
-      - test-sets/test-set2/1.yaml
-      - test-sets/test-set2/2.yaml
-      - test-sets/test-set2/3.yaml
-    name: test-set2
-  - files:
-      - test-sets/test-set3/1.yaml
-      - test-sets/test-set3/2.yaml
-      - test-sets/test-set3/3.yaml
-      - test-sets/test-set3/4.yaml
-    name: test-set3
-  - files:
-      - test-sets/test-set4/1.yaml
-      - test-sets/test-set4/2.yaml
-      - test-sets/test-set4/3.yaml
-    name: test-set4
-  - files:
-      - test-sets/test-set5/1.yaml
-      - test-sets/test-set5/2.yaml
-      - test-sets/test-set5/3.yaml
-    name: test-set5
-  - files:
-      - test-sets/rolling-update/1.yaml
-      - test-sets/rolling-update/2.yaml
-    name: rolling-update
-  - files:
-      - test-sets/rolling-update-2/1.yaml
-      - test-sets/rolling-update-2/2.yaml
-    name: rolling-update-2
-  - files:
-      - test-sets/autoscaling-1/1.yaml
-      - test-sets/autoscaling-1/2.yaml
-      - test-sets/autoscaling-1/3.yaml
-    name: autoscaling-1
-  - files:
-      - test-sets/autoscaling-2/1.yaml
-      - test-sets/autoscaling-2/2.yaml
-    name: autoscaling-2
-  - files:
-      - test-sets/proxy-with-hetzner/1.yaml
-      - test-sets/proxy-with-hetzner/2.yaml
-      - test-sets/proxy-with-hetzner/3.yaml
-      - test-sets/proxy-with-hetzner/4.yaml
-      - test-sets/proxy-with-hetzner/5.yaml
-      - test-sets/proxy-with-hetzner/6.yaml
-      - test-sets/proxy-with-hetzner/7.yaml
-    name: proxy-with-hetzner
-  - files:
-      - test-sets/proxy-without-hetzner/1.yaml
-      - test-sets/proxy-without-hetzner/2.yaml
-      - test-sets/proxy-without-hetzner/3.yaml
-      - test-sets/proxy-without-hetzner/4.yaml
-      - test-sets/proxy-without-hetzner/5.yaml
-      - test-sets/proxy-without-hetzner/6.yaml
-      - test-sets/proxy-without-hetzner/7.yaml
-      - test-sets/proxy-without-hetzner/8.yaml
-      - test-sets/proxy-without-hetzner/9.yaml
-      - test-sets/proxy-without-hetzner/10.yaml
-    name: proxy-without-hetzner
-  - files:
-      - test-sets/succeeds-on-last-1/1.yaml
-      - test-sets/succeeds-on-last-1/2.yaml
-    name: succeeds-on-last-1
-  - files:
-      - test-sets/succeeds-on-last-2/1.yaml
-      - test-sets/succeeds-on-last-2/2.yaml
-      - test-sets/succeeds-on-last-2/3.yaml
-    name: succeeds-on-last-2
-  - files:
-      - test-sets/succeeds-on-last-3/1.yaml
-      - test-sets/succeeds-on-last-3/2.yaml
-    name: succeeds-on-last-3
-  - files:
-      - test-sets/succeeds-on-last-4/1.yaml
-      - test-sets/succeeds-on-last-4/2.yaml
-      - test-sets/succeeds-on-last-4/3.yaml
-    name: succeeds-on-last-4
+- files:
+  - test-sets/test-set1/1.yaml
+  - test-sets/test-set1/2.yaml
+  name: test-set1
+- files:
+  - test-sets/test-set2/1.yaml
+  - test-sets/test-set2/2.yaml
+  - test-sets/test-set2/3.yaml
+  name: test-set2
+- files:
+  - test-sets/test-set3/1.yaml
+  - test-sets/test-set3/2.yaml
+  - test-sets/test-set3/3.yaml
+  - test-sets/test-set3/4.yaml
+  name: test-set3
+- files:
+  - test-sets/test-set4/1.yaml
+  - test-sets/test-set4/2.yaml
+  - test-sets/test-set4/3.yaml
+  name: test-set4
+- files:
+  - test-sets/test-set5/1.yaml
+  - test-sets/test-set5/2.yaml
+  - test-sets/test-set5/3.yaml
+  name: test-set5
+- files:
+  - test-sets/rolling-update/1.yaml
+  - test-sets/rolling-update/2.yaml
+  name: rolling-update
+- files:
+  - test-sets/rolling-update-2/1.yaml
+  - test-sets/rolling-update-2/2.yaml
+  name: rolling-update-2
+- files:
+  - test-sets/autoscaling-1/1.yaml
+  - test-sets/autoscaling-1/2.yaml
+  - test-sets/autoscaling-1/3.yaml
+  name: autoscaling-1
+- files:
+  - test-sets/autoscaling-2/1.yaml
+  - test-sets/autoscaling-2/2.yaml
+  name: autoscaling-2
+- files:
+  - test-sets/proxy-with-hetzner/1.yaml
+  - test-sets/proxy-with-hetzner/2.yaml
+  - test-sets/proxy-with-hetzner/3.yaml
+  - test-sets/proxy-with-hetzner/4.yaml
+  - test-sets/proxy-with-hetzner/5.yaml
+  - test-sets/proxy-with-hetzner/6.yaml
+  - test-sets/proxy-with-hetzner/7.yaml
+  name: proxy-with-hetzner
+- files:
+  - test-sets/proxy-without-hetzner/1.yaml
+  - test-sets/proxy-without-hetzner/2.yaml
+  - test-sets/proxy-without-hetzner/3.yaml
+  - test-sets/proxy-without-hetzner/4.yaml
+  - test-sets/proxy-without-hetzner/5.yaml
+  - test-sets/proxy-without-hetzner/6.yaml
+  - test-sets/proxy-without-hetzner/7.yaml
+  - test-sets/proxy-without-hetzner/8.yaml
+  - test-sets/proxy-without-hetzner/9.yaml
+  - test-sets/proxy-without-hetzner/10.yaml
+  name: proxy-without-hetzner
+- files:
+  - test-sets/succeeds-on-last-1/1.yaml
+  - test-sets/succeeds-on-last-1/2.yaml
+  name: succeeds-on-last-1
+- files:
+  - test-sets/succeeds-on-last-2/1.yaml
+  - test-sets/succeeds-on-last-2/2.yaml
+  - test-sets/succeeds-on-last-2/3.yaml
+  name: succeeds-on-last-2
+- files:
+  - test-sets/succeeds-on-last-3/1.yaml
+  - test-sets/succeeds-on-last-3/2.yaml
+  name: succeeds-on-last-3
+- files:
+  - test-sets/succeeds-on-last-4/1.yaml
+  - test-sets/succeeds-on-last-4/2.yaml
+  - test-sets/succeeds-on-last-4/3.yaml
+  name: succeeds-on-last-4
 
 images:
-  - name: ghcr.io/berops/claudie/testing-framework
-    newTag: 80c26c3-4096
+- name: ghcr.io/berops/claudie/testing-framework
+  newTag: 24e565e-4105

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -2,95 +2,91 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: claudie
 resources:
-- testing-framework.yaml
+  - testing-framework.yaml
 
 secretGenerator:
-- files:
-  - test-sets/test-set1/1.yaml
-  - test-sets/test-set1/2.yaml
-  name: test-set1
-- files:
-  - test-sets/test-set2/1.yaml
-  - test-sets/test-set2/2.yaml
-  - test-sets/test-set2/3.yaml
-  name: test-set2
-- files:
-  - test-sets/test-set3/1.yaml
-  - test-sets/test-set3/2.yaml
-  - test-sets/test-set3/3.yaml
-  - test-sets/test-set3/4.yaml
-  name: test-set3
-- files:
-  - test-sets/test-set4/1.yaml
-  - test-sets/test-set4/2.yaml
-  - test-sets/test-set4/3.yaml
-  name: test-set4
-- files:
-  - test-sets/test-set5/1.yaml
-  - test-sets/test-set5/2.yaml
-  - test-sets/test-set5/3.yaml
-  name: test-set5
-- files:
-  - test-sets/rolling-update/1.yaml
-  - test-sets/rolling-update/2.yaml
-  name: rolling-update
-- files:
-  - test-sets/rolling-update-2/1.yaml
-  - test-sets/rolling-update-2/2.yaml
-  name: rolling-update-2
-- files:
-  - test-sets/autoscaling-1/1.yaml
-  - test-sets/autoscaling-1/2.yaml
-  - test-sets/autoscaling-1/3.yaml
-  name: autoscaling-1
-- files:
-  - test-sets/autoscaling-2/1.yaml
-  - test-sets/autoscaling-2/2.yaml
-  name: autoscaling-2
-- files:
-  - test-sets/proxy-with-hetzner/1.yaml
-  - test-sets/proxy-with-hetzner/2.yaml
-  - test-sets/proxy-with-hetzner/3.yaml
-  - test-sets/proxy-with-hetzner/4.yaml
-  - test-sets/proxy-with-hetzner/5.yaml
-  - test-sets/proxy-with-hetzner/6.yaml
-  - test-sets/proxy-with-hetzner/7.yaml
-  name: proxy-with-hetzner
-- files:
-  - test-sets/proxy-without-hetzner/1.yaml
-  - test-sets/proxy-without-hetzner/2.yaml
-  - test-sets/proxy-without-hetzner/3.yaml
-  - test-sets/proxy-without-hetzner/4.yaml
-  - test-sets/proxy-without-hetzner/5.yaml
-  - test-sets/proxy-without-hetzner/6.yaml
-  - test-sets/proxy-without-hetzner/7.yaml
-  - test-sets/proxy-without-hetzner/8.yaml
-  - test-sets/proxy-without-hetzner/9.yaml
-  - test-sets/proxy-without-hetzner/10.yaml
-  name: proxy-without-hetzner
-- files:
-  - test-sets/succeeds-on-last-1/1.yaml
-  - test-sets/succeeds-on-last-1/2.yaml
-  name: succeeds-on-last-1
-- files:
-  - test-sets/succeeds-on-last-2/1.yaml
-  - test-sets/succeeds-on-last-2/2.yaml
-  - test-sets/succeeds-on-last-2/3.yaml
-  name: succeeds-on-last-2
-- files:
-  - test-sets/succeeds-on-last-3/1.yaml
-  - test-sets/succeeds-on-last-3/2.yaml
-  name: succeeds-on-last-3
-- files:
-  - test-sets/succeeds-on-last-4/1.yaml
-  - test-sets/succeeds-on-last-4/2.yaml
-  - test-sets/succeeds-on-last-4/3.yaml
-  name: succeeds-on-last-4
+  - files:
+      - test-sets/test-set1/1.yaml
+      - test-sets/test-set1/2.yaml
+    name: test-set1
+  - files:
+      - test-sets/test-set2/1.yaml
+      - test-sets/test-set2/2.yaml
+      - test-sets/test-set2/3.yaml
+    name: test-set2
+  - files:
+      - test-sets/test-set3/1.yaml
+      - test-sets/test-set3/2.yaml
+      - test-sets/test-set3/3.yaml
+      - test-sets/test-set3/4.yaml
+    name: test-set3
+  - files:
+      - test-sets/test-set4/1.yaml
+      - test-sets/test-set4/2.yaml
+      - test-sets/test-set4/3.yaml
+    name: test-set4
+  - files:
+      - test-sets/test-set5/1.yaml
+      - test-sets/test-set5/2.yaml
+      - test-sets/test-set5/3.yaml
+    name: test-set5
+  - files:
+      - test-sets/rolling-update/1.yaml
+      - test-sets/rolling-update/2.yaml
+    name: rolling-update
+  - files:
+      - test-sets/rolling-update-2/1.yaml
+      - test-sets/rolling-update-2/2.yaml
+    name: rolling-update-2
+  - files:
+      - test-sets/autoscaling-1/1.yaml
+      - test-sets/autoscaling-1/2.yaml
+      - test-sets/autoscaling-1/3.yaml
+    name: autoscaling-1
+  - files:
+      - test-sets/autoscaling-2/1.yaml
+      - test-sets/autoscaling-2/2.yaml
+    name: autoscaling-2
+  - files:
+      - test-sets/proxy-with-hetzner/1.yaml
+      - test-sets/proxy-with-hetzner/2.yaml
+      - test-sets/proxy-with-hetzner/3.yaml
+      - test-sets/proxy-with-hetzner/4.yaml
+      - test-sets/proxy-with-hetzner/5.yaml
+      - test-sets/proxy-with-hetzner/6.yaml
+      - test-sets/proxy-with-hetzner/7.yaml
+    name: proxy-with-hetzner
+  - files:
+      - test-sets/proxy-without-hetzner/1.yaml
+      - test-sets/proxy-without-hetzner/2.yaml
+      - test-sets/proxy-without-hetzner/3.yaml
+      - test-sets/proxy-without-hetzner/4.yaml
+      - test-sets/proxy-without-hetzner/5.yaml
+      - test-sets/proxy-without-hetzner/6.yaml
+      - test-sets/proxy-without-hetzner/7.yaml
+      - test-sets/proxy-without-hetzner/8.yaml
+      - test-sets/proxy-without-hetzner/9.yaml
+      - test-sets/proxy-without-hetzner/10.yaml
+    name: proxy-without-hetzner
+  - files:
+      - test-sets/succeeds-on-last-1/1.yaml
+      - test-sets/succeeds-on-last-1/2.yaml
+    name: succeeds-on-last-1
+  - files:
+      - test-sets/succeeds-on-last-2/1.yaml
+      - test-sets/succeeds-on-last-2/2.yaml
+      - test-sets/succeeds-on-last-2/3.yaml
+    name: succeeds-on-last-2
+  - files:
+      - test-sets/succeeds-on-last-3/1.yaml
+      - test-sets/succeeds-on-last-3/2.yaml
+    name: succeeds-on-last-3
+  - files:
+      - test-sets/succeeds-on-last-4/1.yaml
+      - test-sets/succeeds-on-last-4/2.yaml
+      - test-sets/succeeds-on-last-4/3.yaml
+    name: succeeds-on-last-4
 
 images:
-- name: ghcr.io/berops/claudie/testing-framework
-<<<<<<< HEAD
-  newTag: 24e565e-4105
-=======
-  newTag: 4a5f28e-4103
->>>>>>> master
+  - name: ghcr.io/berops/claudie/testing-framework
+    newTag: 4a5f28e-4103

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 4e7008f-4112
+  newTag: 7aa048d-4114

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e3b6a75-4110
+  newTag: 4e7008f-4112

--- a/proto/pb/spec/manifest.pb.go
+++ b/proto/pb/spec/manifest.pb.go
@@ -299,7 +299,7 @@ func (x Workflow_Status) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Workflow_Status.Descriptor instead.
 func (Workflow_Status) EnumDescriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{7, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{8, 0}
 }
 
 type TaskResult_Error_Kind int32
@@ -345,7 +345,7 @@ func (x TaskResult_Error_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use TaskResult_Error_Kind.Descriptor instead.
 func (TaskResult_Error_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20, 0, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21, 0, 0}
 }
 
 // Config holds data for a single manifest.
@@ -498,18 +498,63 @@ func (x *Manifest) GetState() Manifest_State {
 	return Manifest_Pending
 }
 
+type Counters struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	K8SNodePoolScaleUpFailed map[string]int64       `protobuf:"bytes,1,rep,name=k8sNodePoolScaleUpFailed,proto3" json:"k8sNodePoolScaleUpFailed,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *Counters) Reset() {
+	*x = Counters{}
+	mi := &file_spec_manifest_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Counters) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Counters) ProtoMessage() {}
+
+func (x *Counters) ProtoReflect() protoreflect.Message {
+	mi := &file_spec_manifest_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Counters.ProtoReflect.Descriptor instead.
+func (*Counters) Descriptor() ([]byte, []int) {
+	return file_spec_manifest_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *Counters) GetK8SNodePoolScaleUpFailed() map[string]int64 {
+	if x != nil {
+		return x.K8SNodePoolScaleUpFailed
+	}
+	return nil
+}
+
 type ClusterState struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Current       *Clusters              `protobuf:"bytes,1,opt,name=current,proto3" json:"current,omitempty"`
 	State         *Workflow              `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
 	InFlight      *TaskEvent             `protobuf:"bytes,5,opt,name=inFlight,proto3" json:"inFlight,omitempty"`
+	Counters      *Counters              `protobuf:"bytes,6,opt,name=counters,proto3" json:"counters,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ClusterState) Reset() {
 	*x = ClusterState{}
-	mi := &file_spec_manifest_proto_msgTypes[2]
+	mi := &file_spec_manifest_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -521,7 +566,7 @@ func (x *ClusterState) String() string {
 func (*ClusterState) ProtoMessage() {}
 
 func (x *ClusterState) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[2]
+	mi := &file_spec_manifest_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -534,7 +579,7 @@ func (x *ClusterState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterState.ProtoReflect.Descriptor instead.
 func (*ClusterState) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{2}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ClusterState) GetCurrent() *Clusters {
@@ -558,6 +603,13 @@ func (x *ClusterState) GetInFlight() *TaskEvent {
 	return nil
 }
 
+func (x *ClusterState) GetCounters() *Counters {
+	if x != nil {
+		return x.Counters
+	}
+	return nil
+}
+
 type Clusters struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	K8S           *K8Scluster            `protobuf:"bytes,1,opt,name=k8s,proto3" json:"k8s,omitempty"`
@@ -568,7 +620,7 @@ type Clusters struct {
 
 func (x *Clusters) Reset() {
 	*x = Clusters{}
-	mi := &file_spec_manifest_proto_msgTypes[3]
+	mi := &file_spec_manifest_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -580,7 +632,7 @@ func (x *Clusters) String() string {
 func (*Clusters) ProtoMessage() {}
 
 func (x *Clusters) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[3]
+	mi := &file_spec_manifest_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -593,7 +645,7 @@ func (x *Clusters) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Clusters.ProtoReflect.Descriptor instead.
 func (*Clusters) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{3}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Clusters) GetK8S() *K8Scluster {
@@ -619,7 +671,7 @@ type LoadBalancers struct {
 
 func (x *LoadBalancers) Reset() {
 	*x = LoadBalancers{}
-	mi := &file_spec_manifest_proto_msgTypes[4]
+	mi := &file_spec_manifest_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -631,7 +683,7 @@ func (x *LoadBalancers) String() string {
 func (*LoadBalancers) ProtoMessage() {}
 
 func (x *LoadBalancers) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[4]
+	mi := &file_spec_manifest_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -644,7 +696,7 @@ func (x *LoadBalancers) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadBalancers.ProtoReflect.Descriptor instead.
 func (*LoadBalancers) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{4}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *LoadBalancers) GetClusters() []*LBcluster {
@@ -666,7 +718,7 @@ type KubernetesContext struct {
 
 func (x *KubernetesContext) Reset() {
 	*x = KubernetesContext{}
-	mi := &file_spec_manifest_proto_msgTypes[5]
+	mi := &file_spec_manifest_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -678,7 +730,7 @@ func (x *KubernetesContext) String() string {
 func (*KubernetesContext) ProtoMessage() {}
 
 func (x *KubernetesContext) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[5]
+	mi := &file_spec_manifest_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -691,7 +743,7 @@ func (x *KubernetesContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubernetesContext.ProtoReflect.Descriptor instead.
 func (*KubernetesContext) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{5}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *KubernetesContext) GetName() string {
@@ -720,7 +772,7 @@ type FinishedWorkflow struct {
 
 func (x *FinishedWorkflow) Reset() {
 	*x = FinishedWorkflow{}
-	mi := &file_spec_manifest_proto_msgTypes[6]
+	mi := &file_spec_manifest_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -732,7 +784,7 @@ func (x *FinishedWorkflow) String() string {
 func (*FinishedWorkflow) ProtoMessage() {}
 
 func (x *FinishedWorkflow) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[6]
+	mi := &file_spec_manifest_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -745,7 +797,7 @@ func (x *FinishedWorkflow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinishedWorkflow.ProtoReflect.Descriptor instead.
 func (*FinishedWorkflow) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{6}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *FinishedWorkflow) GetStatus() Workflow_Status {
@@ -794,7 +846,7 @@ type Workflow struct {
 
 func (x *Workflow) Reset() {
 	*x = Workflow{}
-	mi := &file_spec_manifest_proto_msgTypes[7]
+	mi := &file_spec_manifest_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -806,7 +858,7 @@ func (x *Workflow) String() string {
 func (*Workflow) ProtoMessage() {}
 
 func (x *Workflow) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[7]
+	mi := &file_spec_manifest_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -819,7 +871,7 @@ func (x *Workflow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Workflow.ProtoReflect.Descriptor instead.
 func (*Workflow) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{7}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Workflow) GetStatus() Workflow_Status {
@@ -869,7 +921,7 @@ type K8Scluster struct {
 
 func (x *K8Scluster) Reset() {
 	*x = K8Scluster{}
-	mi := &file_spec_manifest_proto_msgTypes[8]
+	mi := &file_spec_manifest_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -881,7 +933,7 @@ func (x *K8Scluster) String() string {
 func (*K8Scluster) ProtoMessage() {}
 
 func (x *K8Scluster) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[8]
+	mi := &file_spec_manifest_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -894,7 +946,7 @@ func (x *K8Scluster) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use K8Scluster.ProtoReflect.Descriptor instead.
 func (*K8Scluster) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{8}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *K8Scluster) GetClusterInfo() *ClusterInfo {
@@ -957,7 +1009,7 @@ type LBcluster struct {
 
 func (x *LBcluster) Reset() {
 	*x = LBcluster{}
-	mi := &file_spec_manifest_proto_msgTypes[9]
+	mi := &file_spec_manifest_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -969,7 +1021,7 @@ func (x *LBcluster) String() string {
 func (*LBcluster) ProtoMessage() {}
 
 func (x *LBcluster) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[9]
+	mi := &file_spec_manifest_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -982,7 +1034,7 @@ func (x *LBcluster) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LBcluster.ProtoReflect.Descriptor instead.
 func (*LBcluster) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{9}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *LBcluster) GetClusterInfo() *ClusterInfo {
@@ -1035,7 +1087,7 @@ type ClusterInfo struct {
 
 func (x *ClusterInfo) Reset() {
 	*x = ClusterInfo{}
-	mi := &file_spec_manifest_proto_msgTypes[10]
+	mi := &file_spec_manifest_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1047,7 +1099,7 @@ func (x *ClusterInfo) String() string {
 func (*ClusterInfo) ProtoMessage() {}
 
 func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[10]
+	mi := &file_spec_manifest_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1060,7 +1112,7 @@ func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterInfo.ProtoReflect.Descriptor instead.
 func (*ClusterInfo) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{10}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ClusterInfo) GetName() string {
@@ -1103,7 +1155,7 @@ type InstallationProxy struct {
 
 func (x *InstallationProxy) Reset() {
 	*x = InstallationProxy{}
-	mi := &file_spec_manifest_proto_msgTypes[11]
+	mi := &file_spec_manifest_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1115,7 +1167,7 @@ func (x *InstallationProxy) String() string {
 func (*InstallationProxy) ProtoMessage() {}
 
 func (x *InstallationProxy) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[11]
+	mi := &file_spec_manifest_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1128,7 +1180,7 @@ func (x *InstallationProxy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallationProxy.ProtoReflect.Descriptor instead.
 func (*InstallationProxy) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{11}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *InstallationProxy) GetMode() string {
@@ -1175,7 +1227,7 @@ type Role struct {
 
 func (x *Role) Reset() {
 	*x = Role{}
-	mi := &file_spec_manifest_proto_msgTypes[12]
+	mi := &file_spec_manifest_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1187,7 +1239,7 @@ func (x *Role) String() string {
 func (*Role) ProtoMessage() {}
 
 func (x *Role) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[12]
+	mi := &file_spec_manifest_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1200,7 +1252,7 @@ func (x *Role) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role.ProtoReflect.Descriptor instead.
 func (*Role) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{12}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Role) GetName() string {
@@ -1279,7 +1331,7 @@ type TaskEvent struct {
 
 func (x *TaskEvent) Reset() {
 	*x = TaskEvent{}
-	mi := &file_spec_manifest_proto_msgTypes[13]
+	mi := &file_spec_manifest_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1291,7 +1343,7 @@ func (x *TaskEvent) String() string {
 func (*TaskEvent) ProtoMessage() {}
 
 func (x *TaskEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[13]
+	mi := &file_spec_manifest_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1304,7 +1356,7 @@ func (x *TaskEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskEvent.ProtoReflect.Descriptor instead.
 func (*TaskEvent) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{13}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TaskEvent) GetId() string {
@@ -1378,7 +1430,7 @@ type Unreachable struct {
 
 func (x *Unreachable) Reset() {
 	*x = Unreachable{}
-	mi := &file_spec_manifest_proto_msgTypes[14]
+	mi := &file_spec_manifest_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1390,7 +1442,7 @@ func (x *Unreachable) String() string {
 func (*Unreachable) ProtoMessage() {}
 
 func (x *Unreachable) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[14]
+	mi := &file_spec_manifest_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1403,7 +1455,7 @@ func (x *Unreachable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Unreachable.ProtoReflect.Descriptor instead.
 func (*Unreachable) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{14}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Unreachable) GetKubernetes() *Unreachable_UnreachableNodePools {
@@ -1439,7 +1491,7 @@ type Create struct {
 
 func (x *Create) Reset() {
 	*x = Create{}
-	mi := &file_spec_manifest_proto_msgTypes[15]
+	mi := &file_spec_manifest_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1451,7 +1503,7 @@ func (x *Create) String() string {
 func (*Create) ProtoMessage() {}
 
 func (x *Create) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[15]
+	mi := &file_spec_manifest_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1464,7 +1516,7 @@ func (x *Create) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Create.ProtoReflect.Descriptor instead.
 func (*Create) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{15}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *Create) GetK8S() *K8Scluster {
@@ -1533,7 +1585,7 @@ type Update struct {
 
 func (x *Update) Reset() {
 	*x = Update{}
-	mi := &file_spec_manifest_proto_msgTypes[16]
+	mi := &file_spec_manifest_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1545,7 +1597,7 @@ func (x *Update) String() string {
 func (*Update) ProtoMessage() {}
 
 func (x *Update) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[16]
+	mi := &file_spec_manifest_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1558,7 +1610,7 @@ func (x *Update) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update.ProtoReflect.Descriptor instead.
 func (*Update) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Update) GetState() *Update_State {
@@ -2129,7 +2181,7 @@ type Delete struct {
 
 func (x *Delete) Reset() {
 	*x = Delete{}
-	mi := &file_spec_manifest_proto_msgTypes[17]
+	mi := &file_spec_manifest_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2141,7 +2193,7 @@ func (x *Delete) String() string {
 func (*Delete) ProtoMessage() {}
 
 func (x *Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[17]
+	mi := &file_spec_manifest_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2154,7 +2206,7 @@ func (x *Delete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Delete.ProtoReflect.Descriptor instead.
 func (*Delete) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{17}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Delete) GetK8S() *K8Scluster {
@@ -2185,7 +2237,7 @@ type Task struct {
 
 func (x *Task) Reset() {
 	*x = Task{}
-	mi := &file_spec_manifest_proto_msgTypes[18]
+	mi := &file_spec_manifest_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2197,7 +2249,7 @@ func (x *Task) String() string {
 func (*Task) ProtoMessage() {}
 
 func (x *Task) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[18]
+	mi := &file_spec_manifest_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2210,7 +2262,7 @@ func (x *Task) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Task.ProtoReflect.Descriptor instead.
 func (*Task) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{18}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Task) GetDo() isTask_Do {
@@ -2282,7 +2334,7 @@ type Work struct {
 
 func (x *Work) Reset() {
 	*x = Work{}
-	mi := &file_spec_manifest_proto_msgTypes[19]
+	mi := &file_spec_manifest_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2294,7 +2346,7 @@ func (x *Work) String() string {
 func (*Work) ProtoMessage() {}
 
 func (x *Work) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[19]
+	mi := &file_spec_manifest_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2307,7 +2359,7 @@ func (x *Work) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Work.ProtoReflect.Descriptor instead.
 func (*Work) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{19}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Work) GetTask() *Task {
@@ -2343,7 +2395,7 @@ type TaskResult struct {
 
 func (x *TaskResult) Reset() {
 	*x = TaskResult{}
-	mi := &file_spec_manifest_proto_msgTypes[20]
+	mi := &file_spec_manifest_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2355,7 +2407,7 @@ func (x *TaskResult) String() string {
 func (*TaskResult) ProtoMessage() {}
 
 func (x *TaskResult) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[20]
+	mi := &file_spec_manifest_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2368,7 +2420,7 @@ func (x *TaskResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskResult.ProtoReflect.Descriptor instead.
 func (*TaskResult) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TaskResult) GetError() *TaskResult_Error {
@@ -2447,7 +2499,7 @@ type Role_Settings struct {
 
 func (x *Role_Settings) Reset() {
 	*x = Role_Settings{}
-	mi := &file_spec_manifest_proto_msgTypes[22]
+	mi := &file_spec_manifest_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2459,7 +2511,7 @@ func (x *Role_Settings) String() string {
 func (*Role_Settings) ProtoMessage() {}
 
 func (x *Role_Settings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[22]
+	mi := &file_spec_manifest_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2472,7 +2524,7 @@ func (x *Role_Settings) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role_Settings.ProtoReflect.Descriptor instead.
 func (*Role_Settings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{12, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *Role_Settings) GetProxyProtocol() bool {
@@ -2505,7 +2557,7 @@ type Unreachable_ListOfNodeEndpoints struct {
 
 func (x *Unreachable_ListOfNodeEndpoints) Reset() {
 	*x = Unreachable_ListOfNodeEndpoints{}
-	mi := &file_spec_manifest_proto_msgTypes[23]
+	mi := &file_spec_manifest_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2517,7 +2569,7 @@ func (x *Unreachable_ListOfNodeEndpoints) String() string {
 func (*Unreachable_ListOfNodeEndpoints) ProtoMessage() {}
 
 func (x *Unreachable_ListOfNodeEndpoints) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[23]
+	mi := &file_spec_manifest_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2530,7 +2582,7 @@ func (x *Unreachable_ListOfNodeEndpoints) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Unreachable_ListOfNodeEndpoints.ProtoReflect.Descriptor instead.
 func (*Unreachable_ListOfNodeEndpoints) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{14, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{15, 0}
 }
 
 func (x *Unreachable_ListOfNodeEndpoints) GetEndpoints() []string {
@@ -2549,7 +2601,7 @@ type Unreachable_UnreachableNodePools struct {
 
 func (x *Unreachable_UnreachableNodePools) Reset() {
 	*x = Unreachable_UnreachableNodePools{}
-	mi := &file_spec_manifest_proto_msgTypes[24]
+	mi := &file_spec_manifest_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2561,7 +2613,7 @@ func (x *Unreachable_UnreachableNodePools) String() string {
 func (*Unreachable_UnreachableNodePools) ProtoMessage() {}
 
 func (x *Unreachable_UnreachableNodePools) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[24]
+	mi := &file_spec_manifest_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2574,7 +2626,7 @@ func (x *Unreachable_UnreachableNodePools) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Unreachable_UnreachableNodePools.ProtoReflect.Descriptor instead.
 func (*Unreachable_UnreachableNodePools) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{14, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{15, 1}
 }
 
 func (x *Unreachable_UnreachableNodePools) GetNodepools() map[string]*Unreachable_ListOfNodeEndpoints {
@@ -2598,7 +2650,7 @@ type Update_State struct {
 
 func (x *Update_State) Reset() {
 	*x = Update_State{}
-	mi := &file_spec_manifest_proto_msgTypes[27]
+	mi := &file_spec_manifest_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2610,7 +2662,7 @@ func (x *Update_State) String() string {
 func (*Update_State) ProtoMessage() {}
 
 func (x *Update_State) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[27]
+	mi := &file_spec_manifest_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2623,7 +2675,7 @@ func (x *Update_State) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_State.ProtoReflect.Descriptor instead.
 func (*Update_State) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 0}
 }
 
 func (x *Update_State) GetK8S() *K8Scluster {
@@ -2648,7 +2700,7 @@ type Update_None struct {
 
 func (x *Update_None) Reset() {
 	*x = Update_None{}
-	mi := &file_spec_manifest_proto_msgTypes[28]
+	mi := &file_spec_manifest_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2660,7 +2712,7 @@ func (x *Update_None) String() string {
 func (*Update_None) ProtoMessage() {}
 
 func (x *Update_None) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[28]
+	mi := &file_spec_manifest_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2673,7 +2725,7 @@ func (x *Update_None) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_None.ProtoReflect.Descriptor instead.
 func (*Update_None) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 1}
 }
 
 // TerraformerMoveNodePoolToAutoscaled is a message that once
@@ -2696,7 +2748,7 @@ type Update_TerraformerMoveNodePoolToAutoscaled struct {
 
 func (x *Update_TerraformerMoveNodePoolToAutoscaled) Reset() {
 	*x = Update_TerraformerMoveNodePoolToAutoscaled{}
-	mi := &file_spec_manifest_proto_msgTypes[29]
+	mi := &file_spec_manifest_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2708,7 +2760,7 @@ func (x *Update_TerraformerMoveNodePoolToAutoscaled) String() string {
 func (*Update_TerraformerMoveNodePoolToAutoscaled) ProtoMessage() {}
 
 func (x *Update_TerraformerMoveNodePoolToAutoscaled) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[29]
+	mi := &file_spec_manifest_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2721,7 +2773,7 @@ func (x *Update_TerraformerMoveNodePoolToAutoscaled) ProtoReflect() protoreflect
 
 // Deprecated: Use Update_TerraformerMoveNodePoolToAutoscaled.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerMoveNodePoolToAutoscaled) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 2}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 2}
 }
 
 func (x *Update_TerraformerMoveNodePoolToAutoscaled) GetNodepool() string {
@@ -2747,7 +2799,7 @@ type Update_MovedNodePoolToAutoscaled struct {
 
 func (x *Update_MovedNodePoolToAutoscaled) Reset() {
 	*x = Update_MovedNodePoolToAutoscaled{}
-	mi := &file_spec_manifest_proto_msgTypes[30]
+	mi := &file_spec_manifest_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2759,7 +2811,7 @@ func (x *Update_MovedNodePoolToAutoscaled) String() string {
 func (*Update_MovedNodePoolToAutoscaled) ProtoMessage() {}
 
 func (x *Update_MovedNodePoolToAutoscaled) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[30]
+	mi := &file_spec_manifest_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2772,7 +2824,7 @@ func (x *Update_MovedNodePoolToAutoscaled) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_MovedNodePoolToAutoscaled.ProtoReflect.Descriptor instead.
 func (*Update_MovedNodePoolToAutoscaled) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 3}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 3}
 }
 
 func (x *Update_MovedNodePoolToAutoscaled) GetNodepool() string {
@@ -2793,7 +2845,7 @@ type Update_TerraformerMoveNodePoolFromAutoscaled struct {
 
 func (x *Update_TerraformerMoveNodePoolFromAutoscaled) Reset() {
 	*x = Update_TerraformerMoveNodePoolFromAutoscaled{}
-	mi := &file_spec_manifest_proto_msgTypes[31]
+	mi := &file_spec_manifest_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2805,7 +2857,7 @@ func (x *Update_TerraformerMoveNodePoolFromAutoscaled) String() string {
 func (*Update_TerraformerMoveNodePoolFromAutoscaled) ProtoMessage() {}
 
 func (x *Update_TerraformerMoveNodePoolFromAutoscaled) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[31]
+	mi := &file_spec_manifest_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2818,7 +2870,7 @@ func (x *Update_TerraformerMoveNodePoolFromAutoscaled) ProtoReflect() protorefle
 
 // Deprecated: Use Update_TerraformerMoveNodePoolFromAutoscaled.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerMoveNodePoolFromAutoscaled) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 4}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 4}
 }
 
 func (x *Update_TerraformerMoveNodePoolFromAutoscaled) GetNodepool() string {
@@ -2838,7 +2890,7 @@ type Update_MovedNodePoolFromAutoscaled struct {
 
 func (x *Update_MovedNodePoolFromAutoscaled) Reset() {
 	*x = Update_MovedNodePoolFromAutoscaled{}
-	mi := &file_spec_manifest_proto_msgTypes[32]
+	mi := &file_spec_manifest_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2850,7 +2902,7 @@ func (x *Update_MovedNodePoolFromAutoscaled) String() string {
 func (*Update_MovedNodePoolFromAutoscaled) ProtoMessage() {}
 
 func (x *Update_MovedNodePoolFromAutoscaled) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[32]
+	mi := &file_spec_manifest_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2863,7 +2915,7 @@ func (x *Update_MovedNodePoolFromAutoscaled) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use Update_MovedNodePoolFromAutoscaled.ProtoReflect.Descriptor instead.
 func (*Update_MovedNodePoolFromAutoscaled) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 5}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 5}
 }
 
 func (x *Update_MovedNodePoolFromAutoscaled) GetNodepool() string {
@@ -2898,7 +2950,7 @@ type Update_TerraformerAddLoadBalancer struct {
 
 func (x *Update_TerraformerAddLoadBalancer) Reset() {
 	*x = Update_TerraformerAddLoadBalancer{}
-	mi := &file_spec_manifest_proto_msgTypes[33]
+	mi := &file_spec_manifest_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2910,7 +2962,7 @@ func (x *Update_TerraformerAddLoadBalancer) String() string {
 func (*Update_TerraformerAddLoadBalancer) ProtoMessage() {}
 
 func (x *Update_TerraformerAddLoadBalancer) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[33]
+	mi := &file_spec_manifest_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2923,7 +2975,7 @@ func (x *Update_TerraformerAddLoadBalancer) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use Update_TerraformerAddLoadBalancer.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddLoadBalancer) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 6}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 6}
 }
 
 func (x *Update_TerraformerAddLoadBalancer) GetHandle() *LBcluster {
@@ -2942,7 +2994,7 @@ type Update_AddedLoadBalancer struct {
 
 func (x *Update_AddedLoadBalancer) Reset() {
 	*x = Update_AddedLoadBalancer{}
-	mi := &file_spec_manifest_proto_msgTypes[34]
+	mi := &file_spec_manifest_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2954,7 +3006,7 @@ func (x *Update_AddedLoadBalancer) String() string {
 func (*Update_AddedLoadBalancer) ProtoMessage() {}
 
 func (x *Update_AddedLoadBalancer) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[34]
+	mi := &file_spec_manifest_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2967,7 +3019,7 @@ func (x *Update_AddedLoadBalancer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_AddedLoadBalancer.ProtoReflect.Descriptor instead.
 func (*Update_AddedLoadBalancer) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 7}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 7}
 }
 
 func (x *Update_AddedLoadBalancer) GetHandle() string {
@@ -3009,7 +3061,7 @@ type Update_TerraformerDeleteLoadBalancerNodes struct {
 
 func (x *Update_TerraformerDeleteLoadBalancerNodes) Reset() {
 	*x = Update_TerraformerDeleteLoadBalancerNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[35]
+	mi := &file_spec_manifest_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3021,7 +3073,7 @@ func (x *Update_TerraformerDeleteLoadBalancerNodes) String() string {
 func (*Update_TerraformerDeleteLoadBalancerNodes) ProtoMessage() {}
 
 func (x *Update_TerraformerDeleteLoadBalancerNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[35]
+	mi := &file_spec_manifest_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3034,7 +3086,7 @@ func (x *Update_TerraformerDeleteLoadBalancerNodes) ProtoReflect() protoreflect.
 
 // Deprecated: Use Update_TerraformerDeleteLoadBalancerNodes.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerDeleteLoadBalancerNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 8}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 8}
 }
 
 func (x *Update_TerraformerDeleteLoadBalancerNodes) GetHandle() string {
@@ -3091,7 +3143,7 @@ type Update_DeletedLoadBalancerNodes struct {
 
 func (x *Update_DeletedLoadBalancerNodes) Reset() {
 	*x = Update_DeletedLoadBalancerNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[36]
+	mi := &file_spec_manifest_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3103,7 +3155,7 @@ func (x *Update_DeletedLoadBalancerNodes) String() string {
 func (*Update_DeletedLoadBalancerNodes) ProtoMessage() {}
 
 func (x *Update_DeletedLoadBalancerNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[36]
+	mi := &file_spec_manifest_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3116,7 +3168,7 @@ func (x *Update_DeletedLoadBalancerNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_DeletedLoadBalancerNodes.ProtoReflect.Descriptor instead.
 func (*Update_DeletedLoadBalancerNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 9}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 9}
 }
 
 func (x *Update_DeletedLoadBalancerNodes) GetUnreachable() *Unreachable {
@@ -3197,7 +3249,7 @@ type Update_TerraformerAddLoadBalancerNodes struct {
 
 func (x *Update_TerraformerAddLoadBalancerNodes) Reset() {
 	*x = Update_TerraformerAddLoadBalancerNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[37]
+	mi := &file_spec_manifest_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3209,7 +3261,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes) String() string {
 func (*Update_TerraformerAddLoadBalancerNodes) ProtoMessage() {}
 
 func (x *Update_TerraformerAddLoadBalancerNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[37]
+	mi := &file_spec_manifest_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3222,7 +3274,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use Update_TerraformerAddLoadBalancerNodes.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddLoadBalancerNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 10}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 10}
 }
 
 func (x *Update_TerraformerAddLoadBalancerNodes) GetHandle() string {
@@ -3286,7 +3338,7 @@ type Update_AddedLoadBalancerNodes struct {
 
 func (x *Update_AddedLoadBalancerNodes) Reset() {
 	*x = Update_AddedLoadBalancerNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[38]
+	mi := &file_spec_manifest_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3298,7 +3350,7 @@ func (x *Update_AddedLoadBalancerNodes) String() string {
 func (*Update_AddedLoadBalancerNodes) ProtoMessage() {}
 
 func (x *Update_AddedLoadBalancerNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[38]
+	mi := &file_spec_manifest_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3311,7 +3363,7 @@ func (x *Update_AddedLoadBalancerNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_AddedLoadBalancerNodes.ProtoReflect.Descriptor instead.
 func (*Update_AddedLoadBalancerNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 11}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 11}
 }
 
 func (x *Update_AddedLoadBalancerNodes) GetHandle() string {
@@ -3354,7 +3406,7 @@ type Update_DeleteLoadBalancerRoles struct {
 
 func (x *Update_DeleteLoadBalancerRoles) Reset() {
 	*x = Update_DeleteLoadBalancerRoles{}
-	mi := &file_spec_manifest_proto_msgTypes[39]
+	mi := &file_spec_manifest_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3366,7 +3418,7 @@ func (x *Update_DeleteLoadBalancerRoles) String() string {
 func (*Update_DeleteLoadBalancerRoles) ProtoMessage() {}
 
 func (x *Update_DeleteLoadBalancerRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[39]
+	mi := &file_spec_manifest_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3379,7 +3431,7 @@ func (x *Update_DeleteLoadBalancerRoles) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_DeleteLoadBalancerRoles.ProtoReflect.Descriptor instead.
 func (*Update_DeleteLoadBalancerRoles) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 12}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 12}
 }
 
 func (x *Update_DeleteLoadBalancerRoles) GetHandle() string {
@@ -3414,7 +3466,7 @@ type Update_TerraformerAddLoadBalancerRoles struct {
 
 func (x *Update_TerraformerAddLoadBalancerRoles) Reset() {
 	*x = Update_TerraformerAddLoadBalancerRoles{}
-	mi := &file_spec_manifest_proto_msgTypes[40]
+	mi := &file_spec_manifest_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3426,7 +3478,7 @@ func (x *Update_TerraformerAddLoadBalancerRoles) String() string {
 func (*Update_TerraformerAddLoadBalancerRoles) ProtoMessage() {}
 
 func (x *Update_TerraformerAddLoadBalancerRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[40]
+	mi := &file_spec_manifest_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3439,7 +3491,7 @@ func (x *Update_TerraformerAddLoadBalancerRoles) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use Update_TerraformerAddLoadBalancerRoles.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddLoadBalancerRoles) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 13}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 13}
 }
 
 func (x *Update_TerraformerAddLoadBalancerRoles) GetHandle() string {
@@ -3466,7 +3518,7 @@ type Update_AddedLoadBalancerRoles struct {
 
 func (x *Update_AddedLoadBalancerRoles) Reset() {
 	*x = Update_AddedLoadBalancerRoles{}
-	mi := &file_spec_manifest_proto_msgTypes[41]
+	mi := &file_spec_manifest_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3478,7 +3530,7 @@ func (x *Update_AddedLoadBalancerRoles) String() string {
 func (*Update_AddedLoadBalancerRoles) ProtoMessage() {}
 
 func (x *Update_AddedLoadBalancerRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[41]
+	mi := &file_spec_manifest_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3491,7 +3543,7 @@ func (x *Update_AddedLoadBalancerRoles) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_AddedLoadBalancerRoles.ProtoReflect.Descriptor instead.
 func (*Update_AddedLoadBalancerRoles) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 14}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 14}
 }
 
 func (x *Update_AddedLoadBalancerRoles) GetHandle() string {
@@ -3534,7 +3586,7 @@ type Update_TerraformerReplaceDns struct {
 
 func (x *Update_TerraformerReplaceDns) Reset() {
 	*x = Update_TerraformerReplaceDns{}
-	mi := &file_spec_manifest_proto_msgTypes[42]
+	mi := &file_spec_manifest_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3546,7 +3598,7 @@ func (x *Update_TerraformerReplaceDns) String() string {
 func (*Update_TerraformerReplaceDns) ProtoMessage() {}
 
 func (x *Update_TerraformerReplaceDns) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[42]
+	mi := &file_spec_manifest_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3559,7 +3611,7 @@ func (x *Update_TerraformerReplaceDns) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_TerraformerReplaceDns.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerReplaceDns) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 15}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 15}
 }
 
 func (x *Update_TerraformerReplaceDns) GetHandle() string {
@@ -3593,7 +3645,7 @@ type Update_ReplacedDns struct {
 
 func (x *Update_ReplacedDns) Reset() {
 	*x = Update_ReplacedDns{}
-	mi := &file_spec_manifest_proto_msgTypes[43]
+	mi := &file_spec_manifest_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3605,7 +3657,7 @@ func (x *Update_ReplacedDns) String() string {
 func (*Update_ReplacedDns) ProtoMessage() {}
 
 func (x *Update_ReplacedDns) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[43]
+	mi := &file_spec_manifest_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3618,7 +3670,7 @@ func (x *Update_ReplacedDns) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_ReplacedDns.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedDns) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 16}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 16}
 }
 
 func (x *Update_ReplacedDns) GetHandle() string {
@@ -3650,7 +3702,7 @@ type Update_DeleteLoadBalancer struct {
 
 func (x *Update_DeleteLoadBalancer) Reset() {
 	*x = Update_DeleteLoadBalancer{}
-	mi := &file_spec_manifest_proto_msgTypes[44]
+	mi := &file_spec_manifest_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3662,7 +3714,7 @@ func (x *Update_DeleteLoadBalancer) String() string {
 func (*Update_DeleteLoadBalancer) ProtoMessage() {}
 
 func (x *Update_DeleteLoadBalancer) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[44]
+	mi := &file_spec_manifest_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3675,7 +3727,7 @@ func (x *Update_DeleteLoadBalancer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_DeleteLoadBalancer.ProtoReflect.Descriptor instead.
 func (*Update_DeleteLoadBalancer) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 17}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 17}
 }
 
 func (x *Update_DeleteLoadBalancer) GetHandle() string {
@@ -3705,7 +3757,7 @@ type Update_ApiEndpoint struct {
 
 func (x *Update_ApiEndpoint) Reset() {
 	*x = Update_ApiEndpoint{}
-	mi := &file_spec_manifest_proto_msgTypes[45]
+	mi := &file_spec_manifest_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3717,7 +3769,7 @@ func (x *Update_ApiEndpoint) String() string {
 func (*Update_ApiEndpoint) ProtoMessage() {}
 
 func (x *Update_ApiEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[45]
+	mi := &file_spec_manifest_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3730,7 +3782,7 @@ func (x *Update_ApiEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_ApiEndpoint.ProtoReflect.Descriptor instead.
 func (*Update_ApiEndpoint) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 18}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 18}
 }
 
 func (x *Update_ApiEndpoint) GetState() ApiEndpointChangeState {
@@ -3766,7 +3818,7 @@ type Update_K8SOnlyApiEndpoint struct {
 
 func (x *Update_K8SOnlyApiEndpoint) Reset() {
 	*x = Update_K8SOnlyApiEndpoint{}
-	mi := &file_spec_manifest_proto_msgTypes[46]
+	mi := &file_spec_manifest_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3778,7 +3830,7 @@ func (x *Update_K8SOnlyApiEndpoint) String() string {
 func (*Update_K8SOnlyApiEndpoint) ProtoMessage() {}
 
 func (x *Update_K8SOnlyApiEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[46]
+	mi := &file_spec_manifest_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3791,7 +3843,7 @@ func (x *Update_K8SOnlyApiEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_K8SOnlyApiEndpoint.ProtoReflect.Descriptor instead.
 func (*Update_K8SOnlyApiEndpoint) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 19}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 19}
 }
 
 func (x *Update_K8SOnlyApiEndpoint) GetNodepool() string {
@@ -3819,7 +3871,7 @@ type Update_ApiPortOnCluster struct {
 
 func (x *Update_ApiPortOnCluster) Reset() {
 	*x = Update_ApiPortOnCluster{}
-	mi := &file_spec_manifest_proto_msgTypes[47]
+	mi := &file_spec_manifest_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3831,7 +3883,7 @@ func (x *Update_ApiPortOnCluster) String() string {
 func (*Update_ApiPortOnCluster) ProtoMessage() {}
 
 func (x *Update_ApiPortOnCluster) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[47]
+	mi := &file_spec_manifest_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3844,7 +3896,7 @@ func (x *Update_ApiPortOnCluster) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_ApiPortOnCluster.ProtoReflect.Descriptor instead.
 func (*Update_ApiPortOnCluster) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 20}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 20}
 }
 
 func (x *Update_ApiPortOnCluster) GetOpen() bool {
@@ -3871,7 +3923,7 @@ type Update_AnsiblerReplaceProxySettings struct {
 
 func (x *Update_AnsiblerReplaceProxySettings) Reset() {
 	*x = Update_AnsiblerReplaceProxySettings{}
-	mi := &file_spec_manifest_proto_msgTypes[48]
+	mi := &file_spec_manifest_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3883,7 +3935,7 @@ func (x *Update_AnsiblerReplaceProxySettings) String() string {
 func (*Update_AnsiblerReplaceProxySettings) ProtoMessage() {}
 
 func (x *Update_AnsiblerReplaceProxySettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[48]
+	mi := &file_spec_manifest_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3896,7 +3948,7 @@ func (x *Update_AnsiblerReplaceProxySettings) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use Update_AnsiblerReplaceProxySettings.ProtoReflect.Descriptor instead.
 func (*Update_AnsiblerReplaceProxySettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 21}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 21}
 }
 
 func (x *Update_AnsiblerReplaceProxySettings) GetProxy() *InstallationProxy {
@@ -3914,7 +3966,7 @@ type Update_ReplacedProxySettings struct {
 
 func (x *Update_ReplacedProxySettings) Reset() {
 	*x = Update_ReplacedProxySettings{}
-	mi := &file_spec_manifest_proto_msgTypes[49]
+	mi := &file_spec_manifest_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3926,7 +3978,7 @@ func (x *Update_ReplacedProxySettings) String() string {
 func (*Update_ReplacedProxySettings) ProtoMessage() {}
 
 func (x *Update_ReplacedProxySettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[49]
+	mi := &file_spec_manifest_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3939,7 +3991,7 @@ func (x *Update_ReplacedProxySettings) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_ReplacedProxySettings.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedProxySettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 22}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 22}
 }
 
 type Update_TerraformerReplaceRoleExternalSettings struct {
@@ -3956,7 +4008,7 @@ type Update_TerraformerReplaceRoleExternalSettings struct {
 
 func (x *Update_TerraformerReplaceRoleExternalSettings) Reset() {
 	*x = Update_TerraformerReplaceRoleExternalSettings{}
-	mi := &file_spec_manifest_proto_msgTypes[50]
+	mi := &file_spec_manifest_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3968,7 +4020,7 @@ func (x *Update_TerraformerReplaceRoleExternalSettings) String() string {
 func (*Update_TerraformerReplaceRoleExternalSettings) ProtoMessage() {}
 
 func (x *Update_TerraformerReplaceRoleExternalSettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[50]
+	mi := &file_spec_manifest_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3981,7 +4033,7 @@ func (x *Update_TerraformerReplaceRoleExternalSettings) ProtoReflect() protorefl
 
 // Deprecated: Use Update_TerraformerReplaceRoleExternalSettings.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerReplaceRoleExternalSettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 23}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 23}
 }
 
 func (x *Update_TerraformerReplaceRoleExternalSettings) GetHandle() string {
@@ -4029,7 +4081,7 @@ type Update_ReplacedRoleExternalSettings struct {
 
 func (x *Update_ReplacedRoleExternalSettings) Reset() {
 	*x = Update_ReplacedRoleExternalSettings{}
-	mi := &file_spec_manifest_proto_msgTypes[51]
+	mi := &file_spec_manifest_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4041,7 +4093,7 @@ func (x *Update_ReplacedRoleExternalSettings) String() string {
 func (*Update_ReplacedRoleExternalSettings) ProtoMessage() {}
 
 func (x *Update_ReplacedRoleExternalSettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[51]
+	mi := &file_spec_manifest_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4054,7 +4106,7 @@ func (x *Update_ReplacedRoleExternalSettings) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use Update_ReplacedRoleExternalSettings.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedRoleExternalSettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 24}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 24}
 }
 
 func (x *Update_ReplacedRoleExternalSettings) GetHandle() string {
@@ -4084,7 +4136,7 @@ type Update_AnsiblerReplaceRoleInternalSettings struct {
 
 func (x *Update_AnsiblerReplaceRoleInternalSettings) Reset() {
 	*x = Update_AnsiblerReplaceRoleInternalSettings{}
-	mi := &file_spec_manifest_proto_msgTypes[52]
+	mi := &file_spec_manifest_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4096,7 +4148,7 @@ func (x *Update_AnsiblerReplaceRoleInternalSettings) String() string {
 func (*Update_AnsiblerReplaceRoleInternalSettings) ProtoMessage() {}
 
 func (x *Update_AnsiblerReplaceRoleInternalSettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[52]
+	mi := &file_spec_manifest_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4109,7 +4161,7 @@ func (x *Update_AnsiblerReplaceRoleInternalSettings) ProtoReflect() protoreflect
 
 // Deprecated: Use Update_AnsiblerReplaceRoleInternalSettings.ProtoReflect.Descriptor instead.
 func (*Update_AnsiblerReplaceRoleInternalSettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 25}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 25}
 }
 
 func (x *Update_AnsiblerReplaceRoleInternalSettings) GetHandle() string {
@@ -4150,7 +4202,7 @@ type Update_ReplacedRoleInternalSettings struct {
 
 func (x *Update_ReplacedRoleInternalSettings) Reset() {
 	*x = Update_ReplacedRoleInternalSettings{}
-	mi := &file_spec_manifest_proto_msgTypes[53]
+	mi := &file_spec_manifest_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4162,7 +4214,7 @@ func (x *Update_ReplacedRoleInternalSettings) String() string {
 func (*Update_ReplacedRoleInternalSettings) ProtoMessage() {}
 
 func (x *Update_ReplacedRoleInternalSettings) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[53]
+	mi := &file_spec_manifest_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4175,7 +4227,7 @@ func (x *Update_ReplacedRoleInternalSettings) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use Update_ReplacedRoleInternalSettings.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedRoleInternalSettings) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 26}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 26}
 }
 
 func (x *Update_ReplacedRoleInternalSettings) GetHandle() string {
@@ -4211,7 +4263,7 @@ type Update_AnsiblerReplaceTargetPools struct {
 
 func (x *Update_AnsiblerReplaceTargetPools) Reset() {
 	*x = Update_AnsiblerReplaceTargetPools{}
-	mi := &file_spec_manifest_proto_msgTypes[54]
+	mi := &file_spec_manifest_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4223,7 +4275,7 @@ func (x *Update_AnsiblerReplaceTargetPools) String() string {
 func (*Update_AnsiblerReplaceTargetPools) ProtoMessage() {}
 
 func (x *Update_AnsiblerReplaceTargetPools) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[54]
+	mi := &file_spec_manifest_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4236,7 +4288,7 @@ func (x *Update_AnsiblerReplaceTargetPools) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use Update_AnsiblerReplaceTargetPools.ProtoReflect.Descriptor instead.
 func (*Update_AnsiblerReplaceTargetPools) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 27}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 27}
 }
 
 func (x *Update_AnsiblerReplaceTargetPools) GetHandle() string {
@@ -4264,7 +4316,7 @@ type Update_ReplacedTargetPools struct {
 
 func (x *Update_ReplacedTargetPools) Reset() {
 	*x = Update_ReplacedTargetPools{}
-	mi := &file_spec_manifest_proto_msgTypes[55]
+	mi := &file_spec_manifest_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4276,7 +4328,7 @@ func (x *Update_ReplacedTargetPools) String() string {
 func (*Update_ReplacedTargetPools) ProtoMessage() {}
 
 func (x *Update_ReplacedTargetPools) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[55]
+	mi := &file_spec_manifest_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4289,7 +4341,7 @@ func (x *Update_ReplacedTargetPools) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_ReplacedTargetPools.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedTargetPools) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 28}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 28}
 }
 
 func (x *Update_ReplacedTargetPools) GetHandle() string {
@@ -4317,7 +4369,7 @@ type Update_UpgradeVersion struct {
 
 func (x *Update_UpgradeVersion) Reset() {
 	*x = Update_UpgradeVersion{}
-	mi := &file_spec_manifest_proto_msgTypes[56]
+	mi := &file_spec_manifest_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4329,7 +4381,7 @@ func (x *Update_UpgradeVersion) String() string {
 func (*Update_UpgradeVersion) ProtoMessage() {}
 
 func (x *Update_UpgradeVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[56]
+	mi := &file_spec_manifest_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4342,7 +4394,7 @@ func (x *Update_UpgradeVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_UpgradeVersion.ProtoReflect.Descriptor instead.
 func (*Update_UpgradeVersion) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 29}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 29}
 }
 
 func (x *Update_UpgradeVersion) GetVersion() string {
@@ -4369,7 +4421,7 @@ type Update_KuberPatchNodes struct {
 
 func (x *Update_KuberPatchNodes) Reset() {
 	*x = Update_KuberPatchNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[57]
+	mi := &file_spec_manifest_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4381,7 +4433,7 @@ func (x *Update_KuberPatchNodes) String() string {
 func (*Update_KuberPatchNodes) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[57]
+	mi := &file_spec_manifest_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4394,7 +4446,7 @@ func (x *Update_KuberPatchNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_KuberPatchNodes.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30}
 }
 
 func (x *Update_KuberPatchNodes) GetAdd() *Update_KuberPatchNodes_AddBatch {
@@ -4419,7 +4471,7 @@ type Update_PatchedNodes struct {
 
 func (x *Update_PatchedNodes) Reset() {
 	*x = Update_PatchedNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[58]
+	mi := &file_spec_manifest_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4431,7 +4483,7 @@ func (x *Update_PatchedNodes) String() string {
 func (*Update_PatchedNodes) ProtoMessage() {}
 
 func (x *Update_PatchedNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[58]
+	mi := &file_spec_manifest_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4444,7 +4496,7 @@ func (x *Update_PatchedNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_PatchedNodes.ProtoReflect.Descriptor instead.
 func (*Update_PatchedNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 31}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 31}
 }
 
 // KuberDeleteK8sNodes is a message that is processed by the Kuber service
@@ -4482,7 +4534,7 @@ type Update_KuberDeleteK8SNodes struct {
 
 func (x *Update_KuberDeleteK8SNodes) Reset() {
 	*x = Update_KuberDeleteK8SNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[59]
+	mi := &file_spec_manifest_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4494,7 +4546,7 @@ func (x *Update_KuberDeleteK8SNodes) String() string {
 func (*Update_KuberDeleteK8SNodes) ProtoMessage() {}
 
 func (x *Update_KuberDeleteK8SNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[59]
+	mi := &file_spec_manifest_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4507,7 +4559,7 @@ func (x *Update_KuberDeleteK8SNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_KuberDeleteK8SNodes.ProtoReflect.Descriptor instead.
 func (*Update_KuberDeleteK8SNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 32}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 32}
 }
 
 func (x *Update_KuberDeleteK8SNodes) GetWithNodePool() bool {
@@ -4555,7 +4607,7 @@ type Update_DeletedK8SNodes struct {
 
 func (x *Update_DeletedK8SNodes) Reset() {
 	*x = Update_DeletedK8SNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[60]
+	mi := &file_spec_manifest_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4567,7 +4619,7 @@ func (x *Update_DeletedK8SNodes) String() string {
 func (*Update_DeletedK8SNodes) ProtoMessage() {}
 
 func (x *Update_DeletedK8SNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[60]
+	mi := &file_spec_manifest_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4580,7 +4632,7 @@ func (x *Update_DeletedK8SNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_DeletedK8SNodes.ProtoReflect.Descriptor instead.
 func (*Update_DeletedK8SNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 33}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 33}
 }
 
 func (x *Update_DeletedK8SNodes) GetUnreachable() *Unreachable {
@@ -4651,7 +4703,7 @@ type Update_TerraformerAddK8SNodes struct {
 
 func (x *Update_TerraformerAddK8SNodes) Reset() {
 	*x = Update_TerraformerAddK8SNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[61]
+	mi := &file_spec_manifest_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4663,7 +4715,7 @@ func (x *Update_TerraformerAddK8SNodes) String() string {
 func (*Update_TerraformerAddK8SNodes) ProtoMessage() {}
 
 func (x *Update_TerraformerAddK8SNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[61]
+	mi := &file_spec_manifest_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4676,7 +4728,7 @@ func (x *Update_TerraformerAddK8SNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_TerraformerAddK8SNodes.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddK8SNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 34}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 34}
 }
 
 func (x *Update_TerraformerAddK8SNodes) GetKind() isUpdate_TerraformerAddK8SNodes_Kind {
@@ -4731,7 +4783,7 @@ type Update_AddedK8SNodes struct {
 
 func (x *Update_AddedK8SNodes) Reset() {
 	*x = Update_AddedK8SNodes{}
-	mi := &file_spec_manifest_proto_msgTypes[62]
+	mi := &file_spec_manifest_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4743,7 +4795,7 @@ func (x *Update_AddedK8SNodes) String() string {
 func (*Update_AddedK8SNodes) ProtoMessage() {}
 
 func (x *Update_AddedK8SNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[62]
+	mi := &file_spec_manifest_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4756,7 +4808,7 @@ func (x *Update_AddedK8SNodes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_AddedK8SNodes.ProtoReflect.Descriptor instead.
 func (*Update_AddedK8SNodes) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 35}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 35}
 }
 
 func (x *Update_AddedK8SNodes) GetNewNodePool() bool {
@@ -4791,7 +4843,7 @@ type Update_DeletedLoadBalancerNodes_WholeNodePool struct {
 
 func (x *Update_DeletedLoadBalancerNodes_WholeNodePool) Reset() {
 	*x = Update_DeletedLoadBalancerNodes_WholeNodePool{}
-	mi := &file_spec_manifest_proto_msgTypes[63]
+	mi := &file_spec_manifest_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4803,7 +4855,7 @@ func (x *Update_DeletedLoadBalancerNodes_WholeNodePool) String() string {
 func (*Update_DeletedLoadBalancerNodes_WholeNodePool) ProtoMessage() {}
 
 func (x *Update_DeletedLoadBalancerNodes_WholeNodePool) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[63]
+	mi := &file_spec_manifest_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4816,7 +4868,7 @@ func (x *Update_DeletedLoadBalancerNodes_WholeNodePool) ProtoReflect() protorefl
 
 // Deprecated: Use Update_DeletedLoadBalancerNodes_WholeNodePool.ProtoReflect.Descriptor instead.
 func (*Update_DeletedLoadBalancerNodes_WholeNodePool) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 9, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 9, 0}
 }
 
 func (x *Update_DeletedLoadBalancerNodes_WholeNodePool) GetNodepool() *NodePool {
@@ -4846,7 +4898,7 @@ type Update_DeletedLoadBalancerNodes_Partial struct {
 
 func (x *Update_DeletedLoadBalancerNodes_Partial) Reset() {
 	*x = Update_DeletedLoadBalancerNodes_Partial{}
-	mi := &file_spec_manifest_proto_msgTypes[64]
+	mi := &file_spec_manifest_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4858,7 +4910,7 @@ func (x *Update_DeletedLoadBalancerNodes_Partial) String() string {
 func (*Update_DeletedLoadBalancerNodes_Partial) ProtoMessage() {}
 
 func (x *Update_DeletedLoadBalancerNodes_Partial) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[64]
+	mi := &file_spec_manifest_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4871,7 +4923,7 @@ func (x *Update_DeletedLoadBalancerNodes_Partial) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use Update_DeletedLoadBalancerNodes_Partial.ProtoReflect.Descriptor instead.
 func (*Update_DeletedLoadBalancerNodes_Partial) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 9, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 9, 1}
 }
 
 func (x *Update_DeletedLoadBalancerNodes_Partial) GetNodepool() string {
@@ -4909,7 +4961,7 @@ type Update_TerraformerAddLoadBalancerNodes_Existing struct {
 
 func (x *Update_TerraformerAddLoadBalancerNodes_Existing) Reset() {
 	*x = Update_TerraformerAddLoadBalancerNodes_Existing{}
-	mi := &file_spec_manifest_proto_msgTypes[66]
+	mi := &file_spec_manifest_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4921,7 +4973,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes_Existing) String() string {
 func (*Update_TerraformerAddLoadBalancerNodes_Existing) ProtoMessage() {}
 
 func (x *Update_TerraformerAddLoadBalancerNodes_Existing) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[66]
+	mi := &file_spec_manifest_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4934,7 +4986,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes_Existing) ProtoReflect() protore
 
 // Deprecated: Use Update_TerraformerAddLoadBalancerNodes_Existing.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddLoadBalancerNodes_Existing) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 10, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 10, 0}
 }
 
 func (x *Update_TerraformerAddLoadBalancerNodes_Existing) GetNodepool() string {
@@ -4962,7 +5014,7 @@ type Update_TerraformerAddLoadBalancerNodes_New struct {
 
 func (x *Update_TerraformerAddLoadBalancerNodes_New) Reset() {
 	*x = Update_TerraformerAddLoadBalancerNodes_New{}
-	mi := &file_spec_manifest_proto_msgTypes[67]
+	mi := &file_spec_manifest_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4974,7 +5026,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes_New) String() string {
 func (*Update_TerraformerAddLoadBalancerNodes_New) ProtoMessage() {}
 
 func (x *Update_TerraformerAddLoadBalancerNodes_New) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[67]
+	mi := &file_spec_manifest_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4987,7 +5039,7 @@ func (x *Update_TerraformerAddLoadBalancerNodes_New) ProtoReflect() protoreflect
 
 // Deprecated: Use Update_TerraformerAddLoadBalancerNodes_New.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddLoadBalancerNodes_New) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 10, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 10, 1}
 }
 
 func (x *Update_TerraformerAddLoadBalancerNodes_New) GetNodepool() *NodePool {
@@ -5006,7 +5058,7 @@ type Update_AnsiblerReplaceTargetPools_TargetPools struct {
 
 func (x *Update_AnsiblerReplaceTargetPools_TargetPools) Reset() {
 	*x = Update_AnsiblerReplaceTargetPools_TargetPools{}
-	mi := &file_spec_manifest_proto_msgTypes[68]
+	mi := &file_spec_manifest_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5018,7 +5070,7 @@ func (x *Update_AnsiblerReplaceTargetPools_TargetPools) String() string {
 func (*Update_AnsiblerReplaceTargetPools_TargetPools) ProtoMessage() {}
 
 func (x *Update_AnsiblerReplaceTargetPools_TargetPools) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[68]
+	mi := &file_spec_manifest_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5031,7 +5083,7 @@ func (x *Update_AnsiblerReplaceTargetPools_TargetPools) ProtoReflect() protorefl
 
 // Deprecated: Use Update_AnsiblerReplaceTargetPools_TargetPools.ProtoReflect.Descriptor instead.
 func (*Update_AnsiblerReplaceTargetPools_TargetPools) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 27, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 27, 0}
 }
 
 func (x *Update_AnsiblerReplaceTargetPools_TargetPools) GetPools() []string {
@@ -5050,7 +5102,7 @@ type Update_ReplacedTargetPools_TargetPools struct {
 
 func (x *Update_ReplacedTargetPools_TargetPools) Reset() {
 	*x = Update_ReplacedTargetPools_TargetPools{}
-	mi := &file_spec_manifest_proto_msgTypes[70]
+	mi := &file_spec_manifest_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5062,7 +5114,7 @@ func (x *Update_ReplacedTargetPools_TargetPools) String() string {
 func (*Update_ReplacedTargetPools_TargetPools) ProtoMessage() {}
 
 func (x *Update_ReplacedTargetPools_TargetPools) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[70]
+	mi := &file_spec_manifest_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5075,7 +5127,7 @@ func (x *Update_ReplacedTargetPools_TargetPools) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use Update_ReplacedTargetPools_TargetPools.ProtoReflect.Descriptor instead.
 func (*Update_ReplacedTargetPools_TargetPools) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 28, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 28, 0}
 }
 
 func (x *Update_ReplacedTargetPools_TargetPools) GetPools() []string {
@@ -5094,7 +5146,7 @@ type Update_KuberPatchNodes_ListOfTaints struct {
 
 func (x *Update_KuberPatchNodes_ListOfTaints) Reset() {
 	*x = Update_KuberPatchNodes_ListOfTaints{}
-	mi := &file_spec_manifest_proto_msgTypes[72]
+	mi := &file_spec_manifest_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5106,7 +5158,7 @@ func (x *Update_KuberPatchNodes_ListOfTaints) String() string {
 func (*Update_KuberPatchNodes_ListOfTaints) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_ListOfTaints) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[72]
+	mi := &file_spec_manifest_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5119,7 +5171,7 @@ func (x *Update_KuberPatchNodes_ListOfTaints) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use Update_KuberPatchNodes_ListOfTaints.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_ListOfTaints) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 0}
 }
 
 func (x *Update_KuberPatchNodes_ListOfTaints) GetTaints() []*Taint {
@@ -5138,7 +5190,7 @@ type Update_KuberPatchNodes_ListOfLabelKeys struct {
 
 func (x *Update_KuberPatchNodes_ListOfLabelKeys) Reset() {
 	*x = Update_KuberPatchNodes_ListOfLabelKeys{}
-	mi := &file_spec_manifest_proto_msgTypes[73]
+	mi := &file_spec_manifest_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5150,7 +5202,7 @@ func (x *Update_KuberPatchNodes_ListOfLabelKeys) String() string {
 func (*Update_KuberPatchNodes_ListOfLabelKeys) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_ListOfLabelKeys) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[73]
+	mi := &file_spec_manifest_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5163,7 +5215,7 @@ func (x *Update_KuberPatchNodes_ListOfLabelKeys) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use Update_KuberPatchNodes_ListOfLabelKeys.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_ListOfLabelKeys) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 1}
 }
 
 func (x *Update_KuberPatchNodes_ListOfLabelKeys) GetLabels() []string {
@@ -5182,7 +5234,7 @@ type Update_KuberPatchNodes_ListOfAnnotationKeys struct {
 
 func (x *Update_KuberPatchNodes_ListOfAnnotationKeys) Reset() {
 	*x = Update_KuberPatchNodes_ListOfAnnotationKeys{}
-	mi := &file_spec_manifest_proto_msgTypes[74]
+	mi := &file_spec_manifest_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5194,7 +5246,7 @@ func (x *Update_KuberPatchNodes_ListOfAnnotationKeys) String() string {
 func (*Update_KuberPatchNodes_ListOfAnnotationKeys) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_ListOfAnnotationKeys) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[74]
+	mi := &file_spec_manifest_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5207,7 +5259,7 @@ func (x *Update_KuberPatchNodes_ListOfAnnotationKeys) ProtoReflect() protoreflec
 
 // Deprecated: Use Update_KuberPatchNodes_ListOfAnnotationKeys.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_ListOfAnnotationKeys) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 2}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 2}
 }
 
 func (x *Update_KuberPatchNodes_ListOfAnnotationKeys) GetAnnotations() []string {
@@ -5226,7 +5278,7 @@ type Update_KuberPatchNodes_MapOfLabels struct {
 
 func (x *Update_KuberPatchNodes_MapOfLabels) Reset() {
 	*x = Update_KuberPatchNodes_MapOfLabels{}
-	mi := &file_spec_manifest_proto_msgTypes[75]
+	mi := &file_spec_manifest_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5238,7 +5290,7 @@ func (x *Update_KuberPatchNodes_MapOfLabels) String() string {
 func (*Update_KuberPatchNodes_MapOfLabels) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_MapOfLabels) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[75]
+	mi := &file_spec_manifest_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5251,7 +5303,7 @@ func (x *Update_KuberPatchNodes_MapOfLabels) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use Update_KuberPatchNodes_MapOfLabels.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_MapOfLabels) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 3}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 3}
 }
 
 func (x *Update_KuberPatchNodes_MapOfLabels) GetLabels() map[string]string {
@@ -5270,7 +5322,7 @@ type Update_KuberPatchNodes_MapOfAnnotations struct {
 
 func (x *Update_KuberPatchNodes_MapOfAnnotations) Reset() {
 	*x = Update_KuberPatchNodes_MapOfAnnotations{}
-	mi := &file_spec_manifest_proto_msgTypes[76]
+	mi := &file_spec_manifest_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5282,7 +5334,7 @@ func (x *Update_KuberPatchNodes_MapOfAnnotations) String() string {
 func (*Update_KuberPatchNodes_MapOfAnnotations) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_MapOfAnnotations) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[76]
+	mi := &file_spec_manifest_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5295,7 +5347,7 @@ func (x *Update_KuberPatchNodes_MapOfAnnotations) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use Update_KuberPatchNodes_MapOfAnnotations.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_MapOfAnnotations) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 4}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 4}
 }
 
 func (x *Update_KuberPatchNodes_MapOfAnnotations) GetAnnotations() map[string]string {
@@ -5316,7 +5368,7 @@ type Update_KuberPatchNodes_RemoveBatch struct {
 
 func (x *Update_KuberPatchNodes_RemoveBatch) Reset() {
 	*x = Update_KuberPatchNodes_RemoveBatch{}
-	mi := &file_spec_manifest_proto_msgTypes[77]
+	mi := &file_spec_manifest_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5328,7 +5380,7 @@ func (x *Update_KuberPatchNodes_RemoveBatch) String() string {
 func (*Update_KuberPatchNodes_RemoveBatch) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_RemoveBatch) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[77]
+	mi := &file_spec_manifest_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5341,7 +5393,7 @@ func (x *Update_KuberPatchNodes_RemoveBatch) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use Update_KuberPatchNodes_RemoveBatch.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_RemoveBatch) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 5}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 5}
 }
 
 func (x *Update_KuberPatchNodes_RemoveBatch) GetTaints() map[string]*Update_KuberPatchNodes_ListOfTaints {
@@ -5376,7 +5428,7 @@ type Update_KuberPatchNodes_AddBatch struct {
 
 func (x *Update_KuberPatchNodes_AddBatch) Reset() {
 	*x = Update_KuberPatchNodes_AddBatch{}
-	mi := &file_spec_manifest_proto_msgTypes[78]
+	mi := &file_spec_manifest_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5388,7 +5440,7 @@ func (x *Update_KuberPatchNodes_AddBatch) String() string {
 func (*Update_KuberPatchNodes_AddBatch) ProtoMessage() {}
 
 func (x *Update_KuberPatchNodes_AddBatch) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[78]
+	mi := &file_spec_manifest_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5401,7 +5453,7 @@ func (x *Update_KuberPatchNodes_AddBatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_KuberPatchNodes_AddBatch.ProtoReflect.Descriptor instead.
 func (*Update_KuberPatchNodes_AddBatch) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 30, 6}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 30, 6}
 }
 
 func (x *Update_KuberPatchNodes_AddBatch) GetTaints() map[string]*Update_KuberPatchNodes_ListOfTaints {
@@ -5436,7 +5488,7 @@ type Update_DeletedK8SNodes_WholeNodePool struct {
 
 func (x *Update_DeletedK8SNodes_WholeNodePool) Reset() {
 	*x = Update_DeletedK8SNodes_WholeNodePool{}
-	mi := &file_spec_manifest_proto_msgTypes[87]
+	mi := &file_spec_manifest_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5448,7 +5500,7 @@ func (x *Update_DeletedK8SNodes_WholeNodePool) String() string {
 func (*Update_DeletedK8SNodes_WholeNodePool) ProtoMessage() {}
 
 func (x *Update_DeletedK8SNodes_WholeNodePool) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[87]
+	mi := &file_spec_manifest_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5461,7 +5513,7 @@ func (x *Update_DeletedK8SNodes_WholeNodePool) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use Update_DeletedK8SNodes_WholeNodePool.ProtoReflect.Descriptor instead.
 func (*Update_DeletedK8SNodes_WholeNodePool) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 33, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 33, 0}
 }
 
 func (x *Update_DeletedK8SNodes_WholeNodePool) GetNodepool() *NodePool {
@@ -5491,7 +5543,7 @@ type Update_DeletedK8SNodes_Partial struct {
 
 func (x *Update_DeletedK8SNodes_Partial) Reset() {
 	*x = Update_DeletedK8SNodes_Partial{}
-	mi := &file_spec_manifest_proto_msgTypes[88]
+	mi := &file_spec_manifest_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5503,7 +5555,7 @@ func (x *Update_DeletedK8SNodes_Partial) String() string {
 func (*Update_DeletedK8SNodes_Partial) ProtoMessage() {}
 
 func (x *Update_DeletedK8SNodes_Partial) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[88]
+	mi := &file_spec_manifest_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5516,7 +5568,7 @@ func (x *Update_DeletedK8SNodes_Partial) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_DeletedK8SNodes_Partial.ProtoReflect.Descriptor instead.
 func (*Update_DeletedK8SNodes_Partial) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 33, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 33, 1}
 }
 
 func (x *Update_DeletedK8SNodes_Partial) GetNodepool() string {
@@ -5554,7 +5606,7 @@ type Update_TerraformerAddK8SNodes_Existing struct {
 
 func (x *Update_TerraformerAddK8SNodes_Existing) Reset() {
 	*x = Update_TerraformerAddK8SNodes_Existing{}
-	mi := &file_spec_manifest_proto_msgTypes[90]
+	mi := &file_spec_manifest_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5566,7 +5618,7 @@ func (x *Update_TerraformerAddK8SNodes_Existing) String() string {
 func (*Update_TerraformerAddK8SNodes_Existing) ProtoMessage() {}
 
 func (x *Update_TerraformerAddK8SNodes_Existing) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[90]
+	mi := &file_spec_manifest_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5579,7 +5631,7 @@ func (x *Update_TerraformerAddK8SNodes_Existing) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use Update_TerraformerAddK8SNodes_Existing.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddK8SNodes_Existing) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 34, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 34, 0}
 }
 
 func (x *Update_TerraformerAddK8SNodes_Existing) GetNodepool() string {
@@ -5607,7 +5659,7 @@ type Update_TerraformerAddK8SNodes_New struct {
 
 func (x *Update_TerraformerAddK8SNodes_New) Reset() {
 	*x = Update_TerraformerAddK8SNodes_New{}
-	mi := &file_spec_manifest_proto_msgTypes[91]
+	mi := &file_spec_manifest_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5619,7 +5671,7 @@ func (x *Update_TerraformerAddK8SNodes_New) String() string {
 func (*Update_TerraformerAddK8SNodes_New) ProtoMessage() {}
 
 func (x *Update_TerraformerAddK8SNodes_New) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[91]
+	mi := &file_spec_manifest_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5632,7 +5684,7 @@ func (x *Update_TerraformerAddK8SNodes_New) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use Update_TerraformerAddK8SNodes_New.ProtoReflect.Descriptor instead.
 func (*Update_TerraformerAddK8SNodes_New) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{16, 34, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{17, 34, 1}
 }
 
 func (x *Update_TerraformerAddK8SNodes_New) GetNodepool() *NodePool {
@@ -5652,7 +5704,7 @@ type TaskResult_Error struct {
 
 func (x *TaskResult_Error) Reset() {
 	*x = TaskResult_Error{}
-	mi := &file_spec_manifest_proto_msgTypes[92]
+	mi := &file_spec_manifest_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5664,7 +5716,7 @@ func (x *TaskResult_Error) String() string {
 func (*TaskResult_Error) ProtoMessage() {}
 
 func (x *TaskResult_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[92]
+	mi := &file_spec_manifest_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5677,7 +5729,7 @@ func (x *TaskResult_Error) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskResult_Error.ProtoReflect.Descriptor instead.
 func (*TaskResult_Error) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20, 0}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21, 0}
 }
 
 func (x *TaskResult_Error) GetKind() TaskResult_Error_Kind {
@@ -5705,7 +5757,7 @@ type TaskResult_None struct {
 
 func (x *TaskResult_None) Reset() {
 	*x = TaskResult_None{}
-	mi := &file_spec_manifest_proto_msgTypes[93]
+	mi := &file_spec_manifest_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5717,7 +5769,7 @@ func (x *TaskResult_None) String() string {
 func (*TaskResult_None) ProtoMessage() {}
 
 func (x *TaskResult_None) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[93]
+	mi := &file_spec_manifest_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5730,7 +5782,7 @@ func (x *TaskResult_None) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskResult_None.ProtoReflect.Descriptor instead.
 func (*TaskResult_None) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20, 1}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21, 1}
 }
 
 // UpdateState specifies the current state should be updated
@@ -5756,7 +5808,7 @@ type TaskResult_UpdateState struct {
 
 func (x *TaskResult_UpdateState) Reset() {
 	*x = TaskResult_UpdateState{}
-	mi := &file_spec_manifest_proto_msgTypes[94]
+	mi := &file_spec_manifest_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5768,7 +5820,7 @@ func (x *TaskResult_UpdateState) String() string {
 func (*TaskResult_UpdateState) ProtoMessage() {}
 
 func (x *TaskResult_UpdateState) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[94]
+	mi := &file_spec_manifest_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5781,7 +5833,7 @@ func (x *TaskResult_UpdateState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskResult_UpdateState.ProtoReflect.Descriptor instead.
 func (*TaskResult_UpdateState) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20, 2}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21, 2}
 }
 
 func (x *TaskResult_UpdateState) GetK8S() *K8Scluster {
@@ -5814,7 +5866,7 @@ type TaskResult_ClearState struct {
 
 func (x *TaskResult_ClearState) Reset() {
 	*x = TaskResult_ClearState{}
-	mi := &file_spec_manifest_proto_msgTypes[95]
+	mi := &file_spec_manifest_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5826,7 +5878,7 @@ func (x *TaskResult_ClearState) String() string {
 func (*TaskResult_ClearState) ProtoMessage() {}
 
 func (x *TaskResult_ClearState) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_manifest_proto_msgTypes[95]
+	mi := &file_spec_manifest_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5839,7 +5891,7 @@ func (x *TaskResult_ClearState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskResult_ClearState.ProtoReflect.Descriptor instead.
 func (*TaskResult_ClearState) Descriptor() ([]byte, []int) {
-	return file_spec_manifest_proto_rawDescGZIP(), []int{20, 3}
+	return file_spec_manifest_proto_rawDescGZIP(), []int{21, 3}
 }
 
 func (x *TaskResult_ClearState) GetK8S() bool {
@@ -5879,11 +5931,17 @@ const file_spec_manifest_proto_rawDesc = "" +
 	"\aPending\x10\x00\x12\r\n" +
 	"\tScheduled\x10\x01\x12\b\n" +
 	"\x04Done\x10\x02\x12\t\n" +
-	"\x05Error\x10\x03\"\x8b\x01\n" +
+	"\x05Error\x10\x03\"\xc1\x01\n" +
+	"\bCounters\x12h\n" +
+	"\x18k8sNodePoolScaleUpFailed\x18\x01 \x03(\v2,.spec.Counters.K8sNodePoolScaleUpFailedEntryR\x18k8sNodePoolScaleUpFailed\x1aK\n" +
+	"\x1dK8sNodePoolScaleUpFailedEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xb7\x01\n" +
 	"\fClusterState\x12(\n" +
 	"\acurrent\x18\x01 \x01(\v2\x0e.spec.ClustersR\acurrent\x12$\n" +
 	"\x05state\x18\x04 \x01(\v2\x0e.spec.WorkflowR\x05state\x12+\n" +
-	"\binFlight\x18\x05 \x01(\v2\x0f.spec.TaskEventR\binFlight\"i\n" +
+	"\binFlight\x18\x05 \x01(\v2\x0f.spec.TaskEventR\binFlight\x12*\n" +
+	"\bcounters\x18\x06 \x01(\v2\x0e.spec.CountersR\bcounters\"i\n" +
 	"\bClusters\x12\"\n" +
 	"\x03k8s\x18\x01 \x01(\v2\x10.spec.K8sclusterR\x03k8s\x129\n" +
 	"\rloadBalancers\x18\x02 \x01(\v2\x13.spec.LoadBalancersR\rloadBalancers\"<\n" +
@@ -6298,7 +6356,7 @@ func file_spec_manifest_proto_rawDescGZIP() []byte {
 }
 
 var file_spec_manifest_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_spec_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
+var file_spec_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
 var file_spec_manifest_proto_goTypes = []any{
 	(RoleType)(0),                            // 0: spec.RoleType
 	(Event)(0),                               // 1: spec.Event
@@ -6308,255 +6366,259 @@ var file_spec_manifest_proto_goTypes = []any{
 	(TaskResult_Error_Kind)(0),               // 5: spec.TaskResult.Error.Kind
 	(*Config)(nil),                           // 6: spec.Config
 	(*Manifest)(nil),                         // 7: spec.Manifest
-	(*ClusterState)(nil),                     // 8: spec.ClusterState
-	(*Clusters)(nil),                         // 9: spec.Clusters
-	(*LoadBalancers)(nil),                    // 10: spec.LoadBalancers
-	(*KubernetesContext)(nil),                // 11: spec.KubernetesContext
-	(*FinishedWorkflow)(nil),                 // 12: spec.FinishedWorkflow
-	(*Workflow)(nil),                         // 13: spec.Workflow
-	(*K8Scluster)(nil),                       // 14: spec.K8scluster
-	(*LBcluster)(nil),                        // 15: spec.LBcluster
-	(*ClusterInfo)(nil),                      // 16: spec.ClusterInfo
-	(*InstallationProxy)(nil),                // 17: spec.InstallationProxy
-	(*Role)(nil),                             // 18: spec.Role
-	(*TaskEvent)(nil),                        // 19: spec.TaskEvent
-	(*Unreachable)(nil),                      // 20: spec.Unreachable
-	(*Create)(nil),                           // 21: spec.Create
-	(*Update)(nil),                           // 22: spec.Update
-	(*Delete)(nil),                           // 23: spec.Delete
-	(*Task)(nil),                             // 24: spec.Task
-	(*Work)(nil),                             // 25: spec.Work
-	(*TaskResult)(nil),                       // 26: spec.TaskResult
-	nil,                                      // 27: spec.Config.ClustersEntry
-	(*Role_Settings)(nil),                    // 28: spec.Role.Settings
-	(*Unreachable_ListOfNodeEndpoints)(nil),  // 29: spec.Unreachable.ListOfNodeEndpoints
-	(*Unreachable_UnreachableNodePools)(nil), // 30: spec.Unreachable.UnreachableNodePools
-	nil,                                      // 31: spec.Unreachable.LoadbalancersEntry
-	nil,                                      // 32: spec.Unreachable.UnreachableNodePools.NodepoolsEntry
-	(*Update_State)(nil),                     // 33: spec.Update.State
-	(*Update_None)(nil),                      // 34: spec.Update.None
-	(*Update_TerraformerMoveNodePoolToAutoscaled)(nil),    // 35: spec.Update.TerraformerMoveNodePoolToAutoscaled
-	(*Update_MovedNodePoolToAutoscaled)(nil),              // 36: spec.Update.MovedNodePoolToAutoscaled
-	(*Update_TerraformerMoveNodePoolFromAutoscaled)(nil),  // 37: spec.Update.TerraformerMoveNodePoolFromAutoscaled
-	(*Update_MovedNodePoolFromAutoscaled)(nil),            // 38: spec.Update.MovedNodePoolFromAutoscaled
-	(*Update_TerraformerAddLoadBalancer)(nil),             // 39: spec.Update.TerraformerAddLoadBalancer
-	(*Update_AddedLoadBalancer)(nil),                      // 40: spec.Update.AddedLoadBalancer
-	(*Update_TerraformerDeleteLoadBalancerNodes)(nil),     // 41: spec.Update.TerraformerDeleteLoadBalancerNodes
-	(*Update_DeletedLoadBalancerNodes)(nil),               // 42: spec.Update.DeletedLoadBalancerNodes
-	(*Update_TerraformerAddLoadBalancerNodes)(nil),        // 43: spec.Update.TerraformerAddLoadBalancerNodes
-	(*Update_AddedLoadBalancerNodes)(nil),                 // 44: spec.Update.AddedLoadBalancerNodes
-	(*Update_DeleteLoadBalancerRoles)(nil),                // 45: spec.Update.DeleteLoadBalancerRoles
-	(*Update_TerraformerAddLoadBalancerRoles)(nil),        // 46: spec.Update.TerraformerAddLoadBalancerRoles
-	(*Update_AddedLoadBalancerRoles)(nil),                 // 47: spec.Update.AddedLoadBalancerRoles
-	(*Update_TerraformerReplaceDns)(nil),                  // 48: spec.Update.TerraformerReplaceDns
-	(*Update_ReplacedDns)(nil),                            // 49: spec.Update.ReplacedDns
-	(*Update_DeleteLoadBalancer)(nil),                     // 50: spec.Update.DeleteLoadBalancer
-	(*Update_ApiEndpoint)(nil),                            // 51: spec.Update.ApiEndpoint
-	(*Update_K8SOnlyApiEndpoint)(nil),                     // 52: spec.Update.K8sOnlyApiEndpoint
-	(*Update_ApiPortOnCluster)(nil),                       // 53: spec.Update.ApiPortOnCluster
-	(*Update_AnsiblerReplaceProxySettings)(nil),           // 54: spec.Update.AnsiblerReplaceProxySettings
-	(*Update_ReplacedProxySettings)(nil),                  // 55: spec.Update.ReplacedProxySettings
-	(*Update_TerraformerReplaceRoleExternalSettings)(nil), // 56: spec.Update.TerraformerReplaceRoleExternalSettings
-	(*Update_ReplacedRoleExternalSettings)(nil),           // 57: spec.Update.ReplacedRoleExternalSettings
-	(*Update_AnsiblerReplaceRoleInternalSettings)(nil),    // 58: spec.Update.AnsiblerReplaceRoleInternalSettings
-	(*Update_ReplacedRoleInternalSettings)(nil),           // 59: spec.Update.ReplacedRoleInternalSettings
-	(*Update_AnsiblerReplaceTargetPools)(nil),             // 60: spec.Update.AnsiblerReplaceTargetPools
-	(*Update_ReplacedTargetPools)(nil),                    // 61: spec.Update.ReplacedTargetPools
-	(*Update_UpgradeVersion)(nil),                         // 62: spec.Update.UpgradeVersion
-	(*Update_KuberPatchNodes)(nil),                        // 63: spec.Update.KuberPatchNodes
-	(*Update_PatchedNodes)(nil),                           // 64: spec.Update.PatchedNodes
-	(*Update_KuberDeleteK8SNodes)(nil),                    // 65: spec.Update.KuberDeleteK8sNodes
-	(*Update_DeletedK8SNodes)(nil),                        // 66: spec.Update.DeletedK8sNodes
-	(*Update_TerraformerAddK8SNodes)(nil),                 // 67: spec.Update.TerraformerAddK8sNodes
-	(*Update_AddedK8SNodes)(nil),                          // 68: spec.Update.AddedK8sNodes
-	(*Update_DeletedLoadBalancerNodes_WholeNodePool)(nil), // 69: spec.Update.DeletedLoadBalancerNodes.WholeNodePool
-	(*Update_DeletedLoadBalancerNodes_Partial)(nil),       // 70: spec.Update.DeletedLoadBalancerNodes.Partial
-	nil, // 71: spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
-	(*Update_TerraformerAddLoadBalancerNodes_Existing)(nil), // 72: spec.Update.TerraformerAddLoadBalancerNodes.Existing
-	(*Update_TerraformerAddLoadBalancerNodes_New)(nil),      // 73: spec.Update.TerraformerAddLoadBalancerNodes.New
-	(*Update_AnsiblerReplaceTargetPools_TargetPools)(nil),   // 74: spec.Update.AnsiblerReplaceTargetPools.TargetPools
-	nil, // 75: spec.Update.AnsiblerReplaceTargetPools.RolesEntry
-	(*Update_ReplacedTargetPools_TargetPools)(nil), // 76: spec.Update.ReplacedTargetPools.TargetPools
-	nil, // 77: spec.Update.ReplacedTargetPools.RolesEntry
-	(*Update_KuberPatchNodes_ListOfTaints)(nil),         // 78: spec.Update.KuberPatchNodes.ListOfTaints
-	(*Update_KuberPatchNodes_ListOfLabelKeys)(nil),      // 79: spec.Update.KuberPatchNodes.ListOfLabelKeys
-	(*Update_KuberPatchNodes_ListOfAnnotationKeys)(nil), // 80: spec.Update.KuberPatchNodes.ListOfAnnotationKeys
-	(*Update_KuberPatchNodes_MapOfLabels)(nil),          // 81: spec.Update.KuberPatchNodes.MapOfLabels
-	(*Update_KuberPatchNodes_MapOfAnnotations)(nil),     // 82: spec.Update.KuberPatchNodes.MapOfAnnotations
-	(*Update_KuberPatchNodes_RemoveBatch)(nil),          // 83: spec.Update.KuberPatchNodes.RemoveBatch
-	(*Update_KuberPatchNodes_AddBatch)(nil),             // 84: spec.Update.KuberPatchNodes.AddBatch
-	nil,                                                 // 85: spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
-	nil,                                                 // 86: spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
-	nil,                                                 // 87: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
-	nil,                                                 // 88: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
-	nil,                                                 // 89: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
-	nil,                                                 // 90: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
-	nil,                                                 // 91: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
-	nil,                                                 // 92: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
-	(*Update_DeletedK8SNodes_WholeNodePool)(nil), // 93: spec.Update.DeletedK8sNodes.WholeNodePool
-	(*Update_DeletedK8SNodes_Partial)(nil),       // 94: spec.Update.DeletedK8sNodes.Partial
-	nil,                                          // 95: spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
-	(*Update_TerraformerAddK8SNodes_Existing)(nil), // 96: spec.Update.TerraformerAddK8sNodes.Existing
-	(*Update_TerraformerAddK8SNodes_New)(nil),      // 97: spec.Update.TerraformerAddK8sNodes.New
-	(*TaskResult_Error)(nil),                       // 98: spec.TaskResult.Error
-	(*TaskResult_None)(nil),                        // 99: spec.TaskResult.None
-	(*TaskResult_UpdateState)(nil),                 // 100: spec.TaskResult.UpdateState
-	(*TaskResult_ClearState)(nil),                  // 101: spec.TaskResult.ClearState
-	(*timestamppb.Timestamp)(nil),                  // 102: google.protobuf.Timestamp
-	(*DNS)(nil),                                    // 103: spec.DNS
-	(*NodePool)(nil),                               // 104: spec.NodePool
-	(*Stage)(nil),                                  // 105: spec.Stage
-	(*anypb.Any)(nil),                              // 106: google.protobuf.Any
-	(*AutoscalerConf)(nil),                         // 107: spec.AutoscalerConf
-	(*Node)(nil),                                   // 108: spec.Node
-	(*Taint)(nil),                                  // 109: spec.Taint
+	(*Counters)(nil),                         // 8: spec.Counters
+	(*ClusterState)(nil),                     // 9: spec.ClusterState
+	(*Clusters)(nil),                         // 10: spec.Clusters
+	(*LoadBalancers)(nil),                    // 11: spec.LoadBalancers
+	(*KubernetesContext)(nil),                // 12: spec.KubernetesContext
+	(*FinishedWorkflow)(nil),                 // 13: spec.FinishedWorkflow
+	(*Workflow)(nil),                         // 14: spec.Workflow
+	(*K8Scluster)(nil),                       // 15: spec.K8scluster
+	(*LBcluster)(nil),                        // 16: spec.LBcluster
+	(*ClusterInfo)(nil),                      // 17: spec.ClusterInfo
+	(*InstallationProxy)(nil),                // 18: spec.InstallationProxy
+	(*Role)(nil),                             // 19: spec.Role
+	(*TaskEvent)(nil),                        // 20: spec.TaskEvent
+	(*Unreachable)(nil),                      // 21: spec.Unreachable
+	(*Create)(nil),                           // 22: spec.Create
+	(*Update)(nil),                           // 23: spec.Update
+	(*Delete)(nil),                           // 24: spec.Delete
+	(*Task)(nil),                             // 25: spec.Task
+	(*Work)(nil),                             // 26: spec.Work
+	(*TaskResult)(nil),                       // 27: spec.TaskResult
+	nil,                                      // 28: spec.Config.ClustersEntry
+	nil,                                      // 29: spec.Counters.K8sNodePoolScaleUpFailedEntry
+	(*Role_Settings)(nil),                    // 30: spec.Role.Settings
+	(*Unreachable_ListOfNodeEndpoints)(nil),  // 31: spec.Unreachable.ListOfNodeEndpoints
+	(*Unreachable_UnreachableNodePools)(nil), // 32: spec.Unreachable.UnreachableNodePools
+	nil,                                      // 33: spec.Unreachable.LoadbalancersEntry
+	nil,                                      // 34: spec.Unreachable.UnreachableNodePools.NodepoolsEntry
+	(*Update_State)(nil),                     // 35: spec.Update.State
+	(*Update_None)(nil),                      // 36: spec.Update.None
+	(*Update_TerraformerMoveNodePoolToAutoscaled)(nil),    // 37: spec.Update.TerraformerMoveNodePoolToAutoscaled
+	(*Update_MovedNodePoolToAutoscaled)(nil),              // 38: spec.Update.MovedNodePoolToAutoscaled
+	(*Update_TerraformerMoveNodePoolFromAutoscaled)(nil),  // 39: spec.Update.TerraformerMoveNodePoolFromAutoscaled
+	(*Update_MovedNodePoolFromAutoscaled)(nil),            // 40: spec.Update.MovedNodePoolFromAutoscaled
+	(*Update_TerraformerAddLoadBalancer)(nil),             // 41: spec.Update.TerraformerAddLoadBalancer
+	(*Update_AddedLoadBalancer)(nil),                      // 42: spec.Update.AddedLoadBalancer
+	(*Update_TerraformerDeleteLoadBalancerNodes)(nil),     // 43: spec.Update.TerraformerDeleteLoadBalancerNodes
+	(*Update_DeletedLoadBalancerNodes)(nil),               // 44: spec.Update.DeletedLoadBalancerNodes
+	(*Update_TerraformerAddLoadBalancerNodes)(nil),        // 45: spec.Update.TerraformerAddLoadBalancerNodes
+	(*Update_AddedLoadBalancerNodes)(nil),                 // 46: spec.Update.AddedLoadBalancerNodes
+	(*Update_DeleteLoadBalancerRoles)(nil),                // 47: spec.Update.DeleteLoadBalancerRoles
+	(*Update_TerraformerAddLoadBalancerRoles)(nil),        // 48: spec.Update.TerraformerAddLoadBalancerRoles
+	(*Update_AddedLoadBalancerRoles)(nil),                 // 49: spec.Update.AddedLoadBalancerRoles
+	(*Update_TerraformerReplaceDns)(nil),                  // 50: spec.Update.TerraformerReplaceDns
+	(*Update_ReplacedDns)(nil),                            // 51: spec.Update.ReplacedDns
+	(*Update_DeleteLoadBalancer)(nil),                     // 52: spec.Update.DeleteLoadBalancer
+	(*Update_ApiEndpoint)(nil),                            // 53: spec.Update.ApiEndpoint
+	(*Update_K8SOnlyApiEndpoint)(nil),                     // 54: spec.Update.K8sOnlyApiEndpoint
+	(*Update_ApiPortOnCluster)(nil),                       // 55: spec.Update.ApiPortOnCluster
+	(*Update_AnsiblerReplaceProxySettings)(nil),           // 56: spec.Update.AnsiblerReplaceProxySettings
+	(*Update_ReplacedProxySettings)(nil),                  // 57: spec.Update.ReplacedProxySettings
+	(*Update_TerraformerReplaceRoleExternalSettings)(nil), // 58: spec.Update.TerraformerReplaceRoleExternalSettings
+	(*Update_ReplacedRoleExternalSettings)(nil),           // 59: spec.Update.ReplacedRoleExternalSettings
+	(*Update_AnsiblerReplaceRoleInternalSettings)(nil),    // 60: spec.Update.AnsiblerReplaceRoleInternalSettings
+	(*Update_ReplacedRoleInternalSettings)(nil),           // 61: spec.Update.ReplacedRoleInternalSettings
+	(*Update_AnsiblerReplaceTargetPools)(nil),             // 62: spec.Update.AnsiblerReplaceTargetPools
+	(*Update_ReplacedTargetPools)(nil),                    // 63: spec.Update.ReplacedTargetPools
+	(*Update_UpgradeVersion)(nil),                         // 64: spec.Update.UpgradeVersion
+	(*Update_KuberPatchNodes)(nil),                        // 65: spec.Update.KuberPatchNodes
+	(*Update_PatchedNodes)(nil),                           // 66: spec.Update.PatchedNodes
+	(*Update_KuberDeleteK8SNodes)(nil),                    // 67: spec.Update.KuberDeleteK8sNodes
+	(*Update_DeletedK8SNodes)(nil),                        // 68: spec.Update.DeletedK8sNodes
+	(*Update_TerraformerAddK8SNodes)(nil),                 // 69: spec.Update.TerraformerAddK8sNodes
+	(*Update_AddedK8SNodes)(nil),                          // 70: spec.Update.AddedK8sNodes
+	(*Update_DeletedLoadBalancerNodes_WholeNodePool)(nil), // 71: spec.Update.DeletedLoadBalancerNodes.WholeNodePool
+	(*Update_DeletedLoadBalancerNodes_Partial)(nil),       // 72: spec.Update.DeletedLoadBalancerNodes.Partial
+	nil, // 73: spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
+	(*Update_TerraformerAddLoadBalancerNodes_Existing)(nil), // 74: spec.Update.TerraformerAddLoadBalancerNodes.Existing
+	(*Update_TerraformerAddLoadBalancerNodes_New)(nil),      // 75: spec.Update.TerraformerAddLoadBalancerNodes.New
+	(*Update_AnsiblerReplaceTargetPools_TargetPools)(nil),   // 76: spec.Update.AnsiblerReplaceTargetPools.TargetPools
+	nil, // 77: spec.Update.AnsiblerReplaceTargetPools.RolesEntry
+	(*Update_ReplacedTargetPools_TargetPools)(nil), // 78: spec.Update.ReplacedTargetPools.TargetPools
+	nil, // 79: spec.Update.ReplacedTargetPools.RolesEntry
+	(*Update_KuberPatchNodes_ListOfTaints)(nil),         // 80: spec.Update.KuberPatchNodes.ListOfTaints
+	(*Update_KuberPatchNodes_ListOfLabelKeys)(nil),      // 81: spec.Update.KuberPatchNodes.ListOfLabelKeys
+	(*Update_KuberPatchNodes_ListOfAnnotationKeys)(nil), // 82: spec.Update.KuberPatchNodes.ListOfAnnotationKeys
+	(*Update_KuberPatchNodes_MapOfLabels)(nil),          // 83: spec.Update.KuberPatchNodes.MapOfLabels
+	(*Update_KuberPatchNodes_MapOfAnnotations)(nil),     // 84: spec.Update.KuberPatchNodes.MapOfAnnotations
+	(*Update_KuberPatchNodes_RemoveBatch)(nil),          // 85: spec.Update.KuberPatchNodes.RemoveBatch
+	(*Update_KuberPatchNodes_AddBatch)(nil),             // 86: spec.Update.KuberPatchNodes.AddBatch
+	nil,                                                 // 87: spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
+	nil,                                                 // 88: spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
+	nil,                                                 // 89: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
+	nil,                                                 // 90: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
+	nil,                                                 // 91: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
+	nil,                                                 // 92: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
+	nil,                                                 // 93: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
+	nil,                                                 // 94: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
+	(*Update_DeletedK8SNodes_WholeNodePool)(nil), // 95: spec.Update.DeletedK8sNodes.WholeNodePool
+	(*Update_DeletedK8SNodes_Partial)(nil),       // 96: spec.Update.DeletedK8sNodes.Partial
+	nil,                                          // 97: spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
+	(*Update_TerraformerAddK8SNodes_Existing)(nil), // 98: spec.Update.TerraformerAddK8sNodes.Existing
+	(*Update_TerraformerAddK8SNodes_New)(nil),      // 99: spec.Update.TerraformerAddK8sNodes.New
+	(*TaskResult_Error)(nil),                       // 100: spec.TaskResult.Error
+	(*TaskResult_None)(nil),                        // 101: spec.TaskResult.None
+	(*TaskResult_UpdateState)(nil),                 // 102: spec.TaskResult.UpdateState
+	(*TaskResult_ClearState)(nil),                  // 103: spec.TaskResult.ClearState
+	(*timestamppb.Timestamp)(nil),                  // 104: google.protobuf.Timestamp
+	(*DNS)(nil),                                    // 105: spec.DNS
+	(*NodePool)(nil),                               // 106: spec.NodePool
+	(*Stage)(nil),                                  // 107: spec.Stage
+	(*anypb.Any)(nil),                              // 108: google.protobuf.Any
+	(*AutoscalerConf)(nil),                         // 109: spec.AutoscalerConf
+	(*Node)(nil),                                   // 110: spec.Node
+	(*Taint)(nil),                                  // 111: spec.Taint
 }
 var file_spec_manifest_proto_depIdxs = []int32{
-	11,  // 0: spec.Config.k8sCtx:type_name -> spec.KubernetesContext
+	12,  // 0: spec.Config.k8sCtx:type_name -> spec.KubernetesContext
 	7,   // 1: spec.Config.manifest:type_name -> spec.Manifest
-	27,  // 2: spec.Config.clusters:type_name -> spec.Config.ClustersEntry
+	28,  // 2: spec.Config.clusters:type_name -> spec.Config.ClustersEntry
 	3,   // 3: spec.Manifest.state:type_name -> spec.Manifest.State
-	9,   // 4: spec.ClusterState.current:type_name -> spec.Clusters
-	13,  // 5: spec.ClusterState.state:type_name -> spec.Workflow
-	19,  // 6: spec.ClusterState.inFlight:type_name -> spec.TaskEvent
-	14,  // 7: spec.Clusters.k8s:type_name -> spec.K8scluster
-	10,  // 8: spec.Clusters.loadBalancers:type_name -> spec.LoadBalancers
-	15,  // 9: spec.LoadBalancers.clusters:type_name -> spec.LBcluster
-	4,   // 10: spec.FinishedWorkflow.status:type_name -> spec.Workflow.Status
-	102, // 11: spec.FinishedWorkflow.timestamp:type_name -> google.protobuf.Timestamp
-	4,   // 12: spec.Workflow.status:type_name -> spec.Workflow.Status
-	12,  // 13: spec.Workflow.previous:type_name -> spec.FinishedWorkflow
-	16,  // 14: spec.K8scluster.clusterInfo:type_name -> spec.ClusterInfo
-	17,  // 15: spec.K8scluster.installationProxy:type_name -> spec.InstallationProxy
-	16,  // 16: spec.LBcluster.clusterInfo:type_name -> spec.ClusterInfo
-	18,  // 17: spec.LBcluster.roles:type_name -> spec.Role
-	103, // 18: spec.LBcluster.dns:type_name -> spec.DNS
-	104, // 19: spec.ClusterInfo.nodePools:type_name -> spec.NodePool
-	0,   // 20: spec.Role.roleType:type_name -> spec.RoleType
-	28,  // 21: spec.Role.settings:type_name -> spec.Role.Settings
-	102, // 22: spec.TaskEvent.timestamp:type_name -> google.protobuf.Timestamp
-	1,   // 23: spec.TaskEvent.event:type_name -> spec.Event
-	24,  // 24: spec.TaskEvent.task:type_name -> spec.Task
-	105, // 25: spec.TaskEvent.pipeline:type_name -> spec.Stage
-	19,  // 26: spec.TaskEvent.lowerPriority:type_name -> spec.TaskEvent
-	30,  // 27: spec.Unreachable.kubernetes:type_name -> spec.Unreachable.UnreachableNodePools
-	31,  // 28: spec.Unreachable.loadbalancers:type_name -> spec.Unreachable.LoadbalancersEntry
-	14,  // 29: spec.Create.k8s:type_name -> spec.K8scluster
-	15,  // 30: spec.Create.loadBalancers:type_name -> spec.LBcluster
-	33,  // 31: spec.Update.state:type_name -> spec.Update.State
-	34,  // 32: spec.Update.none:type_name -> spec.Update.None
-	39,  // 33: spec.Update.tfAddLoadBalancer:type_name -> spec.Update.TerraformerAddLoadBalancer
-	43,  // 34: spec.Update.tfAddLoadBalancerNodes:type_name -> spec.Update.TerraformerAddLoadBalancerNodes
-	48,  // 35: spec.Update.tfReplaceDns:type_name -> spec.Update.TerraformerReplaceDns
-	67,  // 36: spec.Update.tfAddK8sNodes:type_name -> spec.Update.TerraformerAddK8sNodes
-	46,  // 37: spec.Update.tfAddLoadBalancerRoles:type_name -> spec.Update.TerraformerAddLoadBalancerRoles
-	41,  // 38: spec.Update.tfDeleteLoadBalancerNodes:type_name -> spec.Update.TerraformerDeleteLoadBalancerNodes
-	35,  // 39: spec.Update.tfMoveNodePoolToAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolToAutoscaled
-	37,  // 40: spec.Update.tfMoveNodePoolFromAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolFromAutoscaled
-	56,  // 41: spec.Update.tfReplaceRoleExternalSettings:type_name -> spec.Update.TerraformerReplaceRoleExternalSettings
-	54,  // 42: spec.Update.ansReplaceProxy:type_name -> spec.Update.AnsiblerReplaceProxySettings
-	60,  // 43: spec.Update.ansReplaceTargetPools:type_name -> spec.Update.AnsiblerReplaceTargetPools
-	58,  // 44: spec.Update.ansReplaceRoleInternalSettings:type_name -> spec.Update.AnsiblerReplaceRoleInternalSettings
-	63,  // 45: spec.Update.kpatchNodes:type_name -> spec.Update.KuberPatchNodes
-	65,  // 46: spec.Update.kDeleteNodes:type_name -> spec.Update.KuberDeleteK8sNodes
-	40,  // 47: spec.Update.addedLoadBalancer:type_name -> spec.Update.AddedLoadBalancer
-	44,  // 48: spec.Update.addedLoadBalancerNodes:type_name -> spec.Update.AddedLoadBalancerNodes
-	49,  // 49: spec.Update.replacedDns:type_name -> spec.Update.ReplacedDns
-	68,  // 50: spec.Update.addedK8sNodes:type_name -> spec.Update.AddedK8sNodes
-	55,  // 51: spec.Update.replacedProxy:type_name -> spec.Update.ReplacedProxySettings
-	64,  // 52: spec.Update.patchedNodes:type_name -> spec.Update.PatchedNodes
-	47,  // 53: spec.Update.addedLoadBalancerRoles:type_name -> spec.Update.AddedLoadBalancerRoles
-	61,  // 54: spec.Update.replacedTargetPools:type_name -> spec.Update.ReplacedTargetPools
-	36,  // 55: spec.Update.movedNodePoolToAutoscaled:type_name -> spec.Update.MovedNodePoolToAutoscaled
-	38,  // 56: spec.Update.movedNodePoolFromAutoscaled:type_name -> spec.Update.MovedNodePoolFromAutoscaled
-	59,  // 57: spec.Update.replacedRoleInternalSettings:type_name -> spec.Update.ReplacedRoleInternalSettings
-	57,  // 58: spec.Update.replacedRoleExternalSettings:type_name -> spec.Update.ReplacedRoleExternalSettings
-	50,  // 59: spec.Update.deleteLoadBalancer:type_name -> spec.Update.DeleteLoadBalancer
-	66,  // 60: spec.Update.deletedK8sNodes:type_name -> spec.Update.DeletedK8sNodes
-	42,  // 61: spec.Update.deletedLoadBalancerNodes:type_name -> spec.Update.DeletedLoadBalancerNodes
-	45,  // 62: spec.Update.deleteLoadBalancerRoles:type_name -> spec.Update.DeleteLoadBalancerRoles
-	51,  // 63: spec.Update.apiEndpoint:type_name -> spec.Update.ApiEndpoint
-	53,  // 64: spec.Update.clusterApiPort:type_name -> spec.Update.ApiPortOnCluster
-	52,  // 65: spec.Update.k8sApiEndpoint:type_name -> spec.Update.K8sOnlyApiEndpoint
-	62,  // 66: spec.Update.upgradeVersion:type_name -> spec.Update.UpgradeVersion
-	14,  // 67: spec.Delete.k8s:type_name -> spec.K8scluster
-	15,  // 68: spec.Delete.loadBalancers:type_name -> spec.LBcluster
-	21,  // 69: spec.Task.create:type_name -> spec.Create
-	22,  // 70: spec.Task.update:type_name -> spec.Update
-	23,  // 71: spec.Task.delete:type_name -> spec.Delete
-	24,  // 72: spec.Work.task:type_name -> spec.Task
-	106, // 73: spec.Work.passes:type_name -> google.protobuf.Any
-	98,  // 74: spec.TaskResult.error:type_name -> spec.TaskResult.Error
-	99,  // 75: spec.TaskResult.none:type_name -> spec.TaskResult.None
-	100, // 76: spec.TaskResult.update:type_name -> spec.TaskResult.UpdateState
-	101, // 77: spec.TaskResult.clear:type_name -> spec.TaskResult.ClearState
-	8,   // 78: spec.Config.ClustersEntry.value:type_name -> spec.ClusterState
-	32,  // 79: spec.Unreachable.UnreachableNodePools.nodepools:type_name -> spec.Unreachable.UnreachableNodePools.NodepoolsEntry
-	30,  // 80: spec.Unreachable.LoadbalancersEntry.value:type_name -> spec.Unreachable.UnreachableNodePools
-	29,  // 81: spec.Unreachable.UnreachableNodePools.NodepoolsEntry.value:type_name -> spec.Unreachable.ListOfNodeEndpoints
-	14,  // 82: spec.Update.State.k8s:type_name -> spec.K8scluster
-	15,  // 83: spec.Update.State.loadBalancers:type_name -> spec.LBcluster
-	107, // 84: spec.Update.TerraformerMoveNodePoolToAutoscaled.config:type_name -> spec.AutoscalerConf
-	107, // 85: spec.Update.MovedNodePoolFromAutoscaled.config:type_name -> spec.AutoscalerConf
-	15,  // 86: spec.Update.TerraformerAddLoadBalancer.handle:type_name -> spec.LBcluster
-	20,  // 87: spec.Update.TerraformerDeleteLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
-	20,  // 88: spec.Update.DeletedLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
-	69,  // 89: spec.Update.DeletedLoadBalancerNodes.whole:type_name -> spec.Update.DeletedLoadBalancerNodes.WholeNodePool
-	70,  // 90: spec.Update.DeletedLoadBalancerNodes.partial:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial
-	72,  // 91: spec.Update.TerraformerAddLoadBalancerNodes.existing:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.Existing
-	73,  // 92: spec.Update.TerraformerAddLoadBalancerNodes.new:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.New
-	18,  // 93: spec.Update.TerraformerAddLoadBalancerRoles.roles:type_name -> spec.Role
-	103, // 94: spec.Update.TerraformerReplaceDns.dns:type_name -> spec.DNS
-	20,  // 95: spec.Update.DeleteLoadBalancer.unreachable:type_name -> spec.Unreachable
-	2,   // 96: spec.Update.ApiEndpoint.state:type_name -> spec.ApiEndpointChangeState
-	17,  // 97: spec.Update.AnsiblerReplaceProxySettings.proxy:type_name -> spec.InstallationProxy
-	0,   // 98: spec.Update.TerraformerReplaceRoleExternalSettings.roleType:type_name -> spec.RoleType
-	28,  // 99: spec.Update.AnsiblerReplaceRoleInternalSettings.settings:type_name -> spec.Role.Settings
-	75,  // 100: spec.Update.AnsiblerReplaceTargetPools.roles:type_name -> spec.Update.AnsiblerReplaceTargetPools.RolesEntry
-	77,  // 101: spec.Update.ReplacedTargetPools.roles:type_name -> spec.Update.ReplacedTargetPools.RolesEntry
-	84,  // 102: spec.Update.KuberPatchNodes.add:type_name -> spec.Update.KuberPatchNodes.AddBatch
-	83,  // 103: spec.Update.KuberPatchNodes.remove:type_name -> spec.Update.KuberPatchNodes.RemoveBatch
-	20,  // 104: spec.Update.KuberDeleteK8sNodes.unreachable:type_name -> spec.Unreachable
-	20,  // 105: spec.Update.DeletedK8sNodes.unreachable:type_name -> spec.Unreachable
-	93,  // 106: spec.Update.DeletedK8sNodes.whole:type_name -> spec.Update.DeletedK8sNodes.WholeNodePool
-	94,  // 107: spec.Update.DeletedK8sNodes.partial:type_name -> spec.Update.DeletedK8sNodes.Partial
-	96,  // 108: spec.Update.TerraformerAddK8sNodes.existing:type_name -> spec.Update.TerraformerAddK8sNodes.Existing
-	97,  // 109: spec.Update.TerraformerAddK8sNodes.new:type_name -> spec.Update.TerraformerAddK8sNodes.New
-	104, // 110: spec.Update.DeletedLoadBalancerNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
-	108, // 111: spec.Update.DeletedLoadBalancerNodes.Partial.nodes:type_name -> spec.Node
-	71,  // 112: spec.Update.DeletedLoadBalancerNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
-	108, // 113: spec.Update.TerraformerAddLoadBalancerNodes.Existing.nodes:type_name -> spec.Node
-	104, // 114: spec.Update.TerraformerAddLoadBalancerNodes.New.nodepool:type_name -> spec.NodePool
-	74,  // 115: spec.Update.AnsiblerReplaceTargetPools.RolesEntry.value:type_name -> spec.Update.AnsiblerReplaceTargetPools.TargetPools
-	76,  // 116: spec.Update.ReplacedTargetPools.RolesEntry.value:type_name -> spec.Update.ReplacedTargetPools.TargetPools
-	109, // 117: spec.Update.KuberPatchNodes.ListOfTaints.taints:type_name -> spec.Taint
-	85,  // 118: spec.Update.KuberPatchNodes.MapOfLabels.labels:type_name -> spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
-	86,  // 119: spec.Update.KuberPatchNodes.MapOfAnnotations.annotations:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
-	87,  // 120: spec.Update.KuberPatchNodes.RemoveBatch.taints:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
-	88,  // 121: spec.Update.KuberPatchNodes.RemoveBatch.annotations:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
-	89,  // 122: spec.Update.KuberPatchNodes.RemoveBatch.labels:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
-	90,  // 123: spec.Update.KuberPatchNodes.AddBatch.taints:type_name -> spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
-	91,  // 124: spec.Update.KuberPatchNodes.AddBatch.labels:type_name -> spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
-	92,  // 125: spec.Update.KuberPatchNodes.AddBatch.annotations:type_name -> spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
-	78,  // 126: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
-	80,  // 127: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfAnnotationKeys
-	79,  // 128: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfLabelKeys
-	78,  // 129: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
-	81,  // 130: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfLabels
-	82,  // 131: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations
-	104, // 132: spec.Update.DeletedK8sNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
-	108, // 133: spec.Update.DeletedK8sNodes.Partial.nodes:type_name -> spec.Node
-	95,  // 134: spec.Update.DeletedK8sNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
-	108, // 135: spec.Update.TerraformerAddK8sNodes.Existing.nodes:type_name -> spec.Node
-	104, // 136: spec.Update.TerraformerAddK8sNodes.New.nodepool:type_name -> spec.NodePool
-	5,   // 137: spec.TaskResult.Error.kind:type_name -> spec.TaskResult.Error.Kind
-	14,  // 138: spec.TaskResult.UpdateState.k8s:type_name -> spec.K8scluster
-	10,  // 139: spec.TaskResult.UpdateState.loadBalancers:type_name -> spec.LoadBalancers
-	140, // [140:140] is the sub-list for method output_type
-	140, // [140:140] is the sub-list for method input_type
-	140, // [140:140] is the sub-list for extension type_name
-	140, // [140:140] is the sub-list for extension extendee
-	0,   // [0:140] is the sub-list for field type_name
+	29,  // 4: spec.Counters.k8sNodePoolScaleUpFailed:type_name -> spec.Counters.K8sNodePoolScaleUpFailedEntry
+	10,  // 5: spec.ClusterState.current:type_name -> spec.Clusters
+	14,  // 6: spec.ClusterState.state:type_name -> spec.Workflow
+	20,  // 7: spec.ClusterState.inFlight:type_name -> spec.TaskEvent
+	8,   // 8: spec.ClusterState.counters:type_name -> spec.Counters
+	15,  // 9: spec.Clusters.k8s:type_name -> spec.K8scluster
+	11,  // 10: spec.Clusters.loadBalancers:type_name -> spec.LoadBalancers
+	16,  // 11: spec.LoadBalancers.clusters:type_name -> spec.LBcluster
+	4,   // 12: spec.FinishedWorkflow.status:type_name -> spec.Workflow.Status
+	104, // 13: spec.FinishedWorkflow.timestamp:type_name -> google.protobuf.Timestamp
+	4,   // 14: spec.Workflow.status:type_name -> spec.Workflow.Status
+	13,  // 15: spec.Workflow.previous:type_name -> spec.FinishedWorkflow
+	17,  // 16: spec.K8scluster.clusterInfo:type_name -> spec.ClusterInfo
+	18,  // 17: spec.K8scluster.installationProxy:type_name -> spec.InstallationProxy
+	17,  // 18: spec.LBcluster.clusterInfo:type_name -> spec.ClusterInfo
+	19,  // 19: spec.LBcluster.roles:type_name -> spec.Role
+	105, // 20: spec.LBcluster.dns:type_name -> spec.DNS
+	106, // 21: spec.ClusterInfo.nodePools:type_name -> spec.NodePool
+	0,   // 22: spec.Role.roleType:type_name -> spec.RoleType
+	30,  // 23: spec.Role.settings:type_name -> spec.Role.Settings
+	104, // 24: spec.TaskEvent.timestamp:type_name -> google.protobuf.Timestamp
+	1,   // 25: spec.TaskEvent.event:type_name -> spec.Event
+	25,  // 26: spec.TaskEvent.task:type_name -> spec.Task
+	107, // 27: spec.TaskEvent.pipeline:type_name -> spec.Stage
+	20,  // 28: spec.TaskEvent.lowerPriority:type_name -> spec.TaskEvent
+	32,  // 29: spec.Unreachable.kubernetes:type_name -> spec.Unreachable.UnreachableNodePools
+	33,  // 30: spec.Unreachable.loadbalancers:type_name -> spec.Unreachable.LoadbalancersEntry
+	15,  // 31: spec.Create.k8s:type_name -> spec.K8scluster
+	16,  // 32: spec.Create.loadBalancers:type_name -> spec.LBcluster
+	35,  // 33: spec.Update.state:type_name -> spec.Update.State
+	36,  // 34: spec.Update.none:type_name -> spec.Update.None
+	41,  // 35: spec.Update.tfAddLoadBalancer:type_name -> spec.Update.TerraformerAddLoadBalancer
+	45,  // 36: spec.Update.tfAddLoadBalancerNodes:type_name -> spec.Update.TerraformerAddLoadBalancerNodes
+	50,  // 37: spec.Update.tfReplaceDns:type_name -> spec.Update.TerraformerReplaceDns
+	69,  // 38: spec.Update.tfAddK8sNodes:type_name -> spec.Update.TerraformerAddK8sNodes
+	48,  // 39: spec.Update.tfAddLoadBalancerRoles:type_name -> spec.Update.TerraformerAddLoadBalancerRoles
+	43,  // 40: spec.Update.tfDeleteLoadBalancerNodes:type_name -> spec.Update.TerraformerDeleteLoadBalancerNodes
+	37,  // 41: spec.Update.tfMoveNodePoolToAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolToAutoscaled
+	39,  // 42: spec.Update.tfMoveNodePoolFromAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolFromAutoscaled
+	58,  // 43: spec.Update.tfReplaceRoleExternalSettings:type_name -> spec.Update.TerraformerReplaceRoleExternalSettings
+	56,  // 44: spec.Update.ansReplaceProxy:type_name -> spec.Update.AnsiblerReplaceProxySettings
+	62,  // 45: spec.Update.ansReplaceTargetPools:type_name -> spec.Update.AnsiblerReplaceTargetPools
+	60,  // 46: spec.Update.ansReplaceRoleInternalSettings:type_name -> spec.Update.AnsiblerReplaceRoleInternalSettings
+	65,  // 47: spec.Update.kpatchNodes:type_name -> spec.Update.KuberPatchNodes
+	67,  // 48: spec.Update.kDeleteNodes:type_name -> spec.Update.KuberDeleteK8sNodes
+	42,  // 49: spec.Update.addedLoadBalancer:type_name -> spec.Update.AddedLoadBalancer
+	46,  // 50: spec.Update.addedLoadBalancerNodes:type_name -> spec.Update.AddedLoadBalancerNodes
+	51,  // 51: spec.Update.replacedDns:type_name -> spec.Update.ReplacedDns
+	70,  // 52: spec.Update.addedK8sNodes:type_name -> spec.Update.AddedK8sNodes
+	57,  // 53: spec.Update.replacedProxy:type_name -> spec.Update.ReplacedProxySettings
+	66,  // 54: spec.Update.patchedNodes:type_name -> spec.Update.PatchedNodes
+	49,  // 55: spec.Update.addedLoadBalancerRoles:type_name -> spec.Update.AddedLoadBalancerRoles
+	63,  // 56: spec.Update.replacedTargetPools:type_name -> spec.Update.ReplacedTargetPools
+	38,  // 57: spec.Update.movedNodePoolToAutoscaled:type_name -> spec.Update.MovedNodePoolToAutoscaled
+	40,  // 58: spec.Update.movedNodePoolFromAutoscaled:type_name -> spec.Update.MovedNodePoolFromAutoscaled
+	61,  // 59: spec.Update.replacedRoleInternalSettings:type_name -> spec.Update.ReplacedRoleInternalSettings
+	59,  // 60: spec.Update.replacedRoleExternalSettings:type_name -> spec.Update.ReplacedRoleExternalSettings
+	52,  // 61: spec.Update.deleteLoadBalancer:type_name -> spec.Update.DeleteLoadBalancer
+	68,  // 62: spec.Update.deletedK8sNodes:type_name -> spec.Update.DeletedK8sNodes
+	44,  // 63: spec.Update.deletedLoadBalancerNodes:type_name -> spec.Update.DeletedLoadBalancerNodes
+	47,  // 64: spec.Update.deleteLoadBalancerRoles:type_name -> spec.Update.DeleteLoadBalancerRoles
+	53,  // 65: spec.Update.apiEndpoint:type_name -> spec.Update.ApiEndpoint
+	55,  // 66: spec.Update.clusterApiPort:type_name -> spec.Update.ApiPortOnCluster
+	54,  // 67: spec.Update.k8sApiEndpoint:type_name -> spec.Update.K8sOnlyApiEndpoint
+	64,  // 68: spec.Update.upgradeVersion:type_name -> spec.Update.UpgradeVersion
+	15,  // 69: spec.Delete.k8s:type_name -> spec.K8scluster
+	16,  // 70: spec.Delete.loadBalancers:type_name -> spec.LBcluster
+	22,  // 71: spec.Task.create:type_name -> spec.Create
+	23,  // 72: spec.Task.update:type_name -> spec.Update
+	24,  // 73: spec.Task.delete:type_name -> spec.Delete
+	25,  // 74: spec.Work.task:type_name -> spec.Task
+	108, // 75: spec.Work.passes:type_name -> google.protobuf.Any
+	100, // 76: spec.TaskResult.error:type_name -> spec.TaskResult.Error
+	101, // 77: spec.TaskResult.none:type_name -> spec.TaskResult.None
+	102, // 78: spec.TaskResult.update:type_name -> spec.TaskResult.UpdateState
+	103, // 79: spec.TaskResult.clear:type_name -> spec.TaskResult.ClearState
+	9,   // 80: spec.Config.ClustersEntry.value:type_name -> spec.ClusterState
+	34,  // 81: spec.Unreachable.UnreachableNodePools.nodepools:type_name -> spec.Unreachable.UnreachableNodePools.NodepoolsEntry
+	32,  // 82: spec.Unreachable.LoadbalancersEntry.value:type_name -> spec.Unreachable.UnreachableNodePools
+	31,  // 83: spec.Unreachable.UnreachableNodePools.NodepoolsEntry.value:type_name -> spec.Unreachable.ListOfNodeEndpoints
+	15,  // 84: spec.Update.State.k8s:type_name -> spec.K8scluster
+	16,  // 85: spec.Update.State.loadBalancers:type_name -> spec.LBcluster
+	109, // 86: spec.Update.TerraformerMoveNodePoolToAutoscaled.config:type_name -> spec.AutoscalerConf
+	109, // 87: spec.Update.MovedNodePoolFromAutoscaled.config:type_name -> spec.AutoscalerConf
+	16,  // 88: spec.Update.TerraformerAddLoadBalancer.handle:type_name -> spec.LBcluster
+	21,  // 89: spec.Update.TerraformerDeleteLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
+	21,  // 90: spec.Update.DeletedLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
+	71,  // 91: spec.Update.DeletedLoadBalancerNodes.whole:type_name -> spec.Update.DeletedLoadBalancerNodes.WholeNodePool
+	72,  // 92: spec.Update.DeletedLoadBalancerNodes.partial:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial
+	74,  // 93: spec.Update.TerraformerAddLoadBalancerNodes.existing:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.Existing
+	75,  // 94: spec.Update.TerraformerAddLoadBalancerNodes.new:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.New
+	19,  // 95: spec.Update.TerraformerAddLoadBalancerRoles.roles:type_name -> spec.Role
+	105, // 96: spec.Update.TerraformerReplaceDns.dns:type_name -> spec.DNS
+	21,  // 97: spec.Update.DeleteLoadBalancer.unreachable:type_name -> spec.Unreachable
+	2,   // 98: spec.Update.ApiEndpoint.state:type_name -> spec.ApiEndpointChangeState
+	18,  // 99: spec.Update.AnsiblerReplaceProxySettings.proxy:type_name -> spec.InstallationProxy
+	0,   // 100: spec.Update.TerraformerReplaceRoleExternalSettings.roleType:type_name -> spec.RoleType
+	30,  // 101: spec.Update.AnsiblerReplaceRoleInternalSettings.settings:type_name -> spec.Role.Settings
+	77,  // 102: spec.Update.AnsiblerReplaceTargetPools.roles:type_name -> spec.Update.AnsiblerReplaceTargetPools.RolesEntry
+	79,  // 103: spec.Update.ReplacedTargetPools.roles:type_name -> spec.Update.ReplacedTargetPools.RolesEntry
+	86,  // 104: spec.Update.KuberPatchNodes.add:type_name -> spec.Update.KuberPatchNodes.AddBatch
+	85,  // 105: spec.Update.KuberPatchNodes.remove:type_name -> spec.Update.KuberPatchNodes.RemoveBatch
+	21,  // 106: spec.Update.KuberDeleteK8sNodes.unreachable:type_name -> spec.Unreachable
+	21,  // 107: spec.Update.DeletedK8sNodes.unreachable:type_name -> spec.Unreachable
+	95,  // 108: spec.Update.DeletedK8sNodes.whole:type_name -> spec.Update.DeletedK8sNodes.WholeNodePool
+	96,  // 109: spec.Update.DeletedK8sNodes.partial:type_name -> spec.Update.DeletedK8sNodes.Partial
+	98,  // 110: spec.Update.TerraformerAddK8sNodes.existing:type_name -> spec.Update.TerraformerAddK8sNodes.Existing
+	99,  // 111: spec.Update.TerraformerAddK8sNodes.new:type_name -> spec.Update.TerraformerAddK8sNodes.New
+	106, // 112: spec.Update.DeletedLoadBalancerNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
+	110, // 113: spec.Update.DeletedLoadBalancerNodes.Partial.nodes:type_name -> spec.Node
+	73,  // 114: spec.Update.DeletedLoadBalancerNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
+	110, // 115: spec.Update.TerraformerAddLoadBalancerNodes.Existing.nodes:type_name -> spec.Node
+	106, // 116: spec.Update.TerraformerAddLoadBalancerNodes.New.nodepool:type_name -> spec.NodePool
+	76,  // 117: spec.Update.AnsiblerReplaceTargetPools.RolesEntry.value:type_name -> spec.Update.AnsiblerReplaceTargetPools.TargetPools
+	78,  // 118: spec.Update.ReplacedTargetPools.RolesEntry.value:type_name -> spec.Update.ReplacedTargetPools.TargetPools
+	111, // 119: spec.Update.KuberPatchNodes.ListOfTaints.taints:type_name -> spec.Taint
+	87,  // 120: spec.Update.KuberPatchNodes.MapOfLabels.labels:type_name -> spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
+	88,  // 121: spec.Update.KuberPatchNodes.MapOfAnnotations.annotations:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
+	89,  // 122: spec.Update.KuberPatchNodes.RemoveBatch.taints:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
+	90,  // 123: spec.Update.KuberPatchNodes.RemoveBatch.annotations:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
+	91,  // 124: spec.Update.KuberPatchNodes.RemoveBatch.labels:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
+	92,  // 125: spec.Update.KuberPatchNodes.AddBatch.taints:type_name -> spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
+	93,  // 126: spec.Update.KuberPatchNodes.AddBatch.labels:type_name -> spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
+	94,  // 127: spec.Update.KuberPatchNodes.AddBatch.annotations:type_name -> spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
+	80,  // 128: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
+	82,  // 129: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfAnnotationKeys
+	81,  // 130: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfLabelKeys
+	80,  // 131: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
+	83,  // 132: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfLabels
+	84,  // 133: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations
+	106, // 134: spec.Update.DeletedK8sNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
+	110, // 135: spec.Update.DeletedK8sNodes.Partial.nodes:type_name -> spec.Node
+	97,  // 136: spec.Update.DeletedK8sNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
+	110, // 137: spec.Update.TerraformerAddK8sNodes.Existing.nodes:type_name -> spec.Node
+	106, // 138: spec.Update.TerraformerAddK8sNodes.New.nodepool:type_name -> spec.NodePool
+	5,   // 139: spec.TaskResult.Error.kind:type_name -> spec.TaskResult.Error.Kind
+	15,  // 140: spec.TaskResult.UpdateState.k8s:type_name -> spec.K8scluster
+	11,  // 141: spec.TaskResult.UpdateState.loadBalancers:type_name -> spec.LoadBalancers
+	142, // [142:142] is the sub-list for method output_type
+	142, // [142:142] is the sub-list for method input_type
+	142, // [142:142] is the sub-list for extension type_name
+	142, // [142:142] is the sub-list for extension extendee
+	0,   // [0:142] is the sub-list for field type_name
 }
 
 func init() { file_spec_manifest_proto_init() }
@@ -6567,8 +6629,8 @@ func file_spec_manifest_proto_init() {
 	file_spec_dns_proto_init()
 	file_spec_nodepool_proto_init()
 	file_spec_pass_proto_init()
-	file_spec_manifest_proto_msgTypes[13].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[16].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[14].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[17].OneofWrappers = []any{
 		(*Update_None_)(nil),
 		(*Update_TfAddLoadBalancer)(nil),
 		(*Update_TfAddLoadBalancerNodes)(nil),
@@ -6605,46 +6667,46 @@ func file_spec_manifest_proto_init() {
 		(*Update_K8SApiEndpoint)(nil),
 		(*Update_UpgradeVersion_)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[18].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[19].OneofWrappers = []any{
 		(*Task_Create)(nil),
 		(*Task_Update)(nil),
 		(*Task_Delete)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[20].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[21].OneofWrappers = []any{
 		(*TaskResult_None_)(nil),
 		(*TaskResult_Update)(nil),
 		(*TaskResult_Clear)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[35].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[36].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[37].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[38].OneofWrappers = []any{
 		(*Update_DeletedLoadBalancerNodes_Whole)(nil),
 		(*Update_DeletedLoadBalancerNodes_Partial_)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[37].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[39].OneofWrappers = []any{
 		(*Update_TerraformerAddLoadBalancerNodes_Existing_)(nil),
 		(*Update_TerraformerAddLoadBalancerNodes_New_)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[42].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[43].OneofWrappers = []any{}
 	file_spec_manifest_proto_msgTypes[44].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[59].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[60].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[45].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[46].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[61].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[62].OneofWrappers = []any{
 		(*Update_DeletedK8SNodes_Whole)(nil),
 		(*Update_DeletedK8SNodes_Partial_)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[61].OneofWrappers = []any{
+	file_spec_manifest_proto_msgTypes[63].OneofWrappers = []any{
 		(*Update_TerraformerAddK8SNodes_Existing_)(nil),
 		(*Update_TerraformerAddK8SNodes_New_)(nil),
 	}
-	file_spec_manifest_proto_msgTypes[94].OneofWrappers = []any{}
-	file_spec_manifest_proto_msgTypes[95].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[96].OneofWrappers = []any{}
+	file_spec_manifest_proto_msgTypes[97].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_spec_manifest_proto_rawDesc), len(file_spec_manifest_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   96,
+			NumMessages:   98,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/spec/manifest.proto
+++ b/proto/spec/manifest.proto
@@ -37,10 +37,15 @@ message Manifest {
   State state = 4;
 }
 
+message Counters {
+  map<string, int64> k8sNodePoolScaleUpFailed = 1;
+}
+
 message ClusterState {
   Clusters current = 1;
   Workflow state = 4;
   TaskEvent inFlight = 5;
+  Counters counters = 6;
 }
 
 message Clusters {

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -247,6 +247,20 @@ func processTaskWithError(
 		isStageWarn    = stage.Description.ErrorLevel == spec.ErrorLevel_ERROR_WARN.String()
 	)
 
+	{
+		isInError := cluster.State.Status == spec.Workflow_ERROR.String()
+		if !isInError {
+			// Populate counters only on tasks that are about to be set to Errored.
+			inFlight, err := store.ConvertToGRPCTaskEvent(cluster.InFlight)
+			if err == nil {
+				PopulateTaskErrorCounters(inFlight.Task, &cluster.Counters)
+			}
+
+			// nolint
+			inFlight = nil
+		}
+	}
+
 	// About to advance a failed task.
 	// Store the result in the previously finished workflows.
 	previous := store.FinishedWorkflow{
@@ -262,17 +276,6 @@ func processTaskWithError(
 
 	cluster.State.Status = spec.Workflow_ERROR.String()
 	cluster.State.Description = work.Result.Error.Description
-
-	{
-		// Populate counters
-		inFlight, err := store.ConvertToGRPCTaskEvent(cluster.InFlight)
-		if err == nil {
-			PopulateTaskErrorCounters(inFlight.Task, &cluster.Counters)
-		}
-
-		// nolint
-		inFlight = nil
-	}
 
 	if isErrorPartial {
 		if err := propagateResult(logger, cluster, work.Result); err != nil {

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/berops/claudie/internal/loggerutils"
+	"github.com/berops/claudie/internal/nodepools"
 	"github.com/berops/claudie/proto/pb/spec"
 	"github.com/berops/claudie/services/manager/internal/service/metrics"
 	"github.com/berops/claudie/services/manager/internal/store"
@@ -262,6 +263,16 @@ func processTaskWithError(
 	cluster.State.Status = spec.Workflow_ERROR.String()
 	cluster.State.Description = work.Result.Error.Description
 
+	{
+		// Populate counters
+		inFlight, err := store.ConvertToGRPCTaskEvent(cluster.InFlight)
+		if err == nil {
+			PopulateTaskErrorCounters(inFlight.Task, &cluster.Counters)
+		}
+
+		inFlight = nil
+	}
+
 	if isErrorPartial {
 		if err := propagateResult(logger, cluster, work.Result); err != nil {
 			// Propagating the result failed for unknown reasons, could be due
@@ -425,6 +436,8 @@ func propagateInFlightState(state *store.ClusterState) error {
 		return err
 	}
 
+	PopulateTaskSuccessCounters(t, &state.Counters)
+
 	// If this was a task that was scheduled in front
 	// of a previous task, replace the old state there with
 	// 'this' state, as 'this' state is build upon that previous
@@ -458,4 +471,54 @@ func propagateInFlightState(state *store.ClusterState) error {
 
 	state.Current = cs
 	return nil
+}
+
+// Populates counters after encountering any error during the execution of the task.
+func PopulateTaskErrorCounters(task *spec.Task, counters *store.Counters) {
+	update := task.GetUpdate()
+	if update == nil {
+		return
+	}
+
+	// Failed in terraformer.
+	if addk8s := update.GetTfAddK8SNodes(); addk8s != nil {
+		switch kind := addk8s.Kind.(type) {
+		case *spec.Update_TerraformerAddK8SNodes_Existing_:
+			np := nodepools.FindByName(kind.Existing.Nodepool, update.State.K8S.ClusterInfo.NodePools)
+			if nodepools.IsAutoscaled(np) && len(kind.Existing.Nodes) > 0 {
+				counters.K8sNodePoolScaleUpFailed[kind.Existing.Nodepool] += 1
+			}
+		}
+	}
+
+	// Failed somewhere after terraformer.
+	if addk8s := update.GetAddedK8SNodes(); addk8s != nil {
+		np := nodepools.FindByName(addk8s.Nodepool, update.State.K8S.ClusterInfo.NodePools)
+		if nodepools.IsAutoscaled(np) && len(addk8s.Nodes) > 0 {
+			counters.K8sNodePoolScaleUpFailed[addk8s.Nodepool] += 1
+		}
+	}
+}
+
+// Populates counters after no error has been encountered during the execution of the
+// task and the task has completed its pipeline.
+func PopulateTaskSuccessCounters(task *spec.Task, counters *store.Counters) {
+	update := task.GetUpdate()
+	if update == nil {
+		return
+	}
+
+	if addk8s := update.GetAddedK8SNodes(); addk8s != nil {
+		np := nodepools.FindByName(addk8s.Nodepool, update.State.K8S.ClusterInfo.NodePools)
+		if nodepools.IsAutoscaled(np) && len(addk8s.Nodes) > 0 {
+			delete(counters.K8sNodePoolScaleUpFailed, addk8s.Nodepool)
+		}
+	}
+
+	if del := update.GetDeletedK8SNodes(); del != nil {
+		switch kind := del.Kind.(type) {
+		case *spec.Update_DeletedK8SNodes_Whole:
+			delete(counters.K8sNodePoolScaleUpFailed, kind.Whole.Nodepool.Name)
+		}
+	}
 }

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -270,6 +270,7 @@ func processTaskWithError(
 			PopulateTaskErrorCounters(inFlight.Task, &cluster.Counters)
 		}
 
+		// nolint
 		inFlight = nil
 	}
 

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -513,10 +513,7 @@ func PopulateTaskSuccessCounters(task *spec.Task, counters *store.Counters) {
 	}
 
 	if addk8s := update.GetAddedK8SNodes(); addk8s != nil {
-		np := nodepools.FindByName(addk8s.Nodepool, update.State.K8S.ClusterInfo.NodePools)
-		if nodepools.IsAutoscaled(np) && len(addk8s.Nodes) > 0 {
-			delete(counters.K8sNodePoolScaleUpFailed, addk8s.Nodepool)
-		}
+		delete(counters.K8sNodePoolScaleUpFailed, addk8s.Nodepool)
 	}
 
 	if del := update.GetDeletedK8SNodes(); del != nil {
@@ -524,5 +521,9 @@ func PopulateTaskSuccessCounters(task *spec.Task, counters *store.Counters) {
 		case *spec.Update_DeletedK8SNodes_Whole:
 			delete(counters.K8sNodePoolScaleUpFailed, kind.Whole.Nodepool.Name)
 		}
+	}
+
+	if changed := update.GetTfMoveNodePoolFromAutoscaled(); changed != nil {
+		delete(counters.K8sNodePoolScaleUpFailed, changed.Nodepool)
 	}
 }

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -526,4 +526,7 @@ func PopulateTaskSuccessCounters(task *spec.Task, counters *store.Counters) {
 	if changed := update.GetTfMoveNodePoolFromAutoscaled(); changed != nil {
 		delete(counters.K8sNodePoolScaleUpFailed, changed.Nodepool)
 	}
+	if changed := update.GetMovedNodePoolFromAutoscaled(); changed != nil {
+		delete(counters.K8sNodePoolScaleUpFailed, changed.Nodepool)
+	}
 }

--- a/services/manager/internal/service/reconciliate_unreachable_nodes.go
+++ b/services/manager/internal/service/reconciliate_unreachable_nodes.go
@@ -84,10 +84,10 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 			if cnp.IsControl {
 				controlpools := slices.Collect(nodepools.Control(r.Current.K8S.ClusterInfo.NodePools))
 				if len(controlpools) == 1 {
-					// Deleting last control plane nodepool will result in an invalid cluster.
+					// Deleting nodes from the last control plane nodepool will result in an invalid cluster.
 					errUnreachable = errors.Join(
 						errUnreachable,
-						fmt.Errorf("can't delete nodepool %q with unreachable nodes, the "+
+						fmt.Errorf("can't delete unreachable nodes from nodepool %q, the "+
 							"nodepool is the last control nodepool, the deletion would result in a broken cluster",
 							np,
 						),
@@ -124,11 +124,17 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 			}
 
 			diff := NodePoolsDiffResult{
-				Deleted: make(NodePoolsViewType, len(cnp.Nodes)),
+				PartiallyDeleted: make(NodePoolsViewType, len(nodes)),
 			}
 
-			for _, n := range cnp.Nodes {
-				diff.Deleted[cnp.Name] = append(diff.Deleted[cnp.Name], n.Name)
+			for _, n := range nodes {
+				if n.IsStatic {
+					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], n.K8sName)
+				} else {
+					// k8s names have the cluster ID stripped.
+					fullname := fmt.Sprintf("%s-%s", r.Current.K8S.ClusterInfo.Id(), n.K8sName)
+					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], fullname)
+				}
 			}
 
 			next := ScheduleDeletionsInNodePools(r.Current, &diff, opts)

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -205,6 +205,12 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 						}
 					}
 				}
+
+				// If there was atleast one nodepool for which the target size
+				// was changed, skip the below task scheduling.
+				if clusterResult[cluster] == NotReady {
+					break event_switch
+				}
 			}
 
 			// Update credentials for the current state/InFlight task.

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -184,25 +184,44 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 					// If a nodepool fails to scale up 3x reset the `TargetSize`
 					// of the autoscaled nodepool back to the current size.
 					if counter > 2 {
-						if nodepool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); nodepool != nil {
-							dyn := nodepool.GetDynamicNodePool()
-
-							logger.
-								Warn().
-								Msgf(
-									"Nodepool %q failed to scale up %vx to target size %v, target size will now be set to %v",
-									np,
-									counter,
-									dyn.AutoscalerConfig.TargetSize,
-									dyn.Count,
-								)
-
-							dyn.AutoscalerConfig.TargetSize = dyn.Count
+						nodepool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools)
+						if nodepool == nil {
+							// Nodepool is missing from current state, remove counter.
 							delete(state.Counters.K8SNodePoolScaleUpFailed, np)
-
 							clusterResult[cluster] = NotReady
 							continue
 						}
+
+						dyn := nodepool.GetDynamicNodePool()
+						if dyn == nil {
+							// NodePool is no longer dynamic.
+							delete(state.Counters.K8SNodePoolScaleUpFailed, np)
+							clusterResult[cluster] = NotReady
+							continue
+						}
+
+						if dyn.GetAutoscalerConfig() == nil {
+							// NodePool is no longer autoscaled.
+							delete(state.Counters.K8SNodePoolScaleUpFailed, np)
+							clusterResult[cluster] = NotReady
+							continue
+						}
+
+						logger.
+							Warn().
+							Msgf(
+								"Nodepool %q failed to scale up %vx to target size %v, target size will now be set to %v",
+								np,
+								counter,
+								dyn.AutoscalerConfig.TargetSize,
+								dyn.Count,
+							)
+
+						dyn.AutoscalerConfig.TargetSize = dyn.Count
+						delete(state.Counters.K8SNodePoolScaleUpFailed, np)
+
+						clusterResult[cluster] = NotReady
+						continue
 					}
 				}
 

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -177,6 +177,36 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 
 			clusterResult[cluster] = Noop
 
+			{
+				// Check historical counters for any loopback changes that
+				// needs to be done before looking at scheduling tasks,
+				for np, counter := range state.Counters.K8SNodePoolScaleUpFailed {
+					// If a nodepool fails to scale up 3x reset the `TargetSize`
+					// of the autoscaled nodepool back to the current size.
+					if counter > 2 {
+						if nodepool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); nodepool != nil {
+							dyn := nodepool.GetDynamicNodePool()
+
+							logger.
+								Warn().
+								Msgf(
+									"Nodepool %q failed to scale up %vx to target size %v, target size will now be set to %v",
+									np,
+									counter,
+									dyn.AutoscalerConfig.TargetSize,
+									dyn.Count,
+								)
+
+							dyn.AutoscalerConfig.TargetSize = dyn.Count
+							delete(state.Counters.K8SNodePoolScaleUpFailed, np)
+
+							clusterResult[cluster] = NotReady
+							continue
+						}
+					}
+				}
+			}
+
 			// Update credentials for the current state/InFlight task.
 			//
 			// This is done as the very first step, before any diffs and

--- a/services/manager/internal/store/api.go
+++ b/services/manager/internal/store/api.go
@@ -82,6 +82,12 @@ type ClusterState struct {
 	Current  Clusters   `bson:"current"`
 	InFlight *TaskEvent `bson:"inFlight"`
 	State    Workflow   `bson:"state"`
+	Counters Counters   `bson:"counters"`
+}
+
+type Counters struct {
+	// Autoscaled nodepools for which the scheduled scaleup failed.
+	K8sNodePoolScaleUpFailed map[string]int64 `bson:"k8sNodepoolScaleUpFailed"`
 }
 
 type Clusters struct {

--- a/services/manager/internal/store/convert_db_grpc.go
+++ b/services/manager/internal/store/convert_db_grpc.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/berops/claudie/proto/pb/spec"
@@ -501,6 +502,13 @@ func ConvertToGRPCClusterState(cluster *ClusterState) (*spec.ClusterState, error
 		Current:  current,
 		State:    ConvertToGRPCWorkflow(cluster.State),
 		InFlight: i,
+		Counters: &spec.Counters{
+			K8SNodePoolScaleUpFailed: maps.Clone(cluster.Counters.K8sNodePoolScaleUpFailed),
+		},
+	}
+
+	if out.Counters.K8SNodePoolScaleUpFailed == nil {
+		out.Counters.K8SNodePoolScaleUpFailed = make(map[string]int64)
 	}
 
 	return &out, nil
@@ -521,6 +529,13 @@ func ConvertFromGRPCClusterState(cluster *spec.ClusterState) (*ClusterState, err
 		Current:  clusters,
 		InFlight: task,
 		State:    ConvertFromGRPCWorkflow(cluster.State),
+		Counters: Counters{
+			K8sNodePoolScaleUpFailed: maps.Clone(cluster.GetCounters().GetK8SNodePoolScaleUpFailed()),
+		},
+	}
+
+	if out.Counters.K8sNodePoolScaleUpFailed == nil {
+		out.Counters.K8sNodePoolScaleUpFailed = make(map[string]int64)
 	}
 
 	return &out, nil

--- a/services/manager/internal/store/convert_db_grpc_test.go
+++ b/services/manager/internal/store/convert_db_grpc_test.go
@@ -1265,6 +1265,7 @@ func TestConvertToDBAndBack(t *testing.T) {
 						},
 					},
 				},
+				Counters: &spec.Counters{},
 				State: &spec.Workflow{
 					Status:      spec.Workflow_DONE,
 					Description: "Some description",

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	maxTimeout     = 24_500  // max allowed time for one manifest to finish in [seconds]
-	sleepSec       = 15      // seconds for one cycle of config check
+	sleepSec       = 14      // seconds for one cycle of config check
 	maxTimeoutSave = 60 * 12 // max allowed time for config to be found in the database
 )
 
@@ -39,7 +39,7 @@ func waitForDoneOrError(ctx context.Context, manager managerclient.CrudAPI, set 
 
 	// How many reconciliation iterations are needed for a definitive answer
 	// of whether the input manifest is in error or done.
-	const iterationsNeeded = 20
+	const iterationsNeeded = 22
 
 	var done int
 	var failed int

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -39,7 +39,7 @@ func waitForDoneOrError(ctx context.Context, manager managerclient.CrudAPI, set 
 
 	// How many reconciliation iterations are needed for a definitive answer
 	// of whether the input manifest is in error or done.
-	const iterationsNeeded = 22
+	const iterationsNeeded = 20
 
 	var done int
 	var failed int
@@ -287,8 +287,15 @@ func buildExpectedPeerList(cluster *spec.ClusterState) []Peer {
 }
 
 func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error {
+	var hairpinNATProviders = map[string]struct{}{
+		"cloudrift": {},
+		"openstack": {},
+	}
+
 	for _, np := range nps {
 		for _, n := range np.Nodes {
+			var isHairpinProvider bool
+
 			var sshKey string
 			port := nodepools.SSHPort(np)
 			username := n.Username
@@ -299,6 +306,7 @@ func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error
 			switch typ := np.Type.(type) {
 			case *spec.NodePool_DynamicNodePool:
 				sshKey = typ.DynamicNodePool.PrivateKey
+				_, isHairpinProvider = hairpinNATProviders[typ.DynamicNodePool.Provider.CloudProviderName]
 			case *spec.NodePool_StaticNodePool:
 				sshKey = typ.StaticNodePool.NodeKeys[n.Public]
 			default:
@@ -324,7 +332,7 @@ func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error
 			}
 
 			for range 10 {
-				if err = checkWireguardPeers(n, fmt.Sprint(port), expectedPeerList, &cfg); err == nil {
+				if err = checkWireguardPeers(isHairpinProvider, n, fmt.Sprint(port), expectedPeerList, &cfg); err == nil {
 					break
 				}
 				time.Sleep(150 + time.Duration(rand.IntN(150)))
@@ -339,7 +347,13 @@ func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error
 	return nil
 }
 
-func checkWireguardPeers(thisNode *spec.Node, sshPort string, peerList []Peer, cfg *ssh.ClientConfig) error {
+func checkWireguardPeers(
+	isHairpinProvider bool,
+	thisNode *spec.Node,
+	sshPort string,
+	peerList []Peer,
+	cfg *ssh.ClientConfig,
+) error {
 	endpoint := net.JoinHostPort(thisNode.Public, sshPort)
 	client, err := ssh.Dial("tcp", endpoint, cfg)
 	if err != nil {
@@ -396,6 +410,9 @@ func checkWireguardPeers(thisNode *spec.Node, sshPort string, peerList []Peer, c
 	// go over the expected peers and match a line in the fetched peers.
 	for _, p := range expectedPeerList {
 		ok := slices.ContainsFunc(fetchedPeers, func(s string) bool {
+			if isHairpinProvider {
+				return strings.Contains(s, p.Private)
+			}
 			return strings.Contains(s, p.Public) && strings.Contains(s, p.Private)
 		})
 		if !ok {

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	maxTimeout     = 24_500  // max allowed time for one manifest to finish in [seconds]
-	sleepSec       = 14      // seconds for one cycle of config check
+	sleepSec       = 15      // seconds for one cycle of config check
 	maxTimeoutSave = 60 * 12 // max allowed time for config to be found in the database
 )
 
@@ -39,7 +39,7 @@ func waitForDoneOrError(ctx context.Context, manager managerclient.CrudAPI, set 
 
 	// How many reconciliation iterations are needed for a definitive answer
 	// of whether the input manifest is in error or done.
-	const iterationsNeeded = 18
+	const iterationsNeeded = 20
 
 	var done int
 	var failed int


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2050


Claudie will now stop autoscaling a nodepool after 3 failed attempts. "Stop" can be interpreted here as changing the `TargetSize` of the autoscaled nodepool (which is set by the autoscaler-adapter) back to the current number of nodes in the Nodepool which effectively signals back to the autoscaler-adapter that no scale-up is on-going.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster state now records per-nodepool autoscaling failure counters for scale-up attempts.
  * Reconciler uses these counters to adjust autoscaler targets and skip a reconciliation cycle when persistent failures are detected.

* **Improvements**
  * Repeated scale-up failures automatically pause autoscaling for the affected nodepool and mark the cluster as not ready.
  * Failure counters are persisted, synchronized, and cleared on successful scale operations.
  * Clearer messaging and more accurate handling for removing unreachable control-plane nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->