### PR TITLE
chore: make taints unique

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/manager
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 80c26c3-4096
+  newTag: 4a5f28e-4103

--- a/services/kuber/internal/worker/service/task_patch_nodes.go
+++ b/services/kuber/internal/worker/service/task_patch_nodes.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"cmp"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/berops/claudie/internal/nodepools"
 	"github.com/berops/claudie/proto/pb/spec"
@@ -103,6 +105,18 @@ func updateExistingAnnotationsLabelsTaints(k8s *spec.K8Scluster, add *spec.Updat
 
 		if m, ok := add.Taints[np.Name]; ok {
 			np.Taints = append(np.Taints, m.Taints...)
+
+			slices.SortFunc(np.Taints, func(l, r *spec.Taint) int {
+				return cmp.Or(
+					strings.Compare(l.Effect, r.Effect),
+					strings.Compare(l.Key, r.Key),
+					strings.Compare(l.Value, r.Value),
+				)
+			})
+
+			np.Taints = slices.CompactFunc(np.Taints, func(l, r *spec.Taint) bool {
+				return l.Effect == r.Effect && l.Key == r.Key && l.Value == r.Value
+			})
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node pool taints are now normalized: deterministically sorted and duplicate entries removed for consistent node configurations.
* **Chores**
  * Updated container image tags for Claudie components and the testing framework to new versions used during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->