### PR TITLE
chore: update kubeone

### DIFF
--- a/internal/api/manifest/validate.go
+++ b/internal/api/manifest/validate.go
@@ -84,7 +84,7 @@ func prettyPrintValidationError(err error) error {
 		case "cidrv4":
 			nerr = fmt.Errorf("field '%s' is required to have a valid CIDRv4 value", err.StructField())
 		case "ver":
-			nerr = fmt.Errorf("field '%s' is required to have a kubernetes version of: 1.32.x, 1.33.x, 1.34.x", err.StructField())
+			nerr = fmt.Errorf("field '%s' is required to have a kubernetes version of: 1.33.x, 1.34.x, 1.35.x", err.StructField())
 		case "proxyMode":
 			nerr = fmt.Errorf("field '%s' is required to have a valid proxy mode value of \"on\", \"off\", \"default\"", err.StructField())
 		case "semver2":

--- a/internal/api/manifest/validate_kubernetes.go
+++ b/internal/api/manifest/validate_kubernetes.go
@@ -14,7 +14,7 @@ var (
 	// NOTE:
 	// first/second capturing group MUST be changed whenever new kubeone version is introduced in Claudie
 	// so validation will catch unsupported versions
-	kubernetesVersionRegexString = `^(1)\.(32|33|34)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+	kubernetesVersionRegexString = `^(1)\.(33|34|35)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 
 	// semverRegex is a regex using the semverRegexString.
 	// It's used to verify the version inside the manifest,

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/manager
-  newTag: 9868502-4117
+  newTag: 46e7803-4124
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 9868502-4117
+  newTag: 46e7803-4124

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 9868502-4117
+  newTag: 46e7803-4124

--- a/services/kube-eleven/Dockerfile
+++ b/services/kube-eleven/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 
 # download and unzip kube-one binary
 RUN apt-get -qq update && apt-get -qq install unzip
-RUN KUBEONE_V=1.12.1 && \
+RUN KUBEONE_V=1.13.4 && \
     wget -q https://github.com/kubermatic/kubeone/releases/download/v${KUBEONE_V}/kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip && \
     unzip -qq kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip -d kubeone_dir
 

--- a/services/kuber/Dockerfile
+++ b/services/kuber/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.25.5 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.33.0 && \
+RUN KC_VERSION=v1.34.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 #Unset the GOPATH

--- a/services/manager/Dockerfile
+++ b/services/manager/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.25.5 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.33.0 && \
+RUN KC_VERSION=v1.34.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 #Unset the GOPATH

--- a/services/testing-framework/Dockerfile
+++ b/services/testing-framework/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.25.5 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.33.0 && \
+RUN KC_VERSION=v1.34.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 


### PR DESCRIPTION
With updated kubeone the support for v1.32.0 is dropped.

Now the supported versions are v1.33, v1.34, v1.35.


I've tested updating from the latest Claudie version, and then also updating kubernetes cluster to v1.35, all went okay


Befure updating to the next Claudie release users will have to update to atleast v1.33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated supported Kubernetes versions to 1.33.x, 1.34.x, and 1.35.x.
  * Bumped kube-one to 1.13.4.
  * Updated kubectl to 1.34.0 across services and build images.
  * Rolled forward container image tags for multiple components and the testing framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->