### PR TITLE
chore: Switch GitHub Actions authentication to claudie-runner app token

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -147,7 +147,6 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)
         uses: actions/create-github-app-token@v1
         with:
           app-id: 3688229
@@ -226,7 +225,6 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: 3688229

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -15,15 +15,24 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Merge with master branch
         uses: everlytic/branch-merge@1.1.5
         with:
-          github_token: ${{ github.token }}
+          github_token: ${{ steps.app-token.outputs.token }}
           source_ref: master
           target_branch: ${{ github.head_ref }}
   #--------------------------------------------------------------------------------------------------
@@ -136,6 +145,15 @@ jobs:
     runs-on: self-hosted
     needs: [merge-branch, check-changes]
     steps:
+      - name: Generate app token
+        id: app-token
+        if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)
         with:
@@ -150,8 +168,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: x-access-token
+          password: ${{ steps.app-token.outputs.token }}
 
       # the newer versions of actions-runner (v2.329.x and later) don't have BuildKit
       - name: Set up Docker Buildx
@@ -206,11 +224,21 @@ jobs:
     runs-on: self-hosted
     needs: [merge-branch, check-changes, build-and-push, golangci, gotest]
     steps:
+      - name: Generate app token
+        id: app-token
+        if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set short sha output
         if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
@@ -262,7 +290,7 @@ jobs:
           BRANCH_NAME=${{ github.head_ref }}
           git config --global user.name 'CI/CD pipeline'
           git config --global user.email 'CI/CD-pipeline@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           git add claudie/kustomization.yaml
           git add testing-framework/kustomization.yaml
           git commit -m "Auto commit - update kustomization.yaml"

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         with:
@@ -151,7 +150,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)
@@ -229,7 +227,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
@@ -148,7 +148,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
@@ -225,7 +225,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -24,17 +24,25 @@ jobs:
     if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/refresh-docs')) || github.event.label.name == 'refresh-docs' }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Set up git author
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
       - name: Git fetch gh-pages

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -21,26 +21,34 @@ jobs:
     name: Create a new  docs release
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set release tag
         run: |
           R=${GITHUB_REF#"refs/tags/"}
           echo "RELEASE=$R" >> $GITHUB_ENV
-      
+
       - name: Set up git author
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Handle Changelog file
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           filename="mkdocs.yml"
           start_line=$(sed -n '/- Changelog:/=' "$filename")

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,7 +25,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           app-id: 3688229
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-          owner: berops
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 3688229
+          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
           private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ jobs:
     name: Create a new release
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3688229
+          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
+          owner: berops
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
@@ -43,8 +51,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: x-access-token
+          password: ${{ steps.app-token.outputs.token }}
 
       # Update autoscaler-adapter manifest in this steps as new kuber would need to contain manifest with the correct image tag
       - name: Edit autoscaler-adapter image tag in the manifest
@@ -89,14 +97,14 @@ jobs:
       - name: Add claudie manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ steps.app-token.outputs.token }}
           tag: ${{ github.ref }}
           file: claudie.yaml
 
       - name: Add network-policy manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ steps.app-token.outputs.token }}
           tag: ${{ github.ref }}
           file: manifests/network-policies/network-policy.yaml
           asset_name: network-policy.yaml
@@ -104,7 +112,7 @@ jobs:
       - name: Add cilium-network-policy manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ steps.app-token.outputs.token }}
           tag: ${{ github.ref }}
           file: manifests/network-policies/network-policy-cilium.yaml
           asset_name: network-policy-cilium.yaml
@@ -112,7 +120,7 @@ jobs:
       - name: Add claudie checksums file to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ steps.app-token.outputs.token }}
           tag: ${{ github.ref }}
           file: claudie_checksum.txt
 


### PR DESCRIPTION
Replace the default GITHUB_TOKEN with a token generated from the claudie-runner GitHub App to enable write access to the berops organization's package registry, facilitating image pushes to ghcr.io across various workflows.

<img width="934" height="212" alt="image" src="https://github.com/user-attachments/assets/b13aa4ff-269e-469c-9b52-bd9bd066c23b" />

1. Jobs run on separate runners. Each job has an isolated environment, so a token minted in one job isn't available in another unless you explicitly pass it through job outputs.
2. Tokens are short-lived (1 hour default). If the pipeline runs longer than that (very plausible with
the E2E tests), a token minted at the start would be expired by the time the edit-kustomization or release jobs need it.
3. actions/create-github-app-token auto-revokes the token at job end as a security cleanup. So even if you passed it between jobs, the next job would receive an already-revoked token.

Generating per job is the standard, recommended pattern (recommended by claude).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI, docs, and release workflows updated to authenticate with a generated GitHub App installation token for all repo operations (checkout, git actions, container registry login, and release uploads), replacing the previous default token to ensure consistent authenticated workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2086)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->