### PR TITLE
revert: claudie-runner app token, restore GITHUB_TOKEN

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -15,23 +15,15 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Merge with master branch
         uses: everlytic/branch-merge@1.1.5
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ github.token }}
           source_ref: master
           target_branch: ${{ github.head_ref }}
   #--------------------------------------------------------------------------------------------------
@@ -144,13 +136,6 @@ jobs:
     runs-on: self-hosted
     needs: [merge-branch, check-changes]
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)
         with:
@@ -165,8 +150,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: x-access-token
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # the newer versions of actions-runner (v2.329.x and later) don't have BuildKit
       - name: Set up Docker Buildx
@@ -221,19 +206,11 @@ jobs:
     runs-on: self-hosted
     needs: [merge-branch, check-changes, build-and-push, golangci, gotest]
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set short sha output
         if: ${{ needs.build-and-push.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false }}
@@ -285,7 +262,7 @@ jobs:
           BRANCH_NAME=${{ github.head_ref }}
           git config --global user.name 'CI/CD pipeline'
           git config --global user.email 'CI/CD-pipeline@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add claudie/kustomization.yaml
           git add testing-framework/kustomization.yaml
           git commit -m "Auto commit - update kustomization.yaml"

--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -135,6 +135,9 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     runs-on: self-hosted
     needs: [merge-branch, check-changes]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         if: (needs.check-changes.outputs.ARRAY_OF_CHANGES != '' && github.event.pull_request.draft == false)

--- a/.github/workflows/automatic-docs-update.yml
+++ b/.github/workflows/automatic-docs-update.yml
@@ -24,24 +24,17 @@ jobs:
     if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/refresh-docs')) || github.event.label.name == 'refresh-docs' }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
-
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Set up git author
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # NOTE: the pipeline will fail, if gh-pages branch isn't created!!!
       - name: Git fetch gh-pages

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -21,33 +21,26 @@ jobs:
     name: Create a new  docs release
     runs-on: ubuntu-22.04
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set release tag
         run: |
           R=${GITHUB_REF#"refs/tags/"}
           echo "RELEASE=$R" >> $GITHUB_ENV
-
+      
       - name: Set up git author
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Handle Changelog file
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           filename="mkdocs.yml"
           start_line=$(sed -n '/- Changelog:/=' "$filename")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,6 @@ jobs:
     name: Create a new release
     runs-on: ubuntu-22.04
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CLAUDIE_CI_APP_ID }}
-          private-key: ${{ secrets.CLAUDIE_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
@@ -50,8 +43,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: x-access-token
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Update autoscaler-adapter manifest in this steps as new kuber would need to contain manifest with the correct image tag
       - name: Edit autoscaler-adapter image tag in the manifest
@@ -96,14 +89,14 @@ jobs:
       - name: Add claudie manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ steps.app-token.outputs.token }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           file: claudie.yaml
 
       - name: Add network-policy manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ steps.app-token.outputs.token }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           file: manifests/network-policies/network-policy.yaml
           asset_name: network-policy.yaml
@@ -111,7 +104,7 @@ jobs:
       - name: Add cilium-network-policy manifest to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ steps.app-token.outputs.token }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           file: manifests/network-policies/network-policy-cilium.yaml
           asset_name: network-policy-cilium.yaml
@@ -119,7 +112,7 @@ jobs:
       - name: Add claudie checksums file to the release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ steps.app-token.outputs.token }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           file: claudie_checksum.txt
 


### PR DESCRIPTION
Reverts #2086.

## Why

The original failure that motivated #2086 was a fork-PR issue (`samuelstolicny/claudie` is not in the package ACL), not a fundamental limitation of `GITHUB_TOKEN`. Switching to a GitHub App token didn't solve the package push because the App's installation identity also isn't in the package ACL, and GitHub's package "Manage Actions access" only lists repositories, not App installations.

The simpler and working answer is: push branches directly to `berops/claudie` (non-fork) so `GITHUB_TOKEN` carries the repo identity that the package ACLs already allow.

## What this does

- Reverts all 4 workflow files (CI-pipeline, release, automatic-docs-update, release-docs) to use `secrets.GITHUB_TOKEN` and `github.token` as they did before #2086.

## Follow-up (manual, not in this PR)

- Delete the `CLAUDIE_CI_APP_PRIVATE_KEY` repository secret.
- Delete the `CLAUDIE_CI_APP_ID` repository variable.
- Uninstall the `claudie-runner` GitHub App from the `berops` org (or keep it dormant).

## After merge

The Verda PR (#2088) can be rebased onto master. Since its branch already lives in `berops/claudie`, the docker push will work with `GITHUB_TOKEN`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD authentication across build, release, and docs workflows by switching from generated app tokens to the workflow’s default token; updated registry login and release publishing steps to use the built-in token for pushes and uploads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2089)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2089)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->