### PR TITLE
chore: add kube-proxy removal

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/manager
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 292fe8e-4207
+  newTag: 4f00447-4209

--- a/services/kube-eleven/Dockerfile
+++ b/services/kube-eleven/Dockerfile
@@ -8,6 +8,10 @@ RUN KUBEONE_V=1.13.4 && \
     wget -q https://github.com/kubermatic/kubeone/releases/download/v${KUBEONE_V}/kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip && \
     unzip -qq kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip -d kubeone_dir
 
+#Install kubectl
+RUN KC_VERSION=v1.34.0 && \
+    wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
+
 #Unset the GOPATH
 ENV GOPATH=
 
@@ -38,7 +42,10 @@ RUN apk update
 RUN apk add -q bash
 
 COPY --from=build /go/kubeone_dir/kubeone /usr/local/bin
+COPY --from=build /go/kubectl /usr/local/bin/kubectl
 COPY --from=build /go/services/kube-eleven/cmd/worker/worker /bin/services/kube-eleven/worker
+
+RUN chmod +x /usr/local/bin/kubectl
 
 #Run worker
 WORKDIR /bin

--- a/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
+++ b/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"github.com/berops/claudie/internal/clusters"
+	"github.com/berops/claudie/internal/command"
+	"github.com/berops/claudie/internal/kubectl"
 	"github.com/berops/claudie/proto/pb/spec"
 	kube_eleven "github.com/berops/claudie/services/kube-eleven/internal/worker/service/internal/kube-eleven"
 	"github.com/rs/zerolog"
@@ -31,6 +33,8 @@ func Reconcile(
 			logger.Info().Msg("Upgrading kubernetes version")
 			k8s.Kubernetes = upgrade.Version
 		}
+
+		removeKubeProxy(logger, k8s.ClusterInfo.Id(), k8s.Kubeconfig)
 	default:
 		logger.
 			Warn().
@@ -69,4 +73,34 @@ func Reconcile(
 	update := tracker.Result.Update()
 	update.Kubernetes(k.K8sCluster)
 	update.Commit()
+}
+
+// TODO: remove in future claudie versions.
+// Only added in version v0.13.0 for backwards
+// compatibility with versions v0.12.x with the
+// move to ebpf cilium.
+func removeKubeProxy(logger zerolog.Logger, clusterId, kubeconfig string) {
+	k := kubectl.Kubectl{
+		Kubeconfig:        kubeconfig,
+		MaxKubectlRetries: 1,
+	}
+
+	k.Stdout = command.GetStdOut(clusterId)
+	k.Stderr = command.GetStdErr(clusterId)
+
+	var anyerror bool
+
+	if err := k.KubectlDeleteResource("cm", "kube-proxy", "-n kube-system"); err != nil {
+		anyerror = true
+	}
+
+	if err := k.KubectlDeleteResource("ds", "kube-proxy", "-n kube-system"); err != nil {
+		anyerror = true
+	}
+
+	if anyerror {
+		logger.
+			Error().
+			Msg("errors encountered while deleting kube-proxy, assuming kube-proxy is not deployed")
+	}
 }


### PR DESCRIPTION
Add kube-proxy removal for clusters that will upgrade from v0.12.x to the next release with ebpf cilium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * kubectl is now available in the runtime environment.
  * Automatic removal of legacy cluster proxy components during Kubernetes version upgrades.

* **Chores**
  * Updated deployment images to the new release tag across manifests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->