### PR TITLE
Link README logo to claudie.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h4 align="center">
   <a href="https://claudie.io" target="_blank" rel="noopener noreferrer">
-  <img src="https://raw.githubusercontent.com/berops/claudie/17480b6cb809fe795d454588af18355c7543f37e/docs/logo%20claudie_blue_no_BG.svg" width="250px"/>
+  <img src="https://raw.githubusercontent.com/berops/claudie/17480b6cb809fe795d454588af18355c7543f37e/docs/logo%20claudie_blue_no_BG.svg" width="250px" alt="Claudie logo"/>
   </a><br/>
   <br/><br/>
   Platform for managing multi-cloud and hybrid-cloud Kubernetes clusters with support for nodepools across different cloud-providers and on-premise data centers

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h4 align="center">
-  <img src="https://raw.githubusercontent.com/berops/claudie/17480b6cb809fe795d454588af18355c7543f37e/docs/logo%20claudie_blue_no_BG.svg" width="250px"/><br/>
+  <a href="https://claudie.io" target="_blank" rel="noopener noreferrer">
+  <img src="https://raw.githubusercontent.com/berops/claudie/17480b6cb809fe795d454588af18355c7543f37e/docs/logo%20claudie_blue_no_BG.svg" width="250px"/>
+  </a><br/>
   <br/><br/>
   Platform for managing multi-cloud and hybrid-cloud Kubernetes clusters with support for nodepools across different cloud-providers and on-premise data centers
 </h4>


### PR DESCRIPTION
### Summary
I made the README logo clickable and linked it to https://claudie.io.

GitHub's About section allows only one website URL, and it is better to keep that URL pointing to the docs. With this change, users can still reach the main website directly by clicking the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README logo to be a clickable link to the Claudie website; it now opens in a new browser tab and uses safe link attributes to prevent opener-related risks, improving navigation from the project landing content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->