### PR TITLE
fix workflow ordering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/exoscale/egoscale/v3 v3.1.35
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zerologr v1.2.3
 	github.com/go-playground/validator/v10 v10.30.2

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/natsutils/subjects.go
+++ b/internal/natsutils/subjects.go
@@ -24,6 +24,9 @@ const (
 	// cluster, thus a kuberentes cluster name is used for the identification
 	// of all of the data related to that cluster.
 	ClusterName = "claudie-internal-cluster-name"
+
+	/// The Stage of the task/work that was picked up by the worker.
+	Stage = "claudie-internal-work-stage"
 )
 
 // A list of default claudie related NATS subjects.

--- a/internal/natsutils/work_queue_utils.go
+++ b/internal/natsutils/work_queue_utils.go
@@ -22,13 +22,19 @@ type ReplyMsg struct {
 	Cluster string
 
 	// TaskID is the ID from the picked up [nats.Msg], that was received
-	// via the [nats.MsgIdHdr]. This is the actuall ID of the task that was
+	// via the [nats.MsgIdHdr]. This is the actual ID of the task that was
 	// scheduled by the manager and this information is given back to the reply
 	// channel in the header [WorkID]. This ID is also used to construct the ID
-	// of the reply message, as each deplication tracking of messages is stream-wide
-	// each stage needs to have its own ID, thus a simply concatenation of the
+	// of the reply message. NATS tracks duplication of messages stream-wide
+	// thus each stage needs to have its own ID, thus a simply concatenation of the
 	// fmt.Sprintf("%v-%v", TaskID, Subject) is used.
 	TaskID string
+
+	// Stage is the Stage extracted from the [nats.Msg] that was received
+	// via the [nats.MsgIdHdr]. This is the actual stage of the task that
+	// is being processed and this information is given back to the reply
+	// channel in the header [Stage].
+	Stage string
 
 	// To which subject should the reply be send to.
 	Subject string
@@ -56,13 +62,14 @@ func ReplyTo(
 	// Duplicate messages are tracked jetstream-wide thus each stage
 	// needs its own ID for it to not be considered as a duplicate if
 	// send to another stage.
-	replyMsgID := fmt.Sprintf("%v-%v", result.TaskID, result.Subject)
+	replyMsgID := fmt.Sprintf("%v-%v-%v", result.TaskID, result.Subject, result.Stage)
 
 	headers := nats.Header{}
 	headers.Set(nats.MsgIdHdr, replyMsgID)
 	headers.Set(WorkID, result.TaskID)
 	headers.Set(InputManifestName, result.InputManifest)
 	headers.Set(ClusterName, result.Cluster)
+	headers.Set(Stage, result.Stage)
 
 	msg := nats.Msg{
 		Subject: result.Subject,

--- a/internal/nodepools/nodepools.go
+++ b/internal/nodepools/nodepools.go
@@ -135,7 +135,11 @@ func PartialCopyWithNodeExclusion(np *spec.NodePool, nodes []string) *spec.NodeP
 		}
 	case *spec.NodePool_StaticNodePool:
 		s := proto.Clone(typ.StaticNodePool).(*spec.StaticNodePool)
-		clear(s.NodeKeys)
+		if s.NodeKeys == nil {
+			s.NodeKeys = make(map[string]string)
+		} else {
+			clear(s.NodeKeys)
+		}
 		for _, n := range cp.Nodes {
 			s.NodeKeys[n.Public] = np.GetStaticNodePool().NodeKeys[n.Public]
 		}
@@ -182,7 +186,11 @@ func PartialCopyWithNodeFilter(np *spec.NodePool, nodes []string) *spec.NodePool
 		}
 	case *spec.NodePool_StaticNodePool:
 		s := proto.Clone(typ.StaticNodePool).(*spec.StaticNodePool)
-		clear(s.NodeKeys)
+		if s.NodeKeys == nil {
+			s.NodeKeys = make(map[string]string)
+		} else {
+			clear(s.NodeKeys)
+		}
 		for _, n := range cp.Nodes {
 			s.NodeKeys[n.Public] = np.GetStaticNodePool().NodeKeys[n.Public]
 		}
@@ -223,7 +231,11 @@ func PartialCopyWithReplacedNodes(np *spec.NodePool, nodes []*spec.Node, nodeKey
 		}
 	case *spec.NodePool_StaticNodePool:
 		s := proto.Clone(typ.StaticNodePool).(*spec.StaticNodePool)
-		clear(s.NodeKeys)
+		if s.NodeKeys == nil {
+			s.NodeKeys = make(map[string]string)
+		} else {
+			clear(s.NodeKeys)
+		}
 		maps.Copy(s.NodeKeys, nodeKeys)
 
 		cp.Type = &spec.NodePool_StaticNodePool{
@@ -291,6 +303,10 @@ func CloneTargetNodes(n *spec.NodePool, nodes []string) []*spec.Node {
 // `nodepool` then the nodepool will be modified to contain
 // no nodes at all.
 func DeleteNodes(nodepool *spec.NodePool, nodes []string) {
+	if nodepool == nil {
+		return
+	}
+
 	var deleted []*spec.Node
 	nodepool.Nodes = slices.DeleteFunc(nodepool.Nodes, func(n *spec.Node) bool {
 		if slices.Contains(nodes, n.Name) {

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/kuber
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/manager
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/manager
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 4f00447-4209
+  newTag: e2bd7e3-4219

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: e2bd7e3-4219
+  newTag: e3ee3d0-4220

--- a/services/ansibler/internal/worker/service/handler_msg.go
+++ b/services/ansibler/internal/worker/service/handler_msg.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,22 +52,27 @@ func handlerInner(
 ) {
 	var (
 		stageID       = msg.Headers().Get(nats.MsgIdHdr)
-		suffix        = fmt.Sprintf("-%v", natsutils.AnsiblerRequests)
-		parsedStageID = strings.Split(stageID, suffix)
+		infix         = fmt.Sprintf("-%v-", natsutils.AnsiblerRequests)
+		parsedStageID = strings.Split(stageID, infix)
 		discard       = false
 	)
 
-	if len(parsedStageID) < 1 || parsedStageID[0] == "" {
+	if len(parsedStageID) < 2 || parsedStageID[0] == "" || parsedStageID[1] == "" {
 		discard = true
-		parsedStageID = []string{"unknown"}
+		parsedStageID = []string{parsedStageID[0], "unknown"}
 	}
 
 	if _, err := uuid.Parse(parsedStageID[0]); err != nil {
 		discard = true
 	}
 
+	if s, err := strconv.ParseInt(parsedStageID[1], 10, 64); err != nil || s < 0 || s > math.MaxUint32 {
+		discard = true
+	}
+
 	var (
 		eventID           = parsedStageID[0]
+		eventStage        = parsedStageID[1]
 		replyChannel      = msg.Headers().Get(natsutils.ReplyToHeader)
 		inputManifestName = msg.Headers().Get(natsutils.InputManifestName)
 		clusterName       = msg.Headers().Get(natsutils.ClusterName)
@@ -73,6 +80,7 @@ func handlerInner(
 		logger = log.With().
 			Str(natsutils.ClusterName, clusterName).
 			Str(natsutils.InputManifestName, inputManifestName).
+			Str(natsutils.Stage, eventStage).
 			Str(nats.MsgIdHdr, eventID).
 			Logger()
 	)
@@ -82,6 +90,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -101,6 +110,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -124,6 +134,7 @@ func handlerInner(
 					InputManifest: inputManifestName,
 					Cluster:       clusterName,
 					TaskID:        eventID,
+					Stage:         eventStage,
 					Subject:       replyChannel,
 				}
 				// Try to send a noop as we failed to unmarshal the received message
@@ -181,6 +192,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 			Result:        result,
 		}

--- a/services/kube-eleven/internal/worker/service/handler_msg.go
+++ b/services/kube-eleven/internal/worker/service/handler_msg.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,22 +52,27 @@ func handlerInner(
 ) {
 	var (
 		stageID       = msg.Headers().Get(nats.MsgIdHdr)
-		suffix        = fmt.Sprintf("-%v", natsutils.KubeElevenRequests)
-		parsedStageID = strings.Split(stageID, suffix)
+		infix         = fmt.Sprintf("-%v-", natsutils.KubeElevenRequests)
+		parsedStageID = strings.Split(stageID, infix)
 		discard       = false
 	)
 
-	if len(parsedStageID) < 1 || parsedStageID[0] == "" {
+	if len(parsedStageID) < 2 || parsedStageID[0] == "" || parsedStageID[1] == "" {
 		discard = true
-		parsedStageID = []string{"unknown"}
+		parsedStageID = []string{parsedStageID[0], "unknown"}
 	}
 
 	if _, err := uuid.Parse(parsedStageID[0]); err != nil {
 		discard = true
 	}
 
+	if s, err := strconv.ParseInt(parsedStageID[1], 10, 64); err != nil || s < 0 || s > math.MaxUint32 {
+		discard = true
+	}
+
 	var (
 		eventID           = parsedStageID[0]
+		eventStage        = parsedStageID[1]
 		replyChannel      = msg.Headers().Get(natsutils.ReplyToHeader)
 		inputManifestName = msg.Headers().Get(natsutils.InputManifestName)
 		clusterName       = msg.Headers().Get(natsutils.ClusterName)
@@ -73,6 +80,7 @@ func handlerInner(
 		logger = log.With().
 			Str(natsutils.ClusterName, clusterName).
 			Str(natsutils.InputManifestName, inputManifestName).
+			Str(natsutils.Stage, eventStage).
 			Str(nats.MsgIdHdr, eventID).
 			Logger()
 	)
@@ -82,6 +90,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -101,6 +110,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -124,6 +134,7 @@ func handlerInner(
 					InputManifest: inputManifestName,
 					Cluster:       clusterName,
 					TaskID:        eventID,
+					Stage:         eventStage,
 					Subject:       replyChannel,
 				}
 				// Try to send a noop as we failed to unmarshal the received message
@@ -181,6 +192,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 			Result:        result,
 		}

--- a/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
+++ b/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
@@ -82,7 +82,7 @@ func Reconcile(
 func removeKubeProxy(logger zerolog.Logger, clusterId, kubeconfig string) {
 	k := kubectl.Kubectl{
 		Kubeconfig:        kubeconfig,
-		MaxKubectlRetries: 1,
+		MaxKubectlRetries: -1,
 	}
 
 	k.Stdout = command.GetStdOut(clusterId)
@@ -100,7 +100,7 @@ func removeKubeProxy(logger zerolog.Logger, clusterId, kubeconfig string) {
 
 	if anyerror {
 		logger.
-			Error().
-			Msg("errors encountered while deleting kube-proxy, assuming kube-proxy is not deployed")
+			Warn().
+			Msg("Errors encountered while deleting kube-proxy, assuming kube-proxy is not deployed. You can ignore this error as this is only for backwards compatibility and will be removed in the future")
 	}
 }

--- a/services/kuber/internal/worker/service/handler_msg.go
+++ b/services/kuber/internal/worker/service/handler_msg.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,22 +53,27 @@ func handlerInner(
 ) {
 	var (
 		stageID       = msg.Headers().Get(nats.MsgIdHdr)
-		suffix        = fmt.Sprintf("-%v", natsutils.KuberRequests)
-		parsedStageID = strings.Split(stageID, suffix)
+		infix         = fmt.Sprintf("-%v-", natsutils.KuberRequests)
+		parsedStageID = strings.Split(stageID, infix)
 		discard       = false
 	)
 
-	if len(parsedStageID) < 1 || parsedStageID[0] == "" {
+	if len(parsedStageID) < 2 || parsedStageID[0] == "" || parsedStageID[1] == "" {
 		discard = true
-		parsedStageID = []string{"unknown"}
+		parsedStageID = []string{parsedStageID[0], "unknown"}
 	}
 
 	if _, err := uuid.Parse(parsedStageID[0]); err != nil {
 		discard = true
 	}
 
+	if s, err := strconv.ParseInt(parsedStageID[1], 10, 64); err != nil || s < 0 || s > math.MaxUint32 {
+		discard = true
+	}
+
 	var (
 		eventID           = parsedStageID[0]
+		eventStage        = parsedStageID[1]
 		replyChannel      = msg.Headers().Get(natsutils.ReplyToHeader)
 		inputManifestName = msg.Headers().Get(natsutils.InputManifestName)
 		clusterName       = msg.Headers().Get(natsutils.ClusterName)
@@ -74,6 +81,7 @@ func handlerInner(
 		logger = log.With().
 			Str(natsutils.ClusterName, clusterName).
 			Str(natsutils.InputManifestName, inputManifestName).
+			Str(natsutils.Stage, eventStage).
 			Str(nats.MsgIdHdr, eventID).
 			Logger()
 	)
@@ -83,6 +91,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -102,6 +111,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -125,6 +135,7 @@ func handlerInner(
 					InputManifest: inputManifestName,
 					Cluster:       clusterName,
 					TaskID:        eventID,
+					Stage:         eventStage,
 					Subject:       replyChannel,
 				}
 				// Try to send a noop as we failed to unmarshal the received message
@@ -182,6 +193,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 			Result:        result,
 		}

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -63,9 +63,6 @@ type Deleter struct {
 // functions of the deleter. The passed in deleteMaster and deleteWorker nodes
 // are being worked with to delete them from the kubernetes cluster via the
 // kubeconfig of the [spec.K8Scluster].
-//
-// It is expected that the passed in 'deleteMaster' and 'deleteWorker' nodes
-// are no longer in the state of the passed in [spec.K8Scluster].
 func NewDeleter(
 	deleteMaster, deleteWorker []*spec.Node,
 	cluster *spec.K8Scluster,
@@ -95,10 +92,12 @@ func NewDeleter(
 	var notDeleted string
 	for cn := range nodepools.Control(cluster.ClusterInfo.NodePools) {
 		for _, n := range cn.Nodes {
-			// pick the first control node as the ones
-			// deleted are no longer in the cluster's state.
-			notDeleted = n.Name
-			break
+			if !slices.ContainsFunc(deleteMaster, func(o *spec.Node) bool { return o.Name == n.Name }) {
+				// pick the first control node as the ones
+				// deleted are no longer in the cluster's state.
+				notDeleted = n.Name
+				break
+			}
 		}
 	}
 

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -94,10 +94,12 @@ func NewDeleter(
 	// find a control node that will not be deleted.
 	var notDeleted string
 	for cn := range nodepools.Control(cluster.ClusterInfo.NodePools) {
-		// pick the first control node as the ones deleted are no longer
-		// in the cluster's state.
-		notDeleted = cn.Nodes[0].Name
-		break
+		for _, n := range cn.Nodes {
+			// pick the first control node as the ones
+			// deleted are no longer in the cluster's state.
+			notDeleted = n.Name
+			break
+		}
 	}
 
 	if notDeleted == "" {

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -58,13 +58,16 @@ type Deleter struct {
 	controlNode   string
 }
 
-// New returns new Deleter struct, used for node deletion from a k8s cluster
+// New returns new [Deleter] struct, used for node deletion from a k8s cluster
 // The passed in [spec.K8Scluster] is not modified in any way by any of the
-// functions of the deleter. Simply the passed in masterNodes and workerNodes
+// functions of the deleter. The passed in deleteMaster and deleteWorker nodes
 // are being worked with to delete them from the kubernetes cluster via the
 // kubeconfig of the [spec.K8Scluster].
+//
+// It is expected that the passed in 'deleteMaster' and 'deleteWorker' nodes
+// are no longer in the state of the passed in [spec.K8Scluster].
 func NewDeleter(
-	deleteMaster, deleteWorker []string,
+	deleteMaster, deleteWorker []*spec.Node,
 	cluster *spec.K8Scluster,
 ) (*Deleter, error) {
 	var (
@@ -74,29 +77,27 @@ func NewDeleter(
 
 	for i := range deleteMaster {
 		mn = append(mn, nodeInfo{
-			fullname:       deleteMaster[i],
-			k8sName:        strings.TrimPrefix(deleteMaster[i], fmt.Sprintf("%s-", clusterID)),
-			publicEndpoint: clusters.NodePublic(deleteMaster[i], cluster),
+			fullname:       deleteMaster[i].Name,
+			k8sName:        strings.TrimPrefix(deleteMaster[i].Name, fmt.Sprintf("%s-", clusterID)),
+			publicEndpoint: deleteMaster[i].Public,
 		})
 	}
 
 	for i := range deleteWorker {
 		wn = append(wn, nodeInfo{
-			fullname:       deleteWorker[i],
-			k8sName:        strings.TrimPrefix(deleteWorker[i], fmt.Sprintf("%s-", clusterID)),
-			publicEndpoint: clusters.NodePublic(deleteWorker[i], cluster),
+			fullname:       deleteWorker[i].Name,
+			k8sName:        strings.TrimPrefix(deleteWorker[i].Name, fmt.Sprintf("%s-", clusterID)),
+			publicEndpoint: deleteWorker[i].Public,
 		})
 	}
 
 	// find a control node that will not be deleted.
 	var notDeleted string
 	for cn := range nodepools.Control(cluster.ClusterInfo.NodePools) {
-		for _, n := range cn.Nodes {
-			if !slices.Contains(deleteMaster, n.Name) {
-				notDeleted = n.Name
-				break
-			}
-		}
+		// pick the first control node as the ones deleted are no longer
+		// in the cluster's state.
+		notDeleted = cn.Nodes[0].Name
+		break
 	}
 
 	if notDeleted == "" {

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -21,99 +21,19 @@ func DeleteNodes(logger zerolog.Logger, tracker Tracker) {
 		return
 	}
 
-	d, ok := action.Update.Delta.(*spec.Update_KDeleteNodes)
-	if !ok {
+	switch typ := action.Update.Delta.(type) {
+	case *spec.Update_DeletedK8SNodes_:
+		deleteNodesFromCluster(logger, typ, action.Update.State.K8S, tracker)
+		return
+	case *spec.Update_KDeleteNodes:
+		deleteFromState(logger, typ, action.Update.State.K8S, tracker)
+		return
+	default:
 		logger.
 			Warn().
-			Msgf("Received task for deleting nodes that is of type %T, which is not for deleeting k8s nodes, ignoring", action.Update.Delta)
+			Msgf("Received task for deleting nodes that is of type %T, which is not supported, ignoring", action.Update.Delta)
 		return
 	}
-
-	var master, worker []string
-
-	k8s := action.Update.State.K8S
-	np := nodepools.FindByName(d.KDeleteNodes.Nodepool, k8s.ClusterInfo.NodePools)
-	if np == nil {
-		logger.
-			Warn().
-			Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
-				"to be deleted is missing from the provided state, scheduling a deletion of one of the "+
-				"specified nodes without propagating the update back", d.KDeleteNodes.Nodepool)
-
-		if len(d.KDeleteNodes.Nodes) < 1 {
-			return
-		}
-
-		fullname := d.KDeleteNodes.Nodes[0]
-		strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
-
-		isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
-		if err != nil {
-			logger.
-				Err(err).
-				Msgf("Failed to determine role for node %q within kubernetes cluster", fullname)
-			tracker.Diagnostics.Push(err)
-			return
-		}
-
-		if isControl {
-			master = append(master, fullname)
-			logger.Info().Msgf("Deleting %v control nodes", len(master))
-		} else {
-			worker = append(worker, fullname)
-			logger.Info().Msgf("Deleting %v worker nodes", len(worker))
-		}
-
-		if err := deleteNodes(logger, master, worker, k8s); err != nil {
-			logger.Err(err).Msg("Failed to delete nodes")
-			tracker.Diagnostics.Push(err)
-			return
-		}
-
-		return
-	}
-
-	if np.IsControl {
-		master = append(master, d.KDeleteNodes.Nodes...)
-		logger.Info().Msgf("Deleting %v control nodes", len(master))
-	} else {
-		worker = append(worker, d.KDeleteNodes.Nodes...)
-		logger.Info().Msgf("Deleting %v worker nodes", len(worker))
-	}
-
-	if len(master) == 0 && len(worker) == 0 {
-		if d.KDeleteNodes.WithNodePool {
-			logger.
-				Info().
-				Msgf("Removing nodepool %q with 0 nodes", d.KDeleteNodes.Nodepool)
-
-			k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, d.KDeleteNodes.Nodepool)
-
-			update := tracker.Result.Update()
-			update.Kubernetes(k8s)
-			update.Commit()
-		}
-
-		return
-	}
-
-	if err := deleteNodes(logger, master, worker, k8s); err != nil {
-		logger.Err(err).Msg("Failed delete nodes")
-		tracker.Diagnostics.Push(err)
-		return
-	}
-
-	if d.KDeleteNodes.WithNodePool {
-		k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, d.KDeleteNodes.Nodepool)
-	} else {
-		nodepools.DeleteNodes(np, d.KDeleteNodes.Nodes)
-	}
-
-	update := tracker.Result.Update()
-	update.Kubernetes(k8s)
-	update.Commit()
-
-	logger.Info().Msg("Nodes successfully deleted")
 }
 
 func isControlNode(name string, kubeconfig string) (bool, error) {
@@ -143,11 +63,129 @@ func isControlNode(name string, kubeconfig string) (bool, error) {
 	return ok, nil
 }
 
-func deleteNodes(logger zerolog.Logger, master, worker []string, k8s *spec.K8Scluster) error {
+func deleteNodes(logger zerolog.Logger, master, worker []*spec.Node, k8s *spec.K8Scluster) error {
 	deleter, err := nodes.NewDeleter(master, worker, k8s)
 	if err != nil {
 		return err
 	}
 
 	return deleter.DeleteNodes(logger)
+}
+
+func deleteFromState(
+	logger zerolog.Logger,
+	a *spec.Update_KDeleteNodes,
+	k8s *spec.K8Scluster,
+	tracker Tracker,
+) {
+	if a.KDeleteNodes.WithNodePool {
+		k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, a.KDeleteNodes.Nodepool)
+	} else {
+		np := nodepools.FindByName(a.KDeleteNodes.Nodepool, k8s.ClusterInfo.NodePools)
+		if np == nil {
+			logger.
+				Warn().
+				Msgf("Nodepool %q not present in current state, assuming it was deleted", a.KDeleteNodes.Nodepool)
+
+			return
+		}
+		nodepools.DeleteNodes(np, a.KDeleteNodes.Nodes)
+	}
+
+	update := tracker.Result.Update()
+	update.Kubernetes(k8s)
+	update.Commit()
+
+	logger.Info().Msg("Nodes Removed from tracked state")
+}
+
+func deleteNodesFromCluster(
+	logger zerolog.Logger,
+	a *spec.Update_DeletedK8SNodes_,
+	k8s *spec.K8Scluster,
+	tracker Tracker,
+) {
+	var master, worker []*spec.Node
+
+	switch typ := a.DeletedK8SNodes.Kind.(type) {
+	case *spec.Update_DeletedK8SNodes_Partial_:
+		np := nodepools.FindByName(typ.Partial.Nodepool, k8s.ClusterInfo.NodePools)
+		if np == nil {
+			logger.
+				Warn().
+				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
+					"to be deleted is missing from the provided state, interpreting this as a drift and "+
+					"scheduling a deletion of one of the nodes", typ.Partial.Nodepool)
+
+			if len(typ.Partial.Nodes) < 1 {
+				return
+			}
+
+			node := typ.Partial.Nodes[0]
+			fullname := node.Name
+			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
+
+			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
+			if err != nil {
+				logger.
+					Err(err).
+					Msgf("Failed to determine role for node %q within kubernetes cluster", fullname)
+				tracker.Diagnostics.Push(err)
+				return
+			}
+
+			if isControl {
+				logger.Info().Msgf("Deleting control node %q", fullname)
+				master = append(master, node)
+			} else {
+				logger.Info().Msgf("Deleting worker node %q", fullname)
+				worker = append(worker, node)
+			}
+
+			if err := deleteNodes(logger, master, worker, k8s); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+
+			return
+		}
+
+		if np.IsControl {
+			for _, n := range typ.Partial.Nodes {
+				master = append(master, n)
+			}
+		} else {
+			for _, n := range typ.Partial.Nodes {
+				worker = append(worker, n)
+			}
+		}
+	case *spec.Update_DeletedK8SNodes_Whole:
+		if typ.Whole.Nodepool.IsControl {
+			for _, n := range typ.Whole.Nodepool.Nodes {
+				master = append(master, n)
+			}
+		} else {
+			for _, n := range typ.Whole.Nodepool.Nodes {
+				worker = append(worker, n)
+			}
+		}
+	}
+
+	if len(master) == 0 && len(worker) == 0 {
+		logger.Info().Msg("Received task with no nodes to remove")
+		return
+	}
+
+	logger.
+		Info().
+		Msgf("Deleting %v control nodes %v worker nodes", len(master), len(worker))
+
+	if err := deleteNodes(logger, master, worker, k8s); err != nil {
+		logger.Err(err).Msg("Failed to delete nodes")
+		tracker.Diagnostics.Push(err)
+		return
+	}
+
+	logger.Info().Msg("Nodes successfuly deleted")
 }

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -191,23 +191,15 @@ func deleteNodesFromCluster(
 		}
 
 		if np.IsControl {
-			for _, n := range typ.Partial.Nodes {
-				master = append(master, n)
-			}
+			master = append(master, typ.Partial.Nodes...)
 		} else {
-			for _, n := range typ.Partial.Nodes {
-				worker = append(worker, n)
-			}
+			worker = append(worker, typ.Partial.Nodes...)
 		}
 	case *spec.Update_DeletedK8SNodes_Whole:
 		if typ.Whole.Nodepool.IsControl {
-			for _, n := range typ.Whole.Nodepool.Nodes {
-				master = append(master, n)
-			}
+			master = append(master, typ.Whole.Nodepool.Nodes...)
 		} else {
-			for _, n := range typ.Whole.Nodepool.Nodes {
-				worker = append(worker, n)
-			}
+			worker = append(worker, typ.Whole.Nodepool.Nodes...)
 		}
 	}
 
@@ -226,5 +218,5 @@ func deleteNodesFromCluster(
 		return
 	}
 
-	logger.Info().Msg("Nodes successfuly deleted")
+	logger.Info().Msg("Nodes successfully deleted")
 }

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -85,8 +85,43 @@ func deleteFromState(
 		if np == nil {
 			logger.
 				Warn().
-				Msgf("Nodepool %q not present in current state, assuming it was deleted", a.KDeleteNodes.Nodepool)
+				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
+					"to be deleted is missing from the provided state, interpreting this as a drift and "+
+					"scheduling a deletion of one of the nodes", a.KDeleteNodes.Nodepool)
 
+			if len(a.KDeleteNodes.Nodes) < 1 {
+				return
+			}
+
+			fullname := a.KDeleteNodes.Nodes[0]
+			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
+
+			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
+			if err != nil {
+				logger.
+					Warn().
+					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
+						"assuming node is no longer part of the cluster", fullname)
+				return
+			}
+
+			var master, worker []*spec.Node
+
+			if isControl {
+				logger.Info().Msgf("Deleting control node %q", fullname)
+				master = append(master, &spec.Node{Name: fullname})
+			} else {
+				logger.Info().Msgf("Deleting worker node %q", fullname)
+				worker = append(worker, &spec.Node{Name: fullname})
+			}
+
+			if err := deleteNodes(logger, master, worker, k8s); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+			// Do not propagate an update in this case as the nodepool is not tracked
+			// and the manager service wil refuse the update.
 			return
 		}
 		nodepools.DeleteNodes(np, a.KDeleteNodes.Nodes)
@@ -96,7 +131,9 @@ func deleteFromState(
 	update.Kubernetes(k8s)
 	update.Commit()
 
-	logger.Info().Msg("Nodes Removed from tracked state")
+	logger.
+		Info().
+		Msgf("Nodes %v Removed from tracked state", a.KDeleteNodes.Nodes)
 }
 
 func deleteNodesFromCluster(
@@ -128,9 +165,9 @@ func deleteNodesFromCluster(
 			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
 			if err != nil {
 				logger.
-					Err(err).
-					Msgf("Failed to determine role for node %q within kubernetes cluster", fullname)
-				tracker.Diagnostics.Push(err)
+					Warn().
+					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
+						"assuming node is no longer part of the cluster", fullname)
 				return
 			}
 
@@ -148,6 +185,8 @@ func deleteNodesFromCluster(
 				return
 			}
 
+			// Do not propagate an update in this case as the nodepool is not tracked
+			// and the manager service wil refuse the update
 			return
 		}
 

--- a/services/manager/internal/service/handler_msg.go
+++ b/services/manager/internal/service/handler_msg.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,22 +44,32 @@ func handlerInner(
 	stores Stores,
 ) {
 	var (
-		// Messages are in the format (ID)-(SUBJECT), this is to avoid duplicate
-		// messageId catching as the task moves trough the pipeline, thus in here
-		// strip the suffix.
-		subject           = msg.Subject()
-		msgID             = strings.TrimSuffix(msg.Headers().Get(nats.MsgIdHdr), fmt.Sprintf("-%s", subject))
+		// Messages are in the format (ID)-(SUBJECT)-(STAGE), this is to avoid duplicate
+		// messageId by NATS as the task moves through the pipeline, thus parse the ID.
+		subject  = msg.Subject()
+		parsedID = strings.Split(msg.Headers().Get(nats.MsgIdHdr), fmt.Sprintf("-%v-", subject))
+	)
+
+	if len(parsedID) < 2 {
+		parsedID = []string{parsedID[0], "unknown"}
+	}
+
+	var (
 		taskID            = msg.Headers().Get(natsutils.WorkID)
 		inputManifestName = msg.Headers().Get(natsutils.InputManifestName)
 		clusterName       = msg.Headers().Get(natsutils.ClusterName)
+		msgStage          = msg.Headers().Get(natsutils.Stage)
 
 		logger = log.With().
 			Str(natsutils.InputManifestName, inputManifestName).
 			Str(natsutils.ClusterName, clusterName).
 			Str(natsutils.WorkID, taskID).
-			Str(nats.MsgIdHdr, msgID).
+			Str(natsutils.Stage, msgStage).
+			Str(nats.MsgIdHdr, parsedID[0]).
 			Str("msg-from-subject", subject).
 			Logger()
+
+		parsedEventStage uint32
 	)
 
 	if inputManifestName == "" {
@@ -82,6 +94,16 @@ func handlerInner(
 			Msg("Message pulled from jetstream has missing ID of the task for which it was scheduled, won't process")
 		discard(logger, msg)
 		return
+	}
+
+	if s, err := strconv.ParseInt(parsedID[1], 10, 64); err != nil || s < 0 || s > math.MaxUint32 {
+		logger.
+			Error().
+			Msg("Message pulled from jetstream has invalid stage, won't process")
+		discard(logger, msg)
+		return
+	} else {
+		parsedEventStage = uint32(s)
 	}
 
 	stage, ok := taskStageFromNatsSubject(subject)
@@ -113,6 +135,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        taskID,
+			TaskStage:     parsedEventStage,
 			Stage:         stage,
 			Result:        &result,
 		}

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -178,6 +178,10 @@ func HealthCheckNodeReachability(
 
 		// nodes that are in the k8s cluster but not in our tracked state.
 		for _, n := range clusterNodes {
+			logger.
+				Warn().
+				Msgf("Node %q present in cluster but not in tracked state, will be removed", n.K8sName)
+
 			result.UnknownKubernetesNodes[n.NodePool] = append(result.UnknownKubernetesNodes[n.NodePool], NodeDescription{
 				K8sName: n.K8sName,
 				Ready:   false, // since we do not track them, consider them as not ready.

--- a/services/manager/internal/service/process_task.go
+++ b/services/manager/internal/service/process_task.go
@@ -23,6 +23,7 @@ type (
 		InputManifest string
 		Cluster       string
 		TaskID        string
+		TaskStage     uint32
 		Stage         store.StageKind
 		Result        *spec.TaskResult
 	}
@@ -70,6 +71,13 @@ func ProcessTask(ctx context.Context, stores Stores, work Work) (acknowledge boo
 
 	if cluster.InFlight == nil || (cluster.InFlight.Id != work.TaskID) {
 		logger.Warn().Msg("Recevied task for cluster does not match, ignoring.")
+		acknowledge = true
+		metrics.NatsMsgsAcknowledged.Inc()
+		return
+	}
+
+	if cluster.InFlight.CurrentStage != work.TaskStage {
+		logger.Warn().Msg("Received stage for task does not match, ignoring.")
 		acknowledge = true
 		metrics.NatsMsgsAcknowledged.Inc()
 		return

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -775,7 +775,7 @@ func ScheduleAdditionsInNodePools(
 
 		// This is a separate stage
 		// as it depends on the success on all of the
-		// previous stages to complete successfuly.
+		// previous stages to complete successfully.
 		//
 		// This stage commits the newly added nodes into
 		// the loadbalancers (if any) so that new traffic
@@ -937,7 +937,7 @@ func ScheduleAdditionsInNodePools(
 
 		// This is a separate stage
 		// as it depends on the success on all of the
-		// previous stages to complete successfuly.
+		// previous stages to complete successfully.
 		//
 		// This stage commits the newly added nodes into
 		// the loadbalancers (if any) so that new traffic
@@ -1228,7 +1228,7 @@ func ScheduleDeletionsInNodePools(
 
 		// This is a separate stage
 		// as it depends on the success on all of the
-		// previous stages to complete successfuly.
+		// previous stages to complete successfully.
 		//
 		// This stage commits the deleted nodes and removes
 		// them from the loadbalancers (if any) so that traffic
@@ -1377,7 +1377,7 @@ func ScheduleDeletionsInNodePools(
 
 		// This is a separate stage
 		// as it depends on the success on all of the
-		// previous stages to complete successfuly.
+		// previous stages to complete successfully.
 		//
 		// This stage commits the deleted nodes and removes
 		// them from the loadbalancers (if any) so that traffic

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -590,11 +590,17 @@ func ScheduleAdditionsInNodePools(
 	diff *NodePoolsDiffResult,
 	opts K8sNodeAdditionOptions,
 ) *spec.TaskEvent {
-	inFlight := proto.Clone(current).(*spec.Clusters)
-	pipeline := []*spec.Stage{}
+	var (
+		inFlight = proto.Clone(current).(*spec.Clusters)
+
+		terraformerStage *spec.Stage
+		ansiblerStage    *spec.Stage
+		kubeElevenStage  *spec.Stage
+		kuberStage       *spec.Stage
+	)
 
 	if !opts.IsStatic {
-		pipeline = append(pipeline, &spec.Stage{
+		terraformerStage = &spec.Stage{
 			StageKind: &spec.Stage_Terraformer{
 				Terraformer: &spec.StageTerraformer{
 					Description: &spec.StageDescription{
@@ -612,7 +618,7 @@ func ScheduleAdditionsInNodePools(
 					},
 				},
 			},
-		})
+		}
 	}
 
 	ans := spec.Stage_Ansibler{
@@ -625,7 +631,7 @@ func ScheduleAdditionsInNodePools(
 		},
 	}
 
-	pipeline = append(pipeline, &spec.Stage{StageKind: &ans})
+	ansiblerStage = &spec.Stage{StageKind: &ans}
 
 	if opts.UseProxy {
 		ans.Ansibler.SubPasses = append(ans.Ansibler.SubPasses, []*spec.StageAnsibler_SubPass{
@@ -698,7 +704,7 @@ func ScheduleAdditionsInNodePools(
 		}...)
 	}
 
-	pipeline = append(pipeline, &spec.Stage{
+	kubeElevenStage = &spec.Stage{
 		StageKind: &spec.Stage_KubeEleven{
 			KubeEleven: &spec.StageKubeEleven{
 				Description: &spec.StageDescription{
@@ -716,7 +722,7 @@ func ScheduleAdditionsInNodePools(
 				},
 			},
 		},
-	})
+	}
 
 	kuber := spec.Stage_Kuber{
 		Kuber: &spec.StageKuber{
@@ -736,7 +742,7 @@ func ScheduleAdditionsInNodePools(
 		},
 	}
 
-	pipeline = append(pipeline, &spec.Stage{StageKind: &kuber})
+	kuberStage = &spec.Stage{StageKind: &kuber}
 
 	for np, nodes := range diff.PartiallyAdded {
 		// If the ApiServer is on the kubernetes cluster on addition of the
@@ -767,21 +773,44 @@ func ScheduleAdditionsInNodePools(
 			continue
 		}
 
+		// This is a separate stage
+		// as it depends on the success on all of the
+		// previous stages to complete successfuly.
+		//
+		// This stage commits the newly added nodes into
+		// the loadbalancers (if any) so that new traffic
+		// can be routed through them.
+		var updateLoadBalancersStage *spec.Stage
+
 		// If changes to the nodepool affects any loadbalancer
 		// also schedule a reconciliation of loadbalancers, as
 		// the envoy targets needs to be regenerated.
+	lbrefresh1:
 		for _, lb := range current.LoadBalancers.Clusters {
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
 					if nodepools.HasNodePoolTypeOf(tg, np) {
-						ans.Ansibler.SubPasses = append(ans.Ansibler.SubPasses, &spec.StageAnsibler_SubPass{
-							Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
-							Description: &spec.StageDescription{
-								About:      "Reconciling Envoy settings after changes to nodepool",
-								ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						updateLoadBalancersStage = &spec.Stage{
+							StageKind: &spec.Stage_Ansibler{
+								Ansibler: &spec.StageAnsibler{
+									Description: &spec.StageDescription{
+										About:      "Updating Envoy configuration on the LoadBalancers",
+										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+									},
+									SubPasses: []*spec.StageAnsibler_SubPass{
+										{
+											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
+											Description: &spec.StageDescription{
+												About:      "Reconciling Envoy settings after changes to nodepool",
+												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+											},
+										},
+									},
+								},
 							},
-						})
+						}
+						break lbrefresh1
 					}
 				}
 			}
@@ -823,6 +852,20 @@ func ScheduleAdditionsInNodePools(
 					},
 				},
 			}
+		}
+
+		var pipeline []*spec.Stage
+
+		if terraformerStage != nil {
+			pipeline = append(pipeline, terraformerStage)
+		}
+
+		pipeline = append(pipeline, ansiblerStage)
+		pipeline = append(pipeline, kubeElevenStage)
+		pipeline = append(pipeline, kuberStage)
+
+		if updateLoadBalancersStage != nil {
+			pipeline = append(pipeline, updateLoadBalancersStage)
 		}
 
 		return &spec.TaskEvent{
@@ -889,21 +932,44 @@ func ScheduleAdditionsInNodePools(
 			},
 		})
 
+		// This is a separate stage
+		// as it depends on the success on all of the
+		// previous stages to complete successfuly.
+		//
+		// This stage commits the newly added nodes into
+		// the loadbalancers (if any) so that new traffic
+		// can be routed through them.
+		var updateLoadBalancersStage *spec.Stage
+
 		// If changes to the nodepool affects any loadbalancer
 		// also schedule a reconciliation of loadbalancers, as
 		// the envoy targets needs to be regenerated.
+	lbrefresh2:
 		for _, lb := range current.LoadBalancers.Clusters {
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
 					if nodepools.HasNodePoolTypeOf(tg, np) {
-						ans.Ansibler.SubPasses = append(ans.Ansibler.SubPasses, &spec.StageAnsibler_SubPass{
-							Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
-							Description: &spec.StageDescription{
-								About:      "Reconciling Envoy settings after changes to nodepool",
-								ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						updateLoadBalancersStage = &spec.Stage{
+							StageKind: &spec.Stage_Ansibler{
+								Ansibler: &spec.StageAnsibler{
+									Description: &spec.StageDescription{
+										About:      "Updating Envoy configuration on the LoadBalancers",
+										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+									},
+									SubPasses: []*spec.StageAnsibler_SubPass{
+										{
+											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
+											Description: &spec.StageDescription{
+												About:      "Reconciling Envoy settings after changes to nodepool",
+												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+											},
+										},
+									},
+								},
 							},
-						})
+						}
+						break lbrefresh2
 					}
 				}
 			}
@@ -942,6 +1008,20 @@ func ScheduleAdditionsInNodePools(
 			}
 		}
 
+		var pipeline []*spec.Stage
+
+		if terraformerStage != nil {
+			pipeline = append(pipeline, terraformerStage)
+		}
+
+		pipeline = append(pipeline, ansiblerStage)
+		pipeline = append(pipeline, kubeElevenStage)
+		pipeline = append(pipeline, kuberStage)
+
+		if updateLoadBalancersStage != nil {
+			pipeline = append(pipeline, updateLoadBalancersStage)
+		}
+
 		return &spec.TaskEvent{
 			Id:        uuid.New().String(),
 			Timestamp: timestamppb.New(time.Now().UTC()),
@@ -975,28 +1055,59 @@ func ScheduleDeletionsInNodePools(
 	diff *NodePoolsDiffResult,
 	opts K8sNodeDeletionOptions,
 ) *spec.TaskEvent {
-	inFlight := proto.Clone(current).(*spec.Clusters)
+	var (
+		inFlight = proto.Clone(current).(*spec.Clusters)
 
-	// The kuber stage is removes the node from the scheduled 'InFlight'
-	// state and also from the kuberentes cluster, regardless if its a
-	// dynamic or a static node.
+		removeFromTrackedStage *spec.Stage
+		removeFromClusterStage *spec.Stage
+		cleanUpStage           *spec.Stage
+		infraRemovalStage      *spec.Stage
+	)
+
+	// Removes the nodes from the scheduled 'InFlight' state.
+	removeFromTrackedStage = &spec.Stage{
+		StageKind: &spec.Stage_Kuber{
+			Kuber: &spec.StageKuber{
+				Description: &spec.StageDescription{
+					About:      "Removing Nodes from tracked state",
+					ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+				},
+				SubPasses: []*spec.StageKuber_SubPass{
+					{
+						Kind: spec.StageKuber_DELETE_NODES,
+						Description: &spec.StageDescription{
+							About:      "Updating tracked state",
+							ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Remove the nodes from the kubernetes cluster itself.
+	//
+	// NOTE: while this will receive a different message
+	// than the [removeFromTackedStage] kuber stage and thus
+	// will trigger a different code path.
 	kuber := spec.Stage_Kuber{
 		Kuber: &spec.StageKuber{
 			Description: &spec.StageDescription{
-				About:      "Reconciling cluster configuration",
+				About:      "Reconciling cluster",
 				ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
 			},
 			SubPasses: []*spec.StageKuber_SubPass{
 				{
 					Kind: spec.StageKuber_DELETE_NODES,
 					Description: &spec.StageDescription{
-						About:      "Deleting nodes from kubernetes cluster",
+						About:      "Deleting nodes from cluster",
 						ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
 					},
 				},
 			},
 		},
 	}
+	removeFromClusterStage = &spec.Stage{StageKind: &kuber}
 
 	// For deletion, the Ansible stage does not need to be executed
 	// as there is no need to refresh/reconcile the modified nodepools
@@ -1007,10 +1118,6 @@ func ScheduleDeletionsInNodePools(
 	// The healthcheck within the reconciliation loop will trigger a refresh
 	// of the VPN, which is the only action to do on deletion, but leaving it
 	// to the healthcheck may buffer more nodes in a single update.
-	pipeline := []*spec.Stage{
-		{StageKind: &kuber},
-	}
-
 	ans := spec.Stage_Ansibler{
 		Ansibler: &spec.StageAnsibler{
 			Description: &spec.StageDescription{
@@ -1063,14 +1170,10 @@ func ScheduleDeletionsInNodePools(
 		}...)
 	}
 
-	if len(ans.Ansibler.SubPasses) > 0 {
-		pipeline = append(pipeline, &spec.Stage{StageKind: &ans})
-	}
-
 	// Only send the data through the terraformer stage if deletion is
 	// for dynamic nodes.
 	if !opts.IsStatic {
-		pipeline = append(pipeline, &spec.Stage{
+		infraRemovalStage = &spec.Stage{
 			StageKind: &spec.Stage_Terraformer{
 				Terraformer: &spec.StageTerraformer{
 					Description: &spec.StageDescription{
@@ -1088,7 +1191,7 @@ func ScheduleDeletionsInNodePools(
 					},
 				},
 			},
-		})
+		}
 	}
 
 	for np, nodes := range diff.PartiallyDeleted {
@@ -1117,6 +1220,15 @@ func ScheduleDeletionsInNodePools(
 			}
 		}
 
+		// This is a separate stage
+		// as it depends on the success on all of the
+		// previous stages to complete successfuly.
+		//
+		// This stage commits the deleted nodes and removes
+		// them from the loadbalancers (if any) so that traffic
+		// stops flowing through them.
+		var removeFromLBStage *spec.Stage
+
 		// Contrary to addition, when deleting we do not skip if the nodepool is not found.
 		// As deleting from a not found nodepool should be handled gracefully by the existing
 		// services.
@@ -1124,21 +1236,48 @@ func ScheduleDeletionsInNodePools(
 		// If changes to the nodepool affects any loadbalancer
 		// also schedule a reconciliation of loadbalancers, as
 		// the envoy targets needs to be regenerated.
+	lbrefresh1:
 		for _, lb := range current.LoadBalancers.Clusters {
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
 					if nodepools.HasNodePoolTypeOf(tg, np) {
-						ans.Ansibler.SubPasses = append(ans.Ansibler.SubPasses, &spec.StageAnsibler_SubPass{
-							Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
-							Description: &spec.StageDescription{
-								About:      "Reconciling Envoy settings after changes to nodepool",
-								ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						removeFromLBStage = &spec.Stage{
+							StageKind: &spec.Stage_Ansibler{
+								Ansibler: &spec.StageAnsibler{
+									Description: &spec.StageDescription{
+										About:      "Updating envoy configuration",
+										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+									},
+									SubPasses: []*spec.StageAnsibler_SubPass{
+										{
+											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
+											Description: &spec.StageDescription{
+												About:      "Removing deleted nodes from envoy",
+												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+											},
+										},
+									},
+								},
 							},
-						})
+						}
+						break lbrefresh1
 					}
 				}
 			}
+		}
+
+		var pipeline []*spec.Stage
+
+		pipeline = append(pipeline, removeFromTrackedStage)
+		pipeline = append(pipeline, removeFromLBStage)
+		pipeline = append(pipeline, removeFromClusterStage)
+		if len(ans.Ansibler.SubPasses) > 0 {
+			cleanUpStage = &spec.Stage{StageKind: &ans}
+			pipeline = append(pipeline, cleanUpStage)
+		}
+		if infraRemovalStage != nil {
+			pipeline = append(pipeline, infraRemovalStage)
 		}
 
 		return &spec.TaskEvent{
@@ -1221,24 +1360,59 @@ func ScheduleDeletionsInNodePools(
 			},
 		})
 
+		// This is a separate stage
+		// as it depends on the success on all of the
+		// previous stages to complete successfuly.
+		//
+		// This stage commits the deleted nodes and removes
+		// them from the loadbalancers (if any) so that traffic
+		// stops flowing through them.
+		var removeFromLBStage *spec.Stage
+
 		// If changes to the nodepool affects any loadbalancer
 		// also schedule a reconciliation of loadbalancers, as
 		// the envoy targets needs to be regenerated.
+	lbrefresh2:
 		for _, lb := range current.LoadBalancers.Clusters {
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
 					if nodepools.HasNodePoolTypeOf(tg, np) {
-						ans.Ansibler.SubPasses = append(ans.Ansibler.SubPasses, &spec.StageAnsibler_SubPass{
-							Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
-							Description: &spec.StageDescription{
-								About:      "Reconciling Envoy settings after changes to nodepool",
-								ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						removeFromLBStage = &spec.Stage{
+							StageKind: &spec.Stage_Ansibler{
+								Ansibler: &spec.StageAnsibler{
+									Description: &spec.StageDescription{
+										About:      "Updating envoy configuration",
+										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+									},
+									SubPasses: []*spec.StageAnsibler_SubPass{
+										{
+											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
+											Description: &spec.StageDescription{
+												About:      "Removing deleted nodes from envoy",
+												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+											},
+										},
+									},
+								},
 							},
-						})
+						}
+						break lbrefresh2
 					}
 				}
 			}
+		}
+
+		var pipeline []*spec.Stage
+
+		pipeline = append(pipeline, removeFromTrackedStage)
+		pipeline = append(pipeline, removeFromLBStage)
+		pipeline = append(pipeline, removeFromClusterStage)
+		if len(ans.Ansibler.SubPasses) > 0 {
+			pipeline = append(pipeline, cleanUpStage)
+		}
+		if infraRemovalStage != nil {
+			pipeline = append(pipeline, infraRemovalStage)
 		}
 
 		return &spec.TaskEvent{

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -790,7 +790,10 @@ func ScheduleAdditionsInNodePools(
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
-					if nodepools.HasNodePoolTypeOf(tg, np) {
+					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
+					// Static nodepools don't have any hashes.
+					staticNodePoolUpdate := opts.IsStatic && tg == np
+					if dynamicNodePoolUpdate || staticNodePoolUpdate {
 						updateLoadBalancersStage = &spec.Stage{
 							StageKind: &spec.Stage_Ansibler{
 								Ansibler: &spec.StageAnsibler{
@@ -949,7 +952,10 @@ func ScheduleAdditionsInNodePools(
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
-					if nodepools.HasNodePoolTypeOf(tg, np) {
+					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
+					// Static nodepools don't have any hashes.
+					staticNodePoolUpdate := opts.IsStatic && tg == np
+					if dynamicNodePoolUpdate || staticNodePoolUpdate {
 						updateLoadBalancersStage = &spec.Stage{
 							StageKind: &spec.Stage_Ansibler{
 								Ansibler: &spec.StageAnsibler{
@@ -1241,7 +1247,10 @@ func ScheduleDeletionsInNodePools(
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
-					if nodepools.HasNodePoolTypeOf(tg, np) {
+					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
+					// Static nodepools don't have any hashes.
+					staticNodePoolUpdate := opts.IsStatic && tg == np
+					if dynamicNodePoolUpdate || staticNodePoolUpdate {
 						removeFromLBStage = &spec.Stage{
 							StageKind: &spec.Stage_Ansibler{
 								Ansibler: &spec.StageAnsibler{
@@ -1270,12 +1279,18 @@ func ScheduleDeletionsInNodePools(
 		var pipeline []*spec.Stage
 
 		pipeline = append(pipeline, removeFromTrackedStage)
-		pipeline = append(pipeline, removeFromLBStage)
+
+		if removeFromLBStage != nil {
+			pipeline = append(pipeline, removeFromLBStage)
+		}
+
 		pipeline = append(pipeline, removeFromClusterStage)
+
 		if len(ans.Ansibler.SubPasses) > 0 {
 			cleanUpStage = &spec.Stage{StageKind: &ans}
 			pipeline = append(pipeline, cleanUpStage)
 		}
+
 		if infraRemovalStage != nil {
 			pipeline = append(pipeline, infraRemovalStage)
 		}
@@ -1377,7 +1392,10 @@ func ScheduleDeletionsInNodePools(
 			for _, r := range lb.Roles {
 				for _, tg := range r.TargetPools {
 					// Need to match against only the nodepool name without the hash.
-					if nodepools.HasNodePoolTypeOf(tg, np) {
+					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
+					// Static nodepools don't have any hashes.
+					staticNodePoolUpdate := opts.IsStatic && tg == np
+					if dynamicNodePoolUpdate || staticNodePoolUpdate {
 						removeFromLBStage = &spec.Stage{
 							StageKind: &spec.Stage_Ansibler{
 								Ansibler: &spec.StageAnsibler{
@@ -1406,9 +1424,14 @@ func ScheduleDeletionsInNodePools(
 		var pipeline []*spec.Stage
 
 		pipeline = append(pipeline, removeFromTrackedStage)
-		pipeline = append(pipeline, removeFromLBStage)
+
+		if removeFromLBStage != nil {
+			pipeline = append(pipeline, removeFromLBStage)
+		}
+
 		pipeline = append(pipeline, removeFromClusterStage)
 		if len(ans.Ansibler.SubPasses) > 0 {
+			cleanUpStage = &spec.Stage{StageKind: &ans}
 			pipeline = append(pipeline, cleanUpStage)
 		}
 		if infraRemovalStage != nil {

--- a/services/manager/internal/service/reconciliate_unreachable_nodes.go
+++ b/services/manager/internal/service/reconciliate_unreachable_nodes.go
@@ -218,6 +218,7 @@ Fix the unreachable nodes by either:
 - if the connectivity issue cannot be resolved, you can:
  - delete the whole nodepool from the kubernetes cluster in the InputManifest
  - delete the selected unreachable node/s manually from the cluster via 'kubectl delete node ...'
+ - delete the node from the InputManifest, if it is a static node.
 
    NOTE: if the unreachable node is the kube-apiserver, claudie will not be able to recover
          after the deletion.

--- a/services/manager/internal/service/watchers.go
+++ b/services/manager/internal/service/watchers.go
@@ -63,7 +63,7 @@ func (s *Service) WatchForScheduledDocuments(ctx context.Context) error {
 			noWork = noWork || len(event.Pipeline) < 1
 			noWork = noWork || (int(event.CurrentStage) > len(event.Pipeline))
 			if noWork {
-				logger.Debug().Msgf("Nothing to be worked on for cluster %q, considering as done", cluster)
+				logger.Info().Msgf("Nothing to be worked on for cluster %q, considering as done", cluster)
 
 				state.InFlight = nil
 				state.State.Status = spec.Workflow_DONE.String()
@@ -96,7 +96,8 @@ func (s *Service) WatchForScheduledDocuments(ctx context.Context) error {
 					cluster,
 					event.Id,
 					event.Task,
-					pipeline[event.CurrentStage],
+					event.CurrentStage,
+					pipeline,
 				)
 				if err != nil {
 					// unexpected but we don't crash the service just ignore and continue.
@@ -129,7 +130,7 @@ func (s *Service) WatchForScheduledDocuments(ctx context.Context) error {
 					// messages from another stage here and there had to be some network issues.
 					logger.
 						Warn().
-						Msgf("event %q: %q, for cluster %q was submitted more than once but the duplication was caught, will move the task to the next stage, assuming the last try failed", event.Id, event.Description, cluster)
+						Msgf("event %q: %q, for cluster %q was submitted more than once but the duplication was caught, will move the task to IN_PROGRESS, assuming the last try failed", event.Id, event.Description, cluster)
 				}
 
 				state.State.Status = spec.Workflow_IN_PROGRESS.String()
@@ -338,7 +339,8 @@ func (s *Service) WatchForDoneOrErrorDocuments(ctx context.Context) error {
 func messageForStage(
 	inputManifestName, clusterName, eventID string,
 	marshalledTask []byte,
-	stage *spec.Stage,
+	stage uint32,
+	pipeline []*spec.Stage,
 ) (nats.Msg, string, error) {
 	var (
 		task         spec.Task
@@ -354,7 +356,7 @@ func messageForStage(
 
 	work.Task = &task
 
-	switch stage := stage.GetStageKind().(type) {
+	switch stage := pipeline[stage].GetStageKind().(type) {
 	case *spec.Stage_Ansibler:
 		b := new(strings.Builder)
 		b.WriteString(stage.Ansibler.Description.About)
@@ -440,7 +442,7 @@ func messageForStage(
 	// thus each stage needs its own ID for it to not
 	// be considered as a duplicate if send to another
 	// stage.
-	stageID := fmt.Sprintf("%v-%v", eventID, subject)
+	stageID := fmt.Sprintf("%v-%v-%v", eventID, subject, stage)
 
 	headers := nats.Header{}
 	headers.Set(nats.MsgIdHdr, stageID)

--- a/services/terraformer/internal/worker/service/handler_msg.go
+++ b/services/terraformer/internal/worker/service/handler_msg.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,22 +56,27 @@ func handlerInner(
 ) {
 	var (
 		stageID       = msg.Headers().Get(nats.MsgIdHdr)
-		suffix        = fmt.Sprintf("-%v", natsutils.TerraformerRequests)
-		parsedStageID = strings.Split(stageID, suffix)
+		infix         = fmt.Sprintf("-%v-", natsutils.TerraformerRequests)
+		parsedStageID = strings.Split(stageID, infix)
 		discard       = false
 	)
 
-	if len(parsedStageID) < 1 || parsedStageID[0] == "" {
+	if len(parsedStageID) < 2 || parsedStageID[0] == "" || parsedStageID[1] == "" {
 		discard = true
-		parsedStageID = []string{"unknown"}
+		parsedStageID = []string{parsedStageID[0], "unknown"}
 	}
 
 	if _, err := uuid.Parse(parsedStageID[0]); err != nil {
 		discard = true
 	}
 
+	if s, err := strconv.ParseInt(parsedStageID[1], 10, 64); err != nil || s < 0 || s > math.MaxUint32 {
+		discard = true
+	}
+
 	var (
 		eventID           = parsedStageID[0]
+		eventStage        = parsedStageID[1]
 		replyChannel      = msg.Headers().Get(natsutils.ReplyToHeader)
 		inputManifestName = msg.Headers().Get(natsutils.InputManifestName)
 		clusterName       = msg.Headers().Get(natsutils.ClusterName)
@@ -77,6 +84,7 @@ func handlerInner(
 		logger = log.With().
 			Str(natsutils.ClusterName, clusterName).
 			Str(natsutils.InputManifestName, inputManifestName).
+			Str(natsutils.Stage, eventStage).
 			Str(nats.MsgIdHdr, eventID).
 			Logger()
 	)
@@ -86,6 +94,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -105,6 +114,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 		}
 		// Try to send a noop as we failed to unmarshal the received message
@@ -128,6 +138,7 @@ func handlerInner(
 					InputManifest: inputManifestName,
 					Cluster:       clusterName,
 					TaskID:        eventID,
+					Stage:         eventStage,
 					Subject:       replyChannel,
 				}
 				// Try to send a noop as we failed to unmarshal the received message
@@ -185,6 +196,7 @@ func handlerInner(
 			InputManifest: inputManifestName,
 			Cluster:       clusterName,
 			TaskID:        eventID,
+			Stage:         eventStage,
 			Subject:       replyChannel,
 			Result:        result,
 		}


### PR DESCRIPTION
This PR introduces the following changes:


- NATS messages are altered, specifically their IDs. Since now a single task can be passed through the same service multiple times part of the ID thats sends into NATS is now also the stage of the task.

- This issue closes https://github.com/berops/claudie/issues/1961. Meaning that the Loadbalancers are either edited first, in case of deletion, or last in case of addition so that traffic will/will not be routed through the targeted nodes based on the operation, which leads to dropped requests if they are.


When updating claudie to a new version with this commit, no tasks needs to be worked on, and ideally the manager service is scaled to 0 replicas to also prevent scheduling any new tasks while the new version is deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage-aware task tracking: stage-specific duplicate detection and stage included in reply/response metadata.

* **Improvements**
  * Stricter stage validation and enriched logging with stage context.
  * Reworked reconciliation and node-deletion pipelines with explicit stage sequencing and clearer deletion routing.
  * Task processing now validates incoming task stage against cluster current stage and skips mismatches.

* **Bug Fixes**
  * Safer nodepool copying to avoid nil-map issues; kube-proxy deletion retries downgraded to warnings.

* **Chores**
  * Updated container image tags and a minor dependency bump.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->