### PR TITLE
feat: add OVH as native provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Before you begin, please make sure you have the following prerequisites installe
    | [CloudRift](https://docs.claudie.io/latest/input-manifest/providers/cloudrift/)    | :heavy_check_mark: | N/A                | N/A               | :heavy_check_mark: |
    | [Verda](https://docs.claudie.io/latest/input-manifest/providers/verda/)            | :heavy_check_mark: | N/A                | N/A               | :heavy_check_mark: |
    | [Cloudflare](https://docs.claudie.io/latest/input-manifest/providers/cloudflare/) | N/A                | :heavy_check_mark: |:heavy_check_mark: | N/A                |
-   | [OVHcloud](https://docs.claudie.io/latest/input-manifest/providers/openstack/)   | :heavy_check_mark: | N/A                | N/A               | :heavy_check_mark: |
+   | [OVHcloud](https://docs.claudie.io/latest/input-manifest/providers/ovh/)         | :heavy_check_mark: | :heavy_check_mark: | N/A               | :heavy_check_mark: |
    | [Openstack](https://docs.claudie.io/latest/input-manifest/providers/openstack/)   | :heavy_check_mark: | N/A                | N/A               | :heavy_check_mark: |
 
 > **Note:** `N/A` indicates that the given feature is not applicable for the provider.

--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -231,7 +231,7 @@ To find out how to configure Azure provider and service account, follow the inst
 ### OVHcloud
 
 The fields that need to be included in a Kubernetes Secret resource to utilize the OVHcloud provider.
-To find out how to configure OVHcloud provider and API credentials, follow the instructions [here](./providers/ovh.md).
+To configure OVHcloud provider and API credentials, follow the [OVHcloud provider guide](./providers/ovh.md).
 
 - `clientid`
 

--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -49,6 +49,7 @@ needs to be defined.
   | `gcp`          | [GCP](#gcp) provider type                   |
   | `hetzner`      | [Hetzner](#hetzner) provider type           |
   | `oci`          | [OCI](#oci) provider type                   |
+  | `ovh`          | [OVHcloud](#ovhcloud) provider type         |
   | `verda`        | [Verda](#verda) provider type               |
 
 - `secretRef` [SecretRef](#secretref)
@@ -227,6 +228,32 @@ To find out how to configure Azure provider and service account, follow the inst
   - `tag`: Optional. If set when the git repository is downloaded, the commit hash from the tag version is used.
   - `path`: specifies the path for a specific provider within the `repository` where the source template files are located.
 
+### OVHcloud
+
+The fields that need to be included in a Kubernetes Secret resource to utilize the OVHcloud provider.
+To find out how to configure OVHcloud provider and API credentials, follow the instructions [here](./providers/ovh.md).
+
+- `clientid`
+
+  OAuth2 Client ID issued by the OVHcloud Control Panel under **Identity and Access Management -> OAuth2 service accounts**.
+
+- `clientsecret`
+
+  OAuth2 Client Secret paired with the `clientid` above. Shown only once at creation time.
+
+- `servicename`
+
+  Public Cloud project ID. Found in the OVHcloud Manager under **Public Cloud -> Project Management**.
+
+- `endpoint` *(optional)*
+
+  OVHcloud API endpoint region. One of `ovh-eu` (default), `ovh-us`, `ovh-ca`, `kimsufi-eu`, `kimsufi-ca`, `soyoustart-eu`, `soyoustart-ca`. This selects the API region, not the compute region.
+
+- `templates`
+  - `repository`: specifies the location from where the external template are to be acquired. Must be a publicly available git repository.
+  - `tag`: Optional. If set when the git repository is downloaded, the commit hash from the tag version is used.
+  - `path`: specifies the path for a specific provider within the `repository` where the source template files are located.
+
 ### Verda
 
 The fields that need to be included in a Kubernetes Secret resource to utilize the Verda Cloud provider.
@@ -334,7 +361,7 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 
 ## Provider Spec
 
-Provider spec is an additional specification built on top of the data from any of the provider instance. Here are provider configuration examples for each individual provider: [aws](providers/aws.md), [azure](providers/azure.md), [cloudrift](providers/cloudrift.md), [exoscale](providers/exoscale.md), [gcp](providers/gcp.md), [cloudflare](providers/cloudflare.md), [hetzner](providers/hetzner.md), [oci](providers/oci.md) and [verda](providers/verda.md).
+Provider spec is an additional specification built on top of the data from any of the provider instance. Here are provider configuration examples for each individual provider: [aws](providers/aws.md), [azure](providers/azure.md), [cloudrift](providers/cloudrift.md), [exoscale](providers/exoscale.md), [gcp](providers/gcp.md), [cloudflare](providers/cloudflare.md), [hetzner](providers/hetzner.md), [oci](providers/oci.md), [ovh](providers/ovh.md) and [verda](providers/verda.md).
 
 - `name`
 

--- a/docs/input-manifest/providers/ovh.md
+++ b/docs/input-manifest/providers/ovh.md
@@ -1,0 +1,355 @@
+# OVHcloud
+[OVHcloud](https://www.ovhcloud.com/) is a European cloud provider with data centres in France, Germany, the UK, Poland, Canada and other locations. Claudie's OVH provider uses the native `ovh/ovh` OpenTofu provider with OAuth2 client credentials. It supports both compute and DNS, so an OVH provider entry can be reused as a load-balancer DNS provider.
+
+## Compute example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ovh-secret
+data:
+  clientid: <base64-encoded-client-id>
+  clientsecret: <base64-encoded-client-secret>
+  servicename: <base64-encoded-public-cloud-project-id>
+  endpoint: <base64-encoded-endpoint>  # optional, defaults to ovh-eu
+type: Opaque
+```
+
+!!! note "No native security groups"
+    The `ovh/ovh` provider does not expose security group or firewall resources. Claudie configures host-level `iptables` rules in cloud-init (the same approach as the CloudRift provider). KubeOne disables UFW during node bootstrap, but the iptables rules persist via `iptables-persistent`.
+
+!!! note "Public IP by default"
+    Every Claudie-provisioned OVH instance gets a routable public IPv4 (`network { public = true }`). Floating IPs are not modelled in v1 because the OVH provider does not yet expose a native floating-IP resource ([issue](https://github.com/ovh/terraform-provider-ovh/issues/1245)).
+
+## Create OVH API credentials
+
+Claudie uses the OAuth2 client-credentials grant supported by both the `ovh/ovh` OpenTofu provider and the official `github.com/ovh/go-ovh` Go client.
+
+1. Sign in to the [OVHcloud Control Panel](https://www.ovh.com/manager/).
+2. Go to **Identity and Access Management -> OAuth2 service accounts -> Create**.
+3. Grant the service account the following scopes:
+    - **Cloud**: `GET/POST/PUT/DELETE /cloud/project/<your-project-id>/*` (compute, networking, volumes, flavors).
+    - **Domain** (only if using OVH as a DNS provider for load balancers): `GET/POST/PUT/DELETE /domain/zone/<your-zone>/*`.
+4. Save the generated `client_id` and `client_secret`. The secret is shown only once.
+5. Look up your Public Cloud **project ID** in the OVHcloud Manager under **Public Cloud -> Project Management**. This is the `servicename` field in the Claudie Secret.
+
+The `endpoint` field selects which OVHcloud API region to authenticate against (not the public-cloud region for instances). Valid values: `ovh-eu` (default), `ovh-us`, `ovh-ca`, `kimsufi-eu`, `kimsufi-ca`, `soyoustart-eu`, `soyoustart-ca`. Most users in Europe leave this empty.
+
+## Available regions and flavors
+
+Public Cloud regions are listed at <https://www.ovhcloud.com/en/about-us/global-infrastructure/regions/>. Common region codes:
+
+| Country | Region codes |
+|---------|--------------|
+| France | `GRA7`, `GRA9`, `GRA11`, `SBG5`, `RBX-A`, `RBX-B`, `PAR` |
+| Germany | `DE1` |
+| UK | `UK1` |
+| Poland | `WAW1` |
+| Italy | `MIL` |
+| Canada | `BHS5`, `YYZ` |
+| Singapore | `SGP1` |
+| Australia | `SYD1`, `SYD2` |
+| US | `US-EAST-VA-1`, `US-WEST-OR-1` |
+
+Flavors and images vary per region. List the live catalog for a region with the `ovhcloud` CLI or the API:
+
+```bash
+# Using ovhcloud CLI (https://github.com/ovh/ovhcloud-cli)
+ovhcloud cloud project flavor list --service-name <project-id> --region GRA11
+ovhcloud cloud project image list  --service-name <project-id> --region GRA11
+
+# Or directly via the API (substitute your credentials)
+curl -sS "https://eu.api.ovh.com/v1/cloud/project/<project-id>/flavor?region=GRA11" \
+  -H "X-Ovh-Application: <app-key>" \
+  -H "X-Ovh-Consumer: <consumer-key>" | jq
+```
+
+Common flavor families:
+
+| Family | Use case |
+|--------|----------|
+| `b3-*`, `b3-*-flex` | General-purpose balanced compute |
+| `c3-*` | CPU-optimised |
+| `r3-*` | RAM-optimised |
+| `d2-*` | Discovery (cheap, low spec) |
+| `i2-*` | Storage-optimised (NVMe) |
+| `t1-*`, `t2-*`, `t3-*` | GPU (NVIDIA) |
+
+## GPU instances
+
+OVH GPU flavors are surfaced through the same flavor list but the API does not expose per-flavor GPU counts. To advertise GPU resources to the Kubernetes cluster autoscaler, set `machineSpec.nvidiaGpuCount` (and optionally `nvidiaGpuType`) in the nodepool spec:
+
+```yaml
+- name: gpu-ovh
+  providerSpec:
+    name: ovh-1
+    region: GRA11
+  count: 1
+  serverType: t1-le-2
+  image: "Ubuntu 24.04"
+  machineSpec:
+    nvidiaGpuCount: 1
+```
+
+The flavor name and image must support GPUs in the chosen region; verify with `ovhcloud cloud project flavor list` before applying.
+
+## Custom SSH port
+
+Like all Claudie-managed nodes, OVH VMs listen for SSH on **port 22522**. The cloud-init script reconfigures `sshd_config` and the `ssh.socket` listener during node provisioning. Inbound 22522/tcp is opened by the iptables firewall script.
+
+## Block storage
+
+Setting `storageDiskSize` on a compute nodepool provisions an `ovh_cloud_project_volume` (type `classic`) per worker and attaches it via `ovh_cloud_project_volume_attached`. The cloud-init script waits for the volume to appear under `/dev/disk/by-id/virtio-<first-20-chars-of-uuid>`, formats it as XFS, and mounts it at `/opt/claudie/data` for Longhorn.
+
+## Input manifest examples
+
+### Create a Secret for the OVH provider
+
+```bash
+kubectl create secret generic ovh-secret-1 \
+  --namespace=<your-namespace> \
+  --from-literal=clientid='<your-client-id>' \
+  --from-literal=clientsecret='<your-client-secret>' \
+  --from-literal=servicename='<your-public-cloud-project-id>'
+# Optionally add: --from-literal=endpoint='ovh-eu'
+```
+
+### Single-provider, single-region cluster
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: ovh-example-manifest
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: ovh-1
+      providerType: ovh
+      templates:
+        repository: "https://github.com/berops/claudie-config"
+        tag: v0.12.0
+        path: "templates/terraformer/ovh"
+      secretRef:
+        name: ovh-secret-1
+        namespace: <your-namespace>
+
+  nodePools:
+    dynamic:
+      - name: control-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+
+      - name: compute-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 2
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+        storageDiskSize: 50
+
+  kubernetes:
+    clusters:
+      - name: ovh-cluster
+        version: "1.34.0"
+        network: 192.168.2.0/24
+        pools:
+          control:
+            - control-ovh
+          compute:
+            - compute-ovh
+```
+
+### GPU compute pool
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: ovh-gpu-manifest
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: ovh-1
+      providerType: ovh
+      templates:
+        repository: "https://github.com/berops/claudie-config"
+        tag: v0.12.0
+        path: "templates/terraformer/ovh"
+      secretRef:
+        name: ovh-secret-1
+        namespace: <your-namespace>
+
+  nodePools:
+    dynamic:
+      - name: control-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+
+      - name: gpu-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: t1-le-2
+        image: "Ubuntu 24.04"
+        machineSpec:
+          nvidiaGpuCount: 1
+        storageDiskSize: 100
+
+  kubernetes:
+    clusters:
+      - name: ovh-gpu-cluster
+        version: "1.34.0"
+        network: 192.168.2.0/24
+        pools:
+          control:
+            - control-ovh
+          compute:
+            - gpu-ovh
+```
+
+### Cluster with load balancer using OVH DNS
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: ovh-lb-manifest
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: ovh-1
+      providerType: ovh
+      templates:
+        repository: "https://github.com/berops/claudie-config"
+        tag: v0.12.0
+        path: "templates/terraformer/ovh"
+      secretRef:
+        name: ovh-secret-1
+        namespace: <your-namespace>
+
+  nodePools:
+    dynamic:
+      - name: control-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+
+      - name: compute-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 2
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+        storageDiskSize: 50
+
+      - name: lb-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+
+  kubernetes:
+    clusters:
+      - name: ovh-cluster
+        version: "1.34.0"
+        network: 192.168.2.0/24
+        pools:
+          control:
+            - control-ovh
+          compute:
+            - compute-ovh
+
+  loadBalancers:
+    roles:
+      - name: ingress
+        protocol: tcp
+        port: 80
+        targetPort: 30080
+        targetPools:
+          - compute-ovh
+    clusters:
+      - name: ovh-lb
+        roles:
+          - ingress
+        dns:
+          dnsZone: example.com
+          provider: ovh-1
+        targetedK8s: ovh-cluster
+        pools:
+          - lb-ovh
+```
+
+### Autoscaling compute pool
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: ovh-autoscale-manifest
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: ovh-1
+      providerType: ovh
+      templates:
+        repository: "https://github.com/berops/claudie-config"
+        tag: v0.12.0
+        path: "templates/terraformer/ovh"
+      secretRef:
+        name: ovh-secret-1
+        namespace: <your-namespace>
+
+  nodePools:
+    dynamic:
+      - name: control-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        count: 1
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+
+      - name: compute-ovh
+        providerSpec:
+          name: ovh-1
+          region: GRA11
+        autoscaler:
+          min: 1
+          max: 3
+        serverType: b3-8
+        image: "Ubuntu 24.04"
+        storageDiskSize: 50
+
+  kubernetes:
+    clusters:
+      - name: ovh-cluster
+        version: "1.34.0"
+        network: 192.168.2.0/24
+        pools:
+          control:
+            - control-ovh
+          compute:
+            - compute-ovh
+```

--- a/docs/input-manifest/providers/ovh.md
+++ b/docs/input-manifest/providers/ovh.md
@@ -24,33 +24,15 @@ type: Opaque
 
 ## Create OVH API credentials
 
-Claudie uses the OAuth2 client-credentials grant supported by both the `ovh/ovh` OpenTofu provider and the official `github.com/ovh/go-ovh` Go client.
+Claudie uses the OAuth2 client-credentials grant. Follow the [OVH provider OAuth2 setup guide](https://search.opentofu.org/provider/ovh/ovh/latest#oauth2) to create a service account and obtain the `client_id` and `client_secret`. Scope the service account for your Public Cloud project, and for your DNS zone if you plan to use OVH as a DNS provider for load balancers.
 
-1. Sign in to the [OVHcloud Control Panel](https://www.ovh.com/manager/).
-2. Go to **Identity and Access Management -> OAuth2 service accounts -> Create**.
-3. Grant the service account the following scopes:
-    - **Cloud**: `GET/POST/PUT/DELETE /cloud/project/<your-project-id>/*` (compute, networking, volumes, flavors).
-    - **Domain** (only if using OVH as a DNS provider for load balancers): `GET/POST/PUT/DELETE /domain/zone/<your-zone>/*`.
-4. Save the generated `client_id` and `client_secret`. The secret is shown only once.
-5. Look up your Public Cloud **project ID** in the OVHcloud Manager under **Public Cloud -> Project Management**. This is the `servicename` field in the Claudie Secret.
+The Public Cloud **project ID** (the `servicename` field in the Claudie Secret) is in the OVHcloud Manager under **Public Cloud -> Project Management**.
 
-The `endpoint` field selects which OVHcloud API region to authenticate against (not the public-cloud region for instances). Valid values: `ovh-eu` (default), `ovh-us`, `ovh-ca`, `kimsufi-eu`, `kimsufi-ca`, `soyoustart-eu`, `soyoustart-ca`. Most users in Europe leave this empty.
+The `endpoint` field selects which OVHcloud API region to authenticate against (not the public-cloud region for instances). Valid values: `ovh-eu` (default), `ovh-us`, `ovh-ca`, `kimsufi-eu`, `kimsufi-ca`, `soyoustart-eu`, `soyoustart-ca`.
 
 ## Available regions and flavors
 
-Public Cloud regions are listed at <https://www.ovhcloud.com/en/about-us/global-infrastructure/regions/>. Common region codes:
-
-| Country | Region codes |
-|---------|--------------|
-| France | `GRA7`, `GRA9`, `GRA11`, `SBG5`, `RBX-A`, `RBX-B`, `PAR` |
-| Germany | `DE1` |
-| UK | `UK1` |
-| Poland | `WAW1` |
-| Italy | `MIL` |
-| Canada | `BHS5`, `YYZ` |
-| Singapore | `SGP1` |
-| Australia | `SYD1`, `SYD2` |
-| US | `US-EAST-VA-1`, `US-WEST-OR-1` |
+Public Cloud regions are listed at <https://www.ovhcloud.com/en/about-us/global-infrastructure/regions/>.
 
 Flavors and images vary per region. List the live catalog for a region with the `ovhcloud` CLI or the API:
 
@@ -78,7 +60,7 @@ Common flavor families:
 
 ## GPU instances
 
-OVH GPU flavors are surfaced through the same flavor list but the API does not expose per-flavor GPU counts. To advertise GPU resources to the Kubernetes cluster autoscaler, set `machineSpec.nvidiaGpuCount` (and optionally `nvidiaGpuType`) in the nodepool spec:
+OVH GPU flavors are listed via the same flavor API as non-GPU flavors. A static GPU nodepool needs only `serverType` set to a GPU flavor UUID (e.g. `t2-45`, `t1-le-2`):
 
 ```yaml
 - name: gpu-ovh
@@ -88,11 +70,13 @@ OVH GPU flavors are surfaced through the same flavor list but the API does not e
   count: 1
   serverType: t1-le-2
   image: "Ubuntu 24.04"
-  machineSpec:
-    nvidiaGpuCount: 1
 ```
 
-The flavor name and image must support GPUs in the chosen region; verify with `ovhcloud cloud project flavor list` before applying.
+For an **autoscaled** GPU nodepool (`autoscaler.min: 0`), also set `machineSpec.nvidiaGpuCount` so the cluster-autoscaler can size the node when scaling from zero. The OVH flavor API does not expose per-flavor GPU counts; without this field the autoscaler assumes zero GPUs and will not scale up to satisfy GPU-requesting pods.
+
+After the cluster is built, install the NVIDIA GPU operator separately (Claudie does not deploy it). The operator brings up drivers, the container toolkit, and the device plugin so `nvidia.com/gpu` becomes allocatable on the node.
+
+Verify GPU availability in the chosen region with `ovhcloud cloud project flavor list` before applying.
 
 ## Custom SSH port
 
@@ -130,7 +114,7 @@ spec:
       providerType: ovh
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.12.0
+        tag: v0.11.2
         path: "templates/terraformer/ovh"
       secretRef:
         name: ovh-secret-1
@@ -181,7 +165,7 @@ spec:
       providerType: ovh
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.12.0
+        tag: v0.11.2
         path: "templates/terraformer/ovh"
       secretRef:
         name: ovh-secret-1
@@ -204,8 +188,6 @@ spec:
         count: 1
         serverType: t1-le-2
         image: "Ubuntu 24.04"
-        machineSpec:
-          nvidiaGpuCount: 1
 
   kubernetes:
     clusters:
@@ -234,7 +216,7 @@ spec:
       providerType: ovh
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.12.0
+        tag: v0.11.2
         path: "templates/terraformer/ovh"
       secretRef:
         name: ovh-secret-1
@@ -312,7 +294,7 @@ spec:
       providerType: ovh
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.12.0
+        tag: v0.11.2
         path: "templates/terraformer/ovh"
       secretRef:
         name: ovh-secret-1

--- a/docs/input-manifest/providers/ovh.md
+++ b/docs/input-manifest/providers/ovh.md
@@ -100,7 +100,7 @@ Like all Claudie-managed nodes, OVH VMs listen for SSH on **port 22522**. The cl
 
 ## Block storage
 
-Setting `storageDiskSize` on a compute nodepool provisions an `ovh_cloud_project_volume` (type `classic`) per worker and attaches it via `ovh_cloud_project_volume_attached`. The cloud-init script waits for the volume to appear under `/dev/disk/by-id/virtio-<first-20-chars-of-uuid>`, formats it as XFS, and mounts it at `/opt/claudie/data` for Longhorn.
+`storageDiskSize` is currently a no-op for OVH nodepools: data (including Longhorn's `/opt/claudie/data`) lives on the OS disk. OVH Public Cloud supports block volumes, but the upstream [`ovh/ovh` Terraform provider](https://registry.terraform.io/providers/ovh/ovh) exposes only `ovh_cloud_project_volume` (create) and offers no resource to attach an existing volume to an instance, so Claudie cannot wire it through declaratively. Support will be added once the provider gains a `volume_attach`-style resource. Until then, attach extra volumes manually via the OVHcloud Manager if you need additional capacity.
 
 ## Input manifest examples
 
@@ -153,7 +153,6 @@ spec:
         count: 2
         serverType: b3-8
         image: "Ubuntu 24.04"
-        storageDiskSize: 50
 
   kubernetes:
     clusters:
@@ -207,7 +206,6 @@ spec:
         image: "Ubuntu 24.04"
         machineSpec:
           nvidiaGpuCount: 1
-        storageDiskSize: 100
 
   kubernetes:
     clusters:
@@ -259,7 +257,6 @@ spec:
         count: 2
         serverType: b3-8
         image: "Ubuntu 24.04"
-        storageDiskSize: 50
 
       - name: lb-ovh
         providerSpec:
@@ -340,7 +337,6 @@ spec:
           max: 3
         serverType: b3-8
         image: "Ubuntu 24.04"
-        storageDiskSize: 50
 
   kubernetes:
     clusters:

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6u
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/oracle/oci-go-sdk/v65 v65.114.2 h1:7ROvpCkL5v63HTHKGajlL+++zqz3+jAflfJt4wLE+J8=
 github.com/oracle/oci-go-sdk/v65 v65.114.2/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
+github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
+github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/internal/api/crd/inputmanifest/v1beta1/inputmanifest_types.go
+++ b/internal/api/crd/inputmanifest/v1beta1/inputmanifest_types.go
@@ -37,6 +37,7 @@ const (
 	EXOSCALE   ProviderType = "exoscale"
 	CLOUDRIFT  ProviderType = "cloudrift"
 	VERDA      ProviderType = "verda"
+	OVH        ProviderType = "ovh"
 )
 
 type SecretField string
@@ -72,6 +73,10 @@ const (
 	VERDA_CLIENT_ID                  SecretField = "clientid"
 	VERDA_CLIENT_SECRET              SecretField = "clientsecret"
 	VERDA_BASE_URL                   SecretField = "baseurl"
+	OVH_CLIENT_ID                    SecretField = "clientid"
+	OVH_CLIENT_SECRET                SecretField = "clientsecret"
+	OVH_SERVICE_NAME                 SecretField = "servicename"
+	OVH_ENDPOINT                     SecretField = "endpoint"
 )
 
 // ProviderWithData helper type that assist in conversion
@@ -96,7 +101,7 @@ type Provider struct {
 	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:MinLength=1
 	ProviderName string `json:"name"`
-	// +kubebuilder:validation:Enum=gcp;hetzner;aws;oci;azure;cloudflare;openstack;exoscale;cloudrift;verda;
+	// +kubebuilder:validation:Enum=gcp;hetzner;aws;oci;azure;cloudflare;openstack;exoscale;cloudrift;verda;ovh;
 	ProviderType ProviderType           `json:"providerType"`
 	SecretRef    corev1.SecretReference `json:"secretRef"`
 	// External templates for building the cluster infrastructure.

--- a/internal/api/manifest/manifest.go
+++ b/internal/api/manifest/manifest.go
@@ -30,6 +30,7 @@ type Provider struct {
 	Exoscale   []Exoscale   `yaml:"exoscale"`
 	CloudRift  []CloudRift  `yaml:"cloudrift"`
 	Verda      []Verda      `yaml:"verda"`
+	OVH        []OVH        `yaml:"ovh"`
 }
 
 type Cloudflare struct {
@@ -114,6 +115,15 @@ type Verda struct {
 	ClientId     string              `validate:"required" yaml:"clientId"`
 	ClientSecret string              `validate:"required" yaml:"clientSecret"`
 	BaseUrl      string              `validate:"omitempty,url" yaml:"baseUrl"`
+	Templates    *TemplateRepository `validate:"omitempty" yaml:"templates" json:"templates"`
+}
+
+type OVH struct {
+	Name         string              `validate:"required,max=15" yaml:"name"`
+	ClientId     string              `validate:"required" yaml:"clientId"`
+	ClientSecret string              `validate:"required" yaml:"clientSecret"`
+	ServiceName  string              `validate:"required" yaml:"serviceName"`
+	Endpoint     string              `validate:"omitempty" yaml:"endpoint"`
 	Templates    *TemplateRepository `validate:"omitempty" yaml:"templates" json:"templates"`
 }
 

--- a/internal/api/manifest/utils.go
+++ b/internal/api/manifest/utils.go
@@ -286,6 +286,35 @@ func (ds *Manifest) GetProvider(providerSpecName string) (*spec.Provider, error)
 		}
 	}
 
+	for _, oConf := range ds.Providers.OVH {
+		if oConf.Name == providerSpecName {
+			t := &spec.TemplateRepository{
+				Repository: oConf.Templates.Repository,
+				Tag:        oConf.Templates.Tag,
+				Path:       oConf.Templates.Path,
+			}
+			if err := FetchCommitHash(t); err != nil {
+				return nil, err
+			}
+			o := &spec.OVHProvider{
+				ClientId:     oConf.ClientId,
+				ClientSecret: oConf.ClientSecret,
+				ServiceName:  oConf.ServiceName,
+			}
+			if oConf.Endpoint != "" {
+				o.Endpoint = &oConf.Endpoint
+			}
+			return &spec.Provider{
+				SpecName: providerSpecName,
+				ProviderType: &spec.Provider_Ovh{
+					Ovh: o,
+				},
+				CloudProviderName: "ovh",
+				Templates:         t,
+			}, nil
+		}
+	}
+
 	return nil, fmt.Errorf("failed to find provider with name: %s", providerSpecName)
 }
 
@@ -625,6 +654,11 @@ func (ds *Manifest) ForEachProvider(do func(name, typ string, tmpls **TemplateRe
 	}
 	for i, c := range ds.Providers.Verda {
 		if !do(c.Name, "verda", &ds.Providers.Verda[i].Templates) {
+			return
+		}
+	}
+	for i, c := range ds.Providers.OVH {
+		if !do(c.Name, "ovh", &ds.Providers.OVH[i].Templates) {
 			return
 		}
 	}

--- a/internal/api/manifest/validate.go
+++ b/internal/api/manifest/validate.go
@@ -20,7 +20,7 @@ func (m *Manifest) Validate() error {
 	providers := len(m.Providers.GCP) + len(m.Providers.Hetzner) + len(m.Providers.AWS) +
 		len(m.Providers.Azure) + len(m.Providers.OCI) + len(m.Providers.Cloudflare) +
 		len(m.Providers.Openstack) + len(m.Providers.Exoscale) + len(m.Providers.CloudRift) +
-		len(m.Providers.Verda)
+		len(m.Providers.Verda) + len(m.Providers.OVH)
 	if providers < 1 {
 		// Return error only if at least one dynamic nodepool defined.
 		if len(m.NodePools.Dynamic) > 0 {

--- a/internal/api/manifest/validate_load_balancer.go
+++ b/internal/api/manifest/validate_load_balancer.go
@@ -200,7 +200,7 @@ func (l *LoadBalancer) Validate(m *Manifest) error {
 			return fmt.Errorf("provider %q used inside cluster %q is not defined", cluster.DNS.Provider, cluster.Name)
 		}
 
-		if !slices.Contains([]string{"gcp", "aws", "azure", "oci", "cloudflare", "hetzner", "exoscale"}, providerTyp) {
+		if !slices.Contains([]string{"gcp", "aws", "azure", "oci", "cloudflare", "hetzner", "exoscale", "ovh"}, providerTyp) {
 			return fmt.Errorf("provider %q used inside cluster %q exists but is not a supported provider", cluster.DNS.Provider, cluster.Name)
 		}
 

--- a/internal/api/manifest/validate_provider.go
+++ b/internal/api/manifest/validate_provider.go
@@ -133,6 +133,17 @@ func (p *Provider) Validate() error {
 		names[c.Name] = true
 	}
 
+	for _, c := range p.OVH {
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("failed to validate provider %q: %w", c.Name, err)
+		}
+
+		if _, ok := names[c.Name]; ok {
+			return fmt.Errorf("name %q is used across multiple providers, must be unique", c.Name)
+		}
+		names[c.Name] = true
+	}
+
 	return nil
 }
 
@@ -146,6 +157,7 @@ func (c *Openstack) Validate() error  { return validateProvider(c) }
 func (c *Exoscale) Validate() error   { return validateProvider(c) }
 func (c *CloudRift) Validate() error  { return validateProvider(c) }
 func (c *Verda) Validate() error      { return validateProvider(c) }
+func (c *OVH) Validate() error        { return validateProvider(c) }
 
 func validateSemver2(fl validator.FieldLevel) bool {
 	semverString := fl.Field().String()

--- a/internal/nodes/arch_resolver.go
+++ b/internal/nodes/arch_resolver.go
@@ -93,6 +93,8 @@ func (r *DynamicNodePoolResolver) resolve(np *spec.DynamicNodePool) (Arch, error
 		return resolveCloudRift(np)
 	case "verda":
 		return resolveVerda(np)
+	case "ovh":
+		return resolveOVH(np)
 	default:
 		return "", fmt.Errorf("%q not supported", np.GetProvider().GetCloudProviderName())
 	}
@@ -116,6 +118,11 @@ func resolveCloudRift(np *spec.DynamicNodePool) (Arch, error) {
 
 func resolveVerda(np *spec.DynamicNodePool) (Arch, error) {
 	// Verda primarily offers AMD64/GPU instances.
+	return Amd64, nil
+}
+
+func resolveOVH(np *spec.DynamicNodePool) (Arch, error) {
+	// OVH Public Cloud offers both AMD64 and (rarely) ARM flavors; default to AMD64.
 	return Amd64, nil
 }
 

--- a/manifests/claudie/crd/claudie.io_inputmanifests.yaml
+++ b/manifests/claudie/crd/claudie.io_inputmanifests.yaml
@@ -389,9 +389,8 @@ spec:
                                   to a node.
                                 type: string
                               timeAdded:
-                                description: |-
-                                  TimeAdded represents the time at which the taint was added.
-                                  It is only written for NoExecute taints.
+                                description: TimeAdded represents the time at which
+                                  the taint was added.
                                 format: date-time
                                 type: string
                               value:
@@ -486,9 +485,8 @@ spec:
                                   to a node.
                                 type: string
                               timeAdded:
-                                description: |-
-                                  TimeAdded represents the time at which the taint was added.
-                                  It is only written for NoExecute taints.
+                                description: TimeAdded represents the time at which
+                                  the taint was added.
                                 format: date-time
                                 type: string
                               value:
@@ -536,6 +534,7 @@ spec:
                       - exoscale
                       - cloudrift
                       - verda
+                      - ovh
                       type: string
                     secretRef:
                       description: |-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
           - Hetzner: input-manifest/providers/hetzner.md
           - OCI: input-manifest/providers/oci.md
           - Openstack: input-manifest/providers/openstack.md
+          - OVHcloud: input-manifest/providers/ovh.md
           - Verda: input-manifest/providers/verda.md
           - On Premise: input-manifest/providers/on-prem.md
       - External templates: input-manifest/external-templates.md

--- a/proto/pb/spec/provider.pb.go
+++ b/proto/pb/spec/provider.pb.go
@@ -605,6 +605,74 @@ func (x *VerdaProvider) GetBaseUrl() string {
 	return ""
 }
 
+type OVHProvider struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClientId      string                 `protobuf:"bytes,1,opt,name=clientId,proto3" json:"clientId,omitempty"`
+	ClientSecret  string                 `protobuf:"bytes,2,opt,name=clientSecret,proto3" json:"clientSecret,omitempty"`
+	ServiceName   string                 `protobuf:"bytes,3,opt,name=serviceName,proto3" json:"serviceName,omitempty"`
+	Endpoint      *string                `protobuf:"bytes,4,opt,name=endpoint,proto3,oneof" json:"endpoint,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OVHProvider) Reset() {
+	*x = OVHProvider{}
+	mi := &file_spec_provider_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OVHProvider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OVHProvider) ProtoMessage() {}
+
+func (x *OVHProvider) ProtoReflect() protoreflect.Message {
+	mi := &file_spec_provider_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OVHProvider.ProtoReflect.Descriptor instead.
+func (*OVHProvider) Descriptor() ([]byte, []int) {
+	return file_spec_provider_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *OVHProvider) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *OVHProvider) GetClientSecret() string {
+	if x != nil {
+		return x.ClientSecret
+	}
+	return ""
+}
+
+func (x *OVHProvider) GetServiceName() string {
+	if x != nil {
+		return x.ServiceName
+	}
+	return ""
+}
+
+func (x *OVHProvider) GetEndpoint() string {
+	if x != nil && x.Endpoint != nil {
+		return *x.Endpoint
+	}
+	return ""
+}
+
 type Provider struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	SpecName          string                 `protobuf:"bytes,1,opt,name=specName,proto3" json:"specName,omitempty"`
@@ -623,6 +691,7 @@ type Provider struct {
 	//	*Provider_Exoscale
 	//	*Provider_Cloudrift
 	//	*Provider_Verda
+	//	*Provider_Ovh
 	ProviderType  isProvider_ProviderType `protobuf_oneof:"ProviderType"`
 	Templates     *TemplateRepository     `protobuf:"bytes,13,opt,name=templates,proto3" json:"templates,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -631,7 +700,7 @@ type Provider struct {
 
 func (x *Provider) Reset() {
 	*x = Provider{}
-	mi := &file_spec_provider_proto_msgTypes[10]
+	mi := &file_spec_provider_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -643,7 +712,7 @@ func (x *Provider) String() string {
 func (*Provider) ProtoMessage() {}
 
 func (x *Provider) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_provider_proto_msgTypes[10]
+	mi := &file_spec_provider_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -656,7 +725,7 @@ func (x *Provider) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Provider.ProtoReflect.Descriptor instead.
 func (*Provider) Descriptor() ([]byte, []int) {
-	return file_spec_provider_proto_rawDescGZIP(), []int{10}
+	return file_spec_provider_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Provider) GetSpecName() string {
@@ -770,6 +839,15 @@ func (x *Provider) GetVerda() *VerdaProvider {
 	return nil
 }
 
+func (x *Provider) GetOvh() *OVHProvider {
+	if x != nil {
+		if x, ok := x.ProviderType.(*Provider_Ovh); ok {
+			return x.Ovh
+		}
+	}
+	return nil
+}
+
 func (x *Provider) GetTemplates() *TemplateRepository {
 	if x != nil {
 		return x.Templates
@@ -821,6 +899,10 @@ type Provider_Verda struct {
 	Verda *VerdaProvider `protobuf:"bytes,15,opt,name=verda,proto3,oneof"`
 }
 
+type Provider_Ovh struct {
+	Ovh *OVHProvider `protobuf:"bytes,16,opt,name=ovh,proto3,oneof"`
+}
+
 func (*Provider_Gcp) isProvider_ProviderType() {}
 
 func (*Provider_Hetzner) isProvider_ProviderType() {}
@@ -841,6 +923,8 @@ func (*Provider_Cloudrift) isProvider_ProviderType() {}
 
 func (*Provider_Verda) isProvider_ProviderType() {}
 
+func (*Provider_Ovh) isProvider_ProviderType() {}
+
 type TemplateRepository struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Repository    string                 `protobuf:"bytes,1,opt,name=repository,proto3" json:"repository,omitempty"`
@@ -853,7 +937,7 @@ type TemplateRepository struct {
 
 func (x *TemplateRepository) Reset() {
 	*x = TemplateRepository{}
-	mi := &file_spec_provider_proto_msgTypes[11]
+	mi := &file_spec_provider_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -865,7 +949,7 @@ func (x *TemplateRepository) String() string {
 func (*TemplateRepository) ProtoMessage() {}
 
 func (x *TemplateRepository) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_provider_proto_msgTypes[11]
+	mi := &file_spec_provider_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -878,7 +962,7 @@ func (x *TemplateRepository) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TemplateRepository.ProtoReflect.Descriptor instead.
 func (*TemplateRepository) Descriptor() ([]byte, []int) {
-	return file_spec_provider_proto_rawDescGZIP(), []int{11}
+	return file_spec_provider_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *TemplateRepository) GetRepository() string {
@@ -956,7 +1040,13 @@ const file_spec_provider_proto_rawDesc = "" +
 	"\fclientSecret\x18\x02 \x01(\tR\fclientSecret\x12\x1d\n" +
 	"\abaseUrl\x18\x03 \x01(\tH\x00R\abaseUrl\x88\x01\x01B\n" +
 	"\n" +
-	"\b_baseUrl\"\x82\x05\n" +
+	"\b_baseUrl\"\x9d\x01\n" +
+	"\vOVHProvider\x12\x1a\n" +
+	"\bclientId\x18\x01 \x01(\tR\bclientId\x12\"\n" +
+	"\fclientSecret\x18\x02 \x01(\tR\fclientSecret\x12 \n" +
+	"\vserviceName\x18\x03 \x01(\tR\vserviceName\x12\x1f\n" +
+	"\bendpoint\x18\x04 \x01(\tH\x00R\bendpoint\x88\x01\x01B\v\n" +
+	"\t_endpoint\"\xa9\x05\n" +
 	"\bProvider\x12\x1a\n" +
 	"\bspecName\x18\x01 \x01(\tR\bspecName\x12,\n" +
 	"\x11cloudProviderName\x18\x02 \x01(\tR\x11cloudProviderName\x12%\n" +
@@ -971,7 +1061,8 @@ const file_spec_provider_proto_rawDesc = "" +
 	"\topenstack\x18\v \x01(\v2\x17.spec.OpenstackProviderH\x00R\topenstack\x124\n" +
 	"\bexoscale\x18\f \x01(\v2\x16.spec.ExoscaleProviderH\x00R\bexoscale\x127\n" +
 	"\tcloudrift\x18\x0e \x01(\v2\x17.spec.CloudRiftProviderH\x00R\tcloudrift\x12+\n" +
-	"\x05verda\x18\x0f \x01(\v2\x13.spec.VerdaProviderH\x00R\x05verda\x126\n" +
+	"\x05verda\x18\x0f \x01(\v2\x13.spec.VerdaProviderH\x00R\x05verda\x12%\n" +
+	"\x03ovh\x18\x10 \x01(\v2\x11.spec.OVHProviderH\x00R\x03ovh\x126\n" +
 	"\ttemplates\x18\r \x01(\v2\x18.spec.TemplateRepositoryR\ttemplatesB\x0e\n" +
 	"\fProviderType\"\x87\x01\n" +
 	"\x12TemplateRepository\x12\x1e\n" +
@@ -997,7 +1088,7 @@ func file_spec_provider_proto_rawDescGZIP() []byte {
 	return file_spec_provider_proto_rawDescData
 }
 
-var file_spec_provider_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_spec_provider_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_spec_provider_proto_goTypes = []any{
 	(*GCPProvider)(nil),        // 0: spec.GCPProvider
 	(*HetznerProvider)(nil),    // 1: spec.HetznerProvider
@@ -1009,8 +1100,9 @@ var file_spec_provider_proto_goTypes = []any{
 	(*ExoscaleProvider)(nil),   // 7: spec.ExoscaleProvider
 	(*CloudRiftProvider)(nil),  // 8: spec.CloudRiftProvider
 	(*VerdaProvider)(nil),      // 9: spec.VerdaProvider
-	(*Provider)(nil),           // 10: spec.Provider
-	(*TemplateRepository)(nil), // 11: spec.TemplateRepository
+	(*OVHProvider)(nil),        // 10: spec.OVHProvider
+	(*Provider)(nil),           // 11: spec.Provider
+	(*TemplateRepository)(nil), // 12: spec.TemplateRepository
 }
 var file_spec_provider_proto_depIdxs = []int32{
 	0,  // 0: spec.Provider.gcp:type_name -> spec.GCPProvider
@@ -1023,12 +1115,13 @@ var file_spec_provider_proto_depIdxs = []int32{
 	7,  // 7: spec.Provider.exoscale:type_name -> spec.ExoscaleProvider
 	8,  // 8: spec.Provider.cloudrift:type_name -> spec.CloudRiftProvider
 	9,  // 9: spec.Provider.verda:type_name -> spec.VerdaProvider
-	11, // 10: spec.Provider.templates:type_name -> spec.TemplateRepository
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	10, // 10: spec.Provider.ovh:type_name -> spec.OVHProvider
+	12, // 11: spec.Provider.templates:type_name -> spec.TemplateRepository
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_spec_provider_proto_init() }
@@ -1038,7 +1131,8 @@ func file_spec_provider_proto_init() {
 	}
 	file_spec_provider_proto_msgTypes[8].OneofWrappers = []any{}
 	file_spec_provider_proto_msgTypes[9].OneofWrappers = []any{}
-	file_spec_provider_proto_msgTypes[10].OneofWrappers = []any{
+	file_spec_provider_proto_msgTypes[10].OneofWrappers = []any{}
+	file_spec_provider_proto_msgTypes[11].OneofWrappers = []any{
 		(*Provider_Gcp)(nil),
 		(*Provider_Hetzner)(nil),
 		(*Provider_Oci)(nil),
@@ -1049,15 +1143,16 @@ func file_spec_provider_proto_init() {
 		(*Provider_Exoscale)(nil),
 		(*Provider_Cloudrift)(nil),
 		(*Provider_Verda)(nil),
+		(*Provider_Ovh)(nil),
 	}
-	file_spec_provider_proto_msgTypes[11].OneofWrappers = []any{}
+	file_spec_provider_proto_msgTypes[12].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_spec_provider_proto_rawDesc), len(file_spec_provider_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/pb/spec/utils.go
+++ b/proto/pb/spec/utils.go
@@ -89,6 +89,8 @@ func (pr *Provider) Credentials() string {
 		return p.Cloudrift.Token
 	case *Provider_Verda:
 		return p.Verda.ClientSecret
+	case *Provider_Ovh:
+		return p.Ovh.ClientSecret
 	default:
 		panic(fmt.Sprintf("unexpected type %T", pr.ProviderType))
 	}
@@ -189,6 +191,17 @@ func (pr *Provider) CopyCredentials(other *Provider) (updated bool) {
 		p.Verda.ClientId = o.Verda.ClientId
 		p.Verda.ClientSecret = o.Verda.ClientSecret
 		p.Verda.BaseUrl = o.Verda.BaseUrl
+		updated = true
+	case *Provider_Ovh:
+		o, ok := other.ProviderType.(*Provider_Ovh)
+		if !ok {
+			return
+		}
+
+		p.Ovh.ClientId = o.Ovh.ClientId
+		p.Ovh.ClientSecret = o.Ovh.ClientSecret
+		p.Ovh.ServiceName = o.Ovh.ServiceName
+		p.Ovh.Endpoint = o.Ovh.Endpoint
 		updated = true
 	default:
 		// do nothing.
@@ -294,6 +307,18 @@ func (pr *Provider) CredentialsEqual(other *Provider) (equal bool) {
 		baseURL := p.Verda.GetBaseUrl() == o.Verda.GetBaseUrl()
 
 		equal = clientID && clientSecret && baseURL
+	case *Provider_Ovh:
+		o, ok := other.ProviderType.(*Provider_Ovh)
+		if !ok {
+			return
+		}
+
+		clientID := p.Ovh.ClientId == o.Ovh.ClientId
+		clientSecret := p.Ovh.ClientSecret == o.Ovh.ClientSecret
+		serviceName := p.Ovh.ServiceName == o.Ovh.ServiceName
+		endpoint := p.Ovh.GetEndpoint() == o.Ovh.GetEndpoint()
+
+		equal = clientID && clientSecret && serviceName && endpoint
 	default:
 		// do nothing.
 	}

--- a/proto/pb/spec/utils.go
+++ b/proto/pb/spec/utils.go
@@ -200,6 +200,7 @@ func (pr *Provider) CopyCredentials(other *Provider) (updated bool) {
 
 		p.Ovh.ClientId = o.Ovh.ClientId
 		p.Ovh.ClientSecret = o.Ovh.ClientSecret
+		p.Ovh.ServiceName = o.Ovh.ServiceName
 		updated = true
 	default:
 		// do nothing.

--- a/proto/pb/spec/utils.go
+++ b/proto/pb/spec/utils.go
@@ -200,8 +200,6 @@ func (pr *Provider) CopyCredentials(other *Provider) (updated bool) {
 
 		p.Ovh.ClientId = o.Ovh.ClientId
 		p.Ovh.ClientSecret = o.Ovh.ClientSecret
-		p.Ovh.ServiceName = o.Ovh.ServiceName
-		p.Ovh.Endpoint = o.Ovh.Endpoint
 		updated = true
 	default:
 		// do nothing.
@@ -316,9 +314,8 @@ func (pr *Provider) CredentialsEqual(other *Provider) (equal bool) {
 		clientID := p.Ovh.ClientId == o.Ovh.ClientId
 		clientSecret := p.Ovh.ClientSecret == o.Ovh.ClientSecret
 		serviceName := p.Ovh.ServiceName == o.Ovh.ServiceName
-		endpoint := p.Ovh.GetEndpoint() == o.Ovh.GetEndpoint()
 
-		equal = clientID && clientSecret && serviceName && endpoint
+		equal = clientID && clientSecret && serviceName
 	default:
 		// do nothing.
 	}

--- a/proto/spec/provider.proto
+++ b/proto/spec/provider.proto
@@ -61,6 +61,13 @@ message VerdaProvider {
   optional string baseUrl = 3;
 }
 
+message OVHProvider {
+  string clientId = 1;
+  string clientSecret = 2;
+  string serviceName = 3;
+  optional string endpoint = 4;
+}
+
 message Provider {
   string specName = 1;
   string cloudProviderName = 2;
@@ -77,6 +84,7 @@ message Provider {
     ExoscaleProvider exoscale = 12;
     CloudRiftProvider cloudrift = 14;
     VerdaProvider verda = 15;
+    OVHProvider ovh = 16;
   }
 
   TemplateRepository templates = 13;

--- a/services/autoscaler-adapter/node_manager/cache.go
+++ b/services/autoscaler-adapter/node_manager/cache.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/ovh/go-ovh/ovh"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/oauth2/google"
@@ -46,6 +47,8 @@ const (
 	verdaTokenPath      = "/oauth2/token"
 	verdaScope          = "cloud-api-v1"
 	verdaRequestTimeout = 30 * time.Second
+
+	ovhDefaultEndpoint = "ovh-eu"
 )
 
 // cacheHetzner function uses hcloud-go module to query supported servers and their info. If the query is successful, the server info is saved in cache.
@@ -327,5 +330,27 @@ func (nm *NodeManager) cacheVerda(np *spec.DynamicNodePool) error {
 	}
 
 	nm.verdaVMs = getTypeInfoVerda(result)
+	return nil
+}
+
+func (nm *NodeManager) cacheOVH(np *spec.DynamicNodePool) error {
+	o := np.Provider.GetOvh()
+	endpoint := ovhDefaultEndpoint
+	if o.GetEndpoint() != "" {
+		endpoint = o.GetEndpoint()
+	}
+
+	client, err := ovh.NewOAuth2Client(endpoint, o.GetClientId(), o.GetClientSecret())
+	if err != nil {
+		return fmt.Errorf("ovh client error: %w", err)
+	}
+
+	var flavors []ovhFlavor
+	path := fmt.Sprintf("/cloud/project/%s/flavor?region=%s", o.GetServiceName(), np.Region)
+	if err := client.Get(path, &flavors); err != nil {
+		return fmt.Errorf("ovh client error: %w", err)
+	}
+
+	nm.ovhVMs = getTypeInfoOVH(flavors)
 	return nil
 }

--- a/services/autoscaler-adapter/node_manager/cache.go
+++ b/services/autoscaler-adapter/node_manager/cache.go
@@ -349,6 +349,6 @@ func (nm *NodeManager) cacheOVH(np *spec.DynamicNodePool) error {
 		return fmt.Errorf("ovh flavor list error: %w", err)
 	}
 
-	nm.ovhVMs = getTypeInfoOVH(flavors)
+	nm.ovhVMs = generics.MergeMaps(getTypeInfoOVH(flavors), nm.ovhVMs)
 	return nil
 }

--- a/services/autoscaler-adapter/node_manager/cache.go
+++ b/services/autoscaler-adapter/node_manager/cache.go
@@ -1,6 +1,7 @@
 package node_manager
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -335,10 +336,7 @@ func (nm *NodeManager) cacheVerda(np *spec.DynamicNodePool) error {
 
 func (nm *NodeManager) cacheOVH(np *spec.DynamicNodePool) error {
 	o := np.Provider.GetOvh()
-	endpoint := ovhDefaultEndpoint
-	if o.GetEndpoint() != "" {
-		endpoint = o.GetEndpoint()
-	}
+	endpoint := cmp.Or(o.GetEndpoint(), ovhDefaultEndpoint)
 
 	client, err := ovh.NewOAuth2Client(endpoint, o.GetClientId(), o.GetClientSecret())
 	if err != nil {
@@ -348,7 +346,7 @@ func (nm *NodeManager) cacheOVH(np *spec.DynamicNodePool) error {
 	var flavors []ovhFlavor
 	path := fmt.Sprintf("/cloud/project/%s/flavor?region=%s", o.GetServiceName(), np.Region)
 	if err := client.Get(path, &flavors); err != nil {
-		return fmt.Errorf("ovh client error: %w", err)
+		return fmt.Errorf("ovh flavor list error: %w", err)
 	}
 
 	nm.ovhVMs = getTypeInfoOVH(flavors)

--- a/services/autoscaler-adapter/node_manager/node_manager.go
+++ b/services/autoscaler-adapter/node_manager/node_manager.go
@@ -42,6 +42,7 @@ type NodeManager struct {
 	exoscaleVMs  map[string]*InstanceInfo
 	cloudriftVMs map[string]*InstanceInfo
 	verdaVMs     map[string]*InstanceInfo
+	ovhVMs       map[string]*InstanceInfo
 
 	// Provider-region-zone cache
 	cacheProviderMap map[string]struct{}
@@ -103,6 +104,10 @@ func (nm *NodeManager) Refresh(autoscaled []*spec.NodePool) error {
 				}
 			case "verda":
 				if err := nm.cacheVerda(dyn); err != nil {
+					return err
+				}
+			case "ovh":
+				if err := nm.cacheOVH(dyn); err != nil {
 					return err
 				}
 			}
@@ -190,6 +195,10 @@ func (nm *NodeManager) InstanceInfo(np *spec.DynamicNodePool) *InstanceInfo {
 		}
 	case "verda":
 		if ti, ok := nm.verdaVMs[np.ServerType]; ok {
+			return ti
+		}
+	case "ovh":
+		if ti, ok := nm.ovhVMs[np.ServerType]; ok {
 			return ti
 		}
 	}

--- a/services/autoscaler-adapter/node_manager/type_info.go
+++ b/services/autoscaler-adapter/node_manager/type_info.go
@@ -228,3 +228,27 @@ func getTypeInfoVerda(instanceTypes []verdaInstanceType) map[string]*InstanceInf
 	}
 	return m
 }
+
+// OVH flavor API response (GET /cloud/project/{serviceName}/flavor).
+// RAM is in MB, disk is in GB. GPU counts are not exposed by this endpoint;
+// users with GPU flavors set MachineSpec.NvidiaGpuCount in the InputManifest,
+// which GetCapacity() then overrides on top of this cache.
+type ovhFlavor struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+	RAM    int64  `json:"ram"`
+	VCPUs  int    `json:"vcpus"`
+	Disk   int64  `json:"disk"`
+}
+
+func getTypeInfoOVH(flavors []ovhFlavor) map[string]*InstanceInfo {
+	m := make(map[string]*InstanceInfo)
+	for _, f := range flavors {
+		m[f.Name] = &InstanceInfo{
+			cpu:    int64(f.VCPUs),
+			memory: f.RAM * 1024 * 1024,
+			disk:   f.Disk * gib,
+		}
+	}
+	return m
+}

--- a/services/autoscaler-adapter/node_manager/type_info.go
+++ b/services/autoscaler-adapter/node_manager/type_info.go
@@ -234,6 +234,7 @@ func getTypeInfoVerda(instanceTypes []verdaInstanceType) map[string]*InstanceInf
 // users with GPU flavors set MachineSpec.NvidiaGpuCount in the InputManifest,
 // which GetCapacity() then overrides on top of this cache.
 type ovhFlavor struct {
+	ID     string `json:"id"`
 	Name   string `json:"name"`
 	Region string `json:"region"`
 	RAM    int64  `json:"ram"`
@@ -241,10 +242,15 @@ type ovhFlavor struct {
 	Disk   int64  `json:"disk"`
 }
 
+// getTypeInfoOVH builds the InstanceInfo lookup map keyed by flavor UUID,
+// because the OVH terraform provider's `flavor.flavor_id` field accepts
+// only UUIDs and Claudie's InputManifest carries that UUID through as
+// `np.ServerType`. The flavor `name` (e.g. b3-8, t2-45) is informational
+// only and not used as a lookup key.
 func getTypeInfoOVH(flavors []ovhFlavor) map[string]*InstanceInfo {
 	m := make(map[string]*InstanceInfo)
 	for _, f := range flavors {
-		m[f.Name] = &InstanceInfo{
+		m[f.ID] = &InstanceInfo{
 			cpu:    int64(f.VCPUs),
 			memory: f.RAM * 1024 * 1024,
 			disk:   f.Disk * gib,

--- a/services/autoscaler-adapter/node_manager/type_info.go
+++ b/services/autoscaler-adapter/node_manager/type_info.go
@@ -229,24 +229,20 @@ func getTypeInfoVerda(instanceTypes []verdaInstanceType) map[string]*InstanceInf
 	return m
 }
 
-// OVH flavor API response (GET /cloud/project/{serviceName}/flavor).
-// RAM is in MB, disk is in GB. GPU counts are not exposed by this endpoint;
-// users with GPU flavors set MachineSpec.NvidiaGpuCount in the InputManifest,
-// which GetCapacity() then overrides on top of this cache.
+// ovhFlavor is the subset of GET /cloud/project/{serviceName}/flavor used
+// for autoscaler capacity estimation. GPU count is not exposed by this
+// endpoint; users with GPU flavors set MachineSpec.NvidiaGpuCount in the
+// InputManifest, which GetCapacity() then overrides on top of this cache.
 type ovhFlavor struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Region string `json:"region"`
-	RAM    int64  `json:"ram"`
-	VCPUs  int    `json:"vcpus"`
-	Disk   int64  `json:"disk"`
+	ID    string `json:"id"`
+	RAM   int64  `json:"ram"`
+	VCPUs int    `json:"vcpus"`
+	Disk  int64  `json:"disk"`
 }
 
-// getTypeInfoOVH builds the InstanceInfo lookup map keyed by flavor UUID,
-// because the OVH terraform provider's `flavor.flavor_id` field accepts
-// only UUIDs and Claudie's InputManifest carries that UUID through as
-// `np.ServerType`. The flavor `name` (e.g. b3-8, t2-45) is informational
-// only and not used as a lookup key.
+// getTypeInfoOVH keys the lookup by flavor UUID because the OVH terraform
+// provider's `flavor.flavor_id` field accepts only UUIDs, and Claudie
+// carries that UUID through as np.ServerType.
 func getTypeInfoOVH(flavors []ovhFlavor) map[string]*InstanceInfo {
 	m := make(map[string]*InstanceInfo)
 	for _, f := range flavors {

--- a/services/claudie-operator/pkg/controller/controler_helpers.go
+++ b/services/claudie-operator/pkg/controller/controler_helpers.go
@@ -252,7 +252,6 @@ func constructInputManifest(
 			if err != nil {
 				return manifest.Manifest{}, buildSecretError(secretNamespaceName, err)
 			}
-			// endpoint is optional, default in OpenTofu provider is ovh-eu.
 			oEndpoint, _ := p.GetSecretField(v1beta1manifest.OVH_ENDPOINT)
 
 			providers.OVH = append(providers.OVH, manifest.OVH{

--- a/services/claudie-operator/pkg/controller/controler_helpers.go
+++ b/services/claudie-operator/pkg/controller/controler_helpers.go
@@ -239,6 +239,30 @@ func constructInputManifest(
 				BaseUrl:      strings.TrimSpace(vBaseUrl),
 				Templates:    p.Templates,
 			})
+		case v1beta1manifest.OVH:
+			oClientId, err := p.GetSecretField(v1beta1manifest.OVH_CLIENT_ID)
+			if err != nil {
+				return manifest.Manifest{}, buildSecretError(secretNamespaceName, err)
+			}
+			oClientSecret, err := p.GetSecretField(v1beta1manifest.OVH_CLIENT_SECRET)
+			if err != nil {
+				return manifest.Manifest{}, buildSecretError(secretNamespaceName, err)
+			}
+			oServiceName, err := p.GetSecretField(v1beta1manifest.OVH_SERVICE_NAME)
+			if err != nil {
+				return manifest.Manifest{}, buildSecretError(secretNamespaceName, err)
+			}
+			// endpoint is optional, default in OpenTofu provider is ovh-eu.
+			oEndpoint, _ := p.GetSecretField(v1beta1manifest.OVH_ENDPOINT)
+
+			providers.OVH = append(providers.OVH, manifest.OVH{
+				Name:         p.ProviderName,
+				ClientId:     strings.TrimSpace(oClientId),
+				ClientSecret: strings.TrimSpace(oClientSecret),
+				ServiceName:  strings.TrimSpace(oServiceName),
+				Endpoint:     strings.TrimSpace(oEndpoint),
+				Templates:    p.Templates,
+			})
 		}
 	}
 

--- a/services/claudie-operator/pkg/controller/validator.go
+++ b/services/claudie-operator/pkg/controller/validator.go
@@ -119,6 +119,8 @@ func validateInputManifest(im *v1beta.InputManifest) error {
 			rawManifest.Providers.CloudRift = append(rawManifest.Providers.CloudRift, manifest.CloudRift{Name: p.ProviderName})
 		case v1beta.VERDA:
 			rawManifest.Providers.Verda = append(rawManifest.Providers.Verda, manifest.Verda{Name: p.ProviderName})
+		case v1beta.OVH:
+			rawManifest.Providers.OVH = append(rawManifest.Providers.OVH, manifest.OVH{Name: p.ProviderName})
 		}
 	}
 

--- a/services/terraformer/internal/worker/service/internal/templates/provider.go
+++ b/services/terraformer/internal/worker/service/internal/templates/provider.go
@@ -30,6 +30,7 @@ type usedProvidersTemplateData struct {
 	Exoscale   bool
 	CloudRift  bool
 	Verda      bool
+	OVH        bool
 }
 
 // CreateUsedProviderDNS creates provider file used for DNS management.
@@ -100,6 +101,9 @@ func getProvidersUsed(nodepools []*spec.DynamicNodePool, data *usedProvidersTemp
 		if nodepool.Provider.CloudProviderName == "verda" {
 			data.Verda = true
 		}
+		if nodepool.Provider.CloudProviderName == "ovh" {
+			data.OVH = true
+		}
 	}
 }
 
@@ -124,5 +128,7 @@ func getDNSProvider(dns *spec.DNS, data *usedProvidersTemplateData) {
 		data.Cloudflare = true
 	case "exoscale":
 		data.Exoscale = true
+	case "ovh":
+		data.OVH = true
 	}
 }

--- a/services/terraformer/internal/worker/service/internal/templates/providers.tpl
+++ b/services/terraformer/internal/worker/service/internal/templates/providers.tpl
@@ -73,5 +73,11 @@ terraform {
       version = "~> 0.11"
     }
     {{- end }}
+    {{- if .OVH }}
+    ovh = {
+      source  = "ovh/ovh"
+      version = "~> 2.13"
+    }
+    {{- end }}
   }
 }


### PR DESCRIPTION
Adds OVH Public Cloud as a Claudie provider.

Authentication is OAuth2 client-credentials via the native ovh/ovh OpenTofu provider. Covers compute, DNS, and the autoscaler-adapter.

Validated end-to-end on real cloud: single-region (BHS5), multi-region (BHS5 + GRA9, WireGuard cross-region mesh), GPU (t2-45 / V100S), autoscaling (0 to 2 to 1), LB plus DNS, and multi-cloud with Hetzner.

Requires the matching templates from berops/claudie-config (linked PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OVHcloud as a supported cloud provider with full configuration and credential management.
  * Enabled OVHcloud GPU instance support for autoscaled GPU nodepools.
  * OVHcloud now supported as a DNS provider for load balancers.

* **Documentation**
  * New comprehensive OVHcloud provider guide covering setup, regions, and operational details.
  * Updated API reference with OVHcloud configuration requirements and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie/pull/2116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->