### PR TITLE
chore: adjust retries to fail faster

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -17,6 +17,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// NoRetries indicates no retries should be performed when passed to the [Kubectl.MaxKubectlRetries] value.
+const NoRetries = -1
+
 // Kubeconfig - the kubeconfig of the cluster as a string
 // when left empty, kuber uses default kubeconfig,
 // MaxKubectlRetries when unset/set=0 will use defaultMaxKubectlRetries = 10

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/manager
-  newTag: 8260975-4236
+  newTag: cd82725-4239
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 8260975-4236
+  newTag: cd82725-4239

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 8260975-4236
+  newTag: cd82725-4239

--- a/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
+++ b/services/kube-eleven/internal/worker/service/task_reconcile_infrastructure.go
@@ -82,7 +82,7 @@ func Reconcile(
 func removeKubeProxy(logger zerolog.Logger, clusterId, kubeconfig string) {
 	k := kubectl.Kubectl{
 		Kubeconfig:        kubeconfig,
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	k.Stdout = command.GetStdOut(clusterId)

--- a/services/kuber/internal/worker/service/task_cilium_rollout_restart.go
+++ b/services/kuber/internal/worker/service/task_cilium_rollout_restart.go
@@ -32,7 +32,7 @@ func CiliumRolloutRestart(logger zerolog.Logger, tracker Tracker) {
 
 	kc := kubectl.Kubectl{
 		Kubeconfig:        kubeconfig,
-		MaxKubectlRetries: 5,
+		MaxKubectlRetries: 3,
 	}
 
 	if err := kc.RolloutRestart("daemonset", "cilium", "-n kube-system"); err != nil {

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -39,7 +39,7 @@ func DeleteNodes(logger zerolog.Logger, tracker Tracker) {
 func isControlNode(name string, kubeconfig string) (bool, error) {
 	kc := kubectl.Kubectl{
 		Kubeconfig:        kubeconfig,
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	type nodeOutput struct {

--- a/services/kuber/internal/worker/service/task_patch_kubeadm_cm.go
+++ b/services/kuber/internal/worker/service/task_patch_kubeadm_cm.go
@@ -115,7 +115,7 @@ func PatchKubeadmCM(logger zerolog.Logger, tracker Tracker) {
 		k := kubectl.Kubectl{
 			Directory:         clusterDir,
 			Kubeconfig:        action.Update.State.K8S.Kubeconfig,
-			MaxKubectlRetries: -1, // No retries.
+			MaxKubectlRetries: kubectl.NoRetries,
 		}
 
 		if err = k.KubectlApply(filepath.Base(file.Name()), "-n kube-system"); err != nil {

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -205,7 +205,7 @@ func HealthCheck(logger zerolog.Logger, state *spec.Clusters) HealthCheckStatus 
 
 	kc := kubectl.Kubectl{
 		Kubeconfig:        state.K8S.Kubeconfig,
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	out, err := kc.KubectlGet("nodes", "-ojson")

--- a/services/manager/internal/service/managementcluster/delete_kubeconfig.go
+++ b/services/manager/internal/service/managementcluster/delete_kubeconfig.go
@@ -19,7 +19,7 @@ func DeleteKubeconfig(clusters *spec.Clusters) error {
 	}
 
 	kc := kubectl.Kubectl{
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	kc.Stdout = comm.GetStdOut(clusterID)

--- a/services/manager/internal/service/managementcluster/delete_metadata.go
+++ b/services/manager/internal/service/managementcluster/delete_metadata.go
@@ -20,7 +20,7 @@ func DeleteClusterMetadata(clusters *spec.Clusters) error {
 	}
 
 	kc := kubectl.Kubectl{
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 		Stdout:            comm.GetStdOut(clusterID),
 		Stderr:            comm.GetStdErr(clusterID),
 	}

--- a/services/manager/internal/service/managementcluster/internal/autoscaler/cluster_autoscaler.go
+++ b/services/manager/internal/service/managementcluster/internal/autoscaler/cluster_autoscaler.go
@@ -90,7 +90,7 @@ func (a *AutoscalerManager) SetUpClusterAutoscaler(logger zerolog.Logger) error 
 
 	kc := kubectl.Kubectl{
 		Directory:         a.directory,
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	if logger.GetLevel() <= zerolog.DebugLevel {
@@ -113,7 +113,7 @@ func (a *AutoscalerManager) DestroyClusterAutoscaler(logger zerolog.Logger) erro
 
 	kc := kubectl.Kubectl{
 		Directory:         a.directory,
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	if err := kc.KubectlDeleteManifest(clusterAutoscalerDeployment, "-n", envs.Namespace); err != nil {

--- a/services/manager/internal/service/managementcluster/secret.go
+++ b/services/manager/internal/service/managementcluster/secret.go
@@ -87,7 +87,7 @@ func (s *Secret) Apply(namespace string) error {
 	kubectl := kubectl.Kubectl{
 		// setting empty string for kubeconfig will create secret on same cluster where claudie is running
 		Kubeconfig:        "",
-		MaxKubectlRetries: -1,
+		MaxKubectlRetries: kubectl.NoRetries,
 	}
 
 	if envs.LogLevel != "info" {

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -744,145 +744,6 @@ func ScheduleAdditionsInNodePools(
 
 	kuberStage = &spec.Stage{StageKind: &kuber}
 
-	for np, nodes := range diff.PartiallyAdded {
-		// If the ApiServer is on the kubernetes cluster on addition of the
-		// control plane nodes the Kubeadm config map needs to be updated which
-		// is used during the join operation of new nodes.
-		if matchedNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); matchedNodePool != nil {
-			if opts.HasApiServer && matchedNodePool.IsControl {
-				kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
-					{
-						Kind: spec.StageKuber_PATCH_KUBEADM,
-						Description: &spec.StageDescription{
-							About:      "Updating Kubeadm certSANs",
-							ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
-						},
-					},
-					{
-						Kind: spec.StageKuber_CILIUM_RESTART,
-						Description: &spec.StageDescription{
-							About: "Rollout restart of cilium pods",
-							// Rollout restart failing is not a fatal error.
-							ErrorLevel: spec.ErrorLevel_ERROR_WARN,
-						},
-					},
-				}...)
-			}
-		} else {
-			// Not possible to add nodes into a nodepool that is not tracked.
-			continue
-		}
-
-		// This is a separate stage
-		// as it depends on the success on all of the
-		// previous stages to complete successfully.
-		//
-		// This stage commits the newly added nodes into
-		// the loadbalancers (if any) so that new traffic
-		// can be routed through them.
-		var updateLoadBalancersStage *spec.Stage
-
-		// If changes to the nodepool affects any loadbalancer
-		// also schedule a reconciliation of loadbalancers, as
-		// the envoy targets needs to be regenerated.
-	lbrefresh1:
-		for _, lb := range current.LoadBalancers.Clusters {
-			for _, r := range lb.Roles {
-				for _, tg := range r.TargetPools {
-					// Need to match against only the nodepool name without the hash.
-					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
-					// Static nodepools don't have any hashes.
-					staticNodePoolUpdate := opts.IsStatic && tg == np
-					if dynamicNodePoolUpdate || staticNodePoolUpdate {
-						updateLoadBalancersStage = &spec.Stage{
-							StageKind: &spec.Stage_Ansibler{
-								Ansibler: &spec.StageAnsibler{
-									Description: &spec.StageDescription{
-										About:      "Updating Envoy configuration on the LoadBalancers",
-										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
-									},
-									SubPasses: []*spec.StageAnsibler_SubPass{
-										{
-											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
-											Description: &spec.StageDescription{
-												About:      "Reconciling Envoy settings after changes to nodepool",
-												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
-											},
-										},
-									},
-								},
-							},
-						}
-						break lbrefresh1
-					}
-				}
-			}
-		}
-
-		update := spec.Task_Update{
-			Update: &spec.Update{
-				State: &spec.Update_State{
-					K8S:           inFlight.K8S,
-					LoadBalancers: inFlight.LoadBalancers.Clusters,
-				},
-				Delta: &spec.Update_None_{},
-			},
-		}
-
-		if opts.IsStatic {
-			// For static nodes, merge the nodes already into the inFlight state,
-			// as they do not need to be build, contrary to dynamic nodes.
-			dst := nodepools.FindByName(np, inFlight.K8S.ClusterInfo.NodePools)
-			src := nodepools.FindByName(np, desired.K8S.ClusterInfo.NodePools)
-			nodepools.CopyNodes(dst, src, nodes)
-			update.Update.Delta = &spec.Update_AddedK8SNodes_{
-				AddedK8SNodes: &spec.Update_AddedK8SNodes{
-					Nodepool:    np,
-					Nodes:       nodes,
-					NewNodePool: false,
-				},
-			}
-		} else {
-			src := nodepools.FindByName(np, desired.K8S.ClusterInfo.NodePools)
-			toAdd := nodepools.CloneTargetNodes(src, nodes)
-			update.Update.Delta = &spec.Update_TfAddK8SNodes{
-				TfAddK8SNodes: &spec.Update_TerraformerAddK8SNodes{
-					Kind: &spec.Update_TerraformerAddK8SNodes_Existing_{
-						Existing: &spec.Update_TerraformerAddK8SNodes_Existing{
-							Nodepool: np,
-							Nodes:    toAdd,
-						},
-					},
-				},
-			}
-		}
-
-		var pipeline []*spec.Stage
-
-		if terraformerStage != nil {
-			pipeline = append(pipeline, terraformerStage)
-		}
-
-		pipeline = append(pipeline, ansiblerStage)
-		pipeline = append(pipeline, kubeElevenStage)
-		pipeline = append(pipeline, kuberStage)
-
-		if updateLoadBalancersStage != nil {
-			pipeline = append(pipeline, updateLoadBalancersStage)
-		}
-
-		return &spec.TaskEvent{
-			Id:        uuid.New().String(),
-			Timestamp: timestamppb.New(time.Now().UTC()),
-			Event:     spec.Event_UPDATE,
-			Task: &spec.Task{
-				Do: &update,
-			},
-			Description: fmt.Sprintf("Adding %v nodes into nodepool %s", len(nodes), np),
-			Pipeline:    pipeline,
-		}
-	}
-
 	for np, nodes := range diff.Added {
 		toAdd := nodepools.FindByName(np, desired.K8S.ClusterInfo.NodePools)
 		if toAdd == nil {
@@ -1036,6 +897,145 @@ func ScheduleAdditionsInNodePools(
 				Do: &update,
 			},
 			Description: fmt.Sprintf("Adding nodepool %s", np),
+			Pipeline:    pipeline,
+		}
+	}
+
+	for np, nodes := range diff.PartiallyAdded {
+		// If the ApiServer is on the kubernetes cluster on addition of the
+		// control plane nodes the Kubeadm config map needs to be updated which
+		// is used during the join operation of new nodes.
+		if matchedNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); matchedNodePool != nil {
+			if opts.HasApiServer && matchedNodePool.IsControl {
+				kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
+					{
+						Kind: spec.StageKuber_PATCH_KUBEADM,
+						Description: &spec.StageDescription{
+							About:      "Updating Kubeadm certSANs",
+							ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+						},
+					},
+					{
+						Kind: spec.StageKuber_CILIUM_RESTART,
+						Description: &spec.StageDescription{
+							About: "Rollout restart of cilium pods",
+							// Rollout restart failing is not a fatal error.
+							ErrorLevel: spec.ErrorLevel_ERROR_WARN,
+						},
+					},
+				}...)
+			}
+		} else {
+			// Not possible to add nodes into a nodepool that is not tracked.
+			continue
+		}
+
+		// This is a separate stage
+		// as it depends on the success on all of the
+		// previous stages to complete successfully.
+		//
+		// This stage commits the newly added nodes into
+		// the loadbalancers (if any) so that new traffic
+		// can be routed through them.
+		var updateLoadBalancersStage *spec.Stage
+
+		// If changes to the nodepool affects any loadbalancer
+		// also schedule a reconciliation of loadbalancers, as
+		// the envoy targets needs to be regenerated.
+	lbrefresh1:
+		for _, lb := range current.LoadBalancers.Clusters {
+			for _, r := range lb.Roles {
+				for _, tg := range r.TargetPools {
+					// Need to match against only the nodepool name without the hash.
+					dynamicNodePoolUpdate := nodepools.HasNodePoolTypeOf(tg, np)
+					// Static nodepools don't have any hashes.
+					staticNodePoolUpdate := opts.IsStatic && tg == np
+					if dynamicNodePoolUpdate || staticNodePoolUpdate {
+						updateLoadBalancersStage = &spec.Stage{
+							StageKind: &spec.Stage_Ansibler{
+								Ansibler: &spec.StageAnsibler{
+									Description: &spec.StageDescription{
+										About:      "Updating Envoy configuration on the LoadBalancers",
+										ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+									},
+									SubPasses: []*spec.StageAnsibler_SubPass{
+										{
+											Kind: spec.StageAnsibler_RECONCILE_LOADBALANCERS,
+											Description: &spec.StageDescription{
+												About:      "Reconciling Envoy settings after changes to nodepool",
+												ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+											},
+										},
+									},
+								},
+							},
+						}
+						break lbrefresh1
+					}
+				}
+			}
+		}
+
+		update := spec.Task_Update{
+			Update: &spec.Update{
+				State: &spec.Update_State{
+					K8S:           inFlight.K8S,
+					LoadBalancers: inFlight.LoadBalancers.Clusters,
+				},
+				Delta: &spec.Update_None_{},
+			},
+		}
+
+		if opts.IsStatic {
+			// For static nodes, merge the nodes already into the inFlight state,
+			// as they do not need to be build, contrary to dynamic nodes.
+			dst := nodepools.FindByName(np, inFlight.K8S.ClusterInfo.NodePools)
+			src := nodepools.FindByName(np, desired.K8S.ClusterInfo.NodePools)
+			nodepools.CopyNodes(dst, src, nodes)
+			update.Update.Delta = &spec.Update_AddedK8SNodes_{
+				AddedK8SNodes: &spec.Update_AddedK8SNodes{
+					Nodepool:    np,
+					Nodes:       nodes,
+					NewNodePool: false,
+				},
+			}
+		} else {
+			src := nodepools.FindByName(np, desired.K8S.ClusterInfo.NodePools)
+			toAdd := nodepools.CloneTargetNodes(src, nodes)
+			update.Update.Delta = &spec.Update_TfAddK8SNodes{
+				TfAddK8SNodes: &spec.Update_TerraformerAddK8SNodes{
+					Kind: &spec.Update_TerraformerAddK8SNodes_Existing_{
+						Existing: &spec.Update_TerraformerAddK8SNodes_Existing{
+							Nodepool: np,
+							Nodes:    toAdd,
+						},
+					},
+				},
+			}
+		}
+
+		var pipeline []*spec.Stage
+
+		if terraformerStage != nil {
+			pipeline = append(pipeline, terraformerStage)
+		}
+
+		pipeline = append(pipeline, ansiblerStage)
+		pipeline = append(pipeline, kubeElevenStage)
+		pipeline = append(pipeline, kuberStage)
+
+		if updateLoadBalancersStage != nil {
+			pipeline = append(pipeline, updateLoadBalancersStage)
+		}
+
+		return &spec.TaskEvent{
+			Id:        uuid.New().String(),
+			Timestamp: timestamppb.New(time.Now().UTC()),
+			Event:     spec.Event_UPDATE,
+			Task: &spec.Task{
+				Do: &update,
+			},
+			Description: fmt.Sprintf("Adding %v nodes into nodepool %s", len(nodes), np),
 			Pipeline:    pipeline,
 		}
 	}

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -181,9 +181,9 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 				// Check historical counters for any loopback changes that
 				// needs to be done before looking at scheduling tasks,
 				for np, counter := range state.Counters.K8SNodePoolScaleUpFailed {
-					// If a nodepool fails to scale up 3x reset the `TargetSize`
+					// If a nodepool fails to scale up, reset the `TargetSize`
 					// of the autoscaled nodepool back to the current size.
-					if counter > 2 {
+					if counter > 0 {
 						nodepool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools)
 						if nodepool == nil {
 							// Nodepool is missing from current state, remove counter.

--- a/services/terraformer/internal/worker/service/internal/tofu/terraform.go
+++ b/services/terraformer/internal/worker/service/internal/tofu/terraform.go
@@ -19,7 +19,7 @@ import (
 // maxTfCommandRetryCount is the maximum amount a Tofu command can be repeated until
 // it succeeds. If after "maxTfCommandRetryCount" retries the commands still fails an error should be
 // returned containing the reason.
-const maxTfCommandRetryCount = 3
+const maxTfCommandRetryCount = 1
 
 // Parallelism is the number of resource to be work on in parallel during the apply/destroy commands.
 var parallelism = envs.GetOrDefaultInt("TERRAFORMER_TOFU_PARALLELISM", 40)


### PR DESCRIPTION
Completely removed retries for failed autoscaled operations and reduced the retries in terraformer and other tasks to speed up the failure process.

Reordered tasks to unblock adding a new nodepool if scale-up continuously fails and blocks other tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit option to disable retries for kubectl operations.

* **Improvements**
  * Reduced retry attempts for several command paths to make operations fail faster when appropriate.
  * Reworked nodepool addition scheduling for more accurate control-plane handling and related restarts.
  * Adjusted autoscaled nodepool recovery behavior for quicker reset on scale-up failures.
  * Updated component image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->