### PR TITLE
Support per-node SSH and WireGuard ports for shared-IP nodes

### DIFF
--- a/internal/nodepools/nodepools.go
+++ b/internal/nodepools/nodepools.go
@@ -30,6 +30,16 @@ func SSHPort(np *spec.NodePool) int32 {
 	return np.SshPort
 }
 
+// NodeSSHPort returns the effective SSH port for a single node. A non-zero
+// Node.SshPort (set for shared-IP / NAT nodes where each VM gets its own mapped
+// port) overrides the node pool's port; otherwise the node pool's SSHPort is used.
+func NodeSSHPort(np *spec.NodePool, n *spec.Node) int32 {
+	if n.SshPort > 0 {
+		return n.SshPort
+	}
+	return SSHPort(np)
+}
+
 type RegionNetwork struct {
 	Region          string
 	ExternalNetwork string
@@ -555,7 +565,7 @@ func RandomNodePublicEndpoint(nps []*spec.NodePool) (username, endpoint, key, ss
 		username = node.Username
 	}
 
-	port := fmt.Sprint(SSHPort(np))
+	port := fmt.Sprint(NodeSSHPort(np, node))
 
 	switch t := np.Type.(type) {
 	case *spec.NodePool_DynamicNodePool:

--- a/internal/nodepools/nodepools_ssh_test.go
+++ b/internal/nodepools/nodepools_ssh_test.go
@@ -1,0 +1,30 @@
+package nodepools
+
+import (
+	"testing"
+
+	"github.com/berops/claudie/proto/pb/spec"
+)
+
+func TestNodeSSHPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodePoolSSH int32
+		nodeSSH     int32
+		want        int32
+	}{
+		{name: "both unset falls back to default 22", nodePoolSSH: 0, nodeSSH: 0, want: DefaultSSHPort},
+		{name: "node pool port used when node unset", nodePoolSSH: 2222, nodeSSH: 0, want: 2222},
+		{name: "per-node port overrides node pool", nodePoolSSH: 2222, nodeSSH: 22222, want: 22222},
+		{name: "per-node port overrides default", nodePoolSSH: 0, nodeSSH: 22222, want: 22222},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			np := &spec.NodePool{SshPort: tt.nodePoolSSH}
+			n := &spec.Node{SshPort: tt.nodeSSH}
+			if got := NodeSSHPort(np, n); got != tt.want {
+				t.Errorf("NodeSSHPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/templateUtils/templates.go
+++ b/internal/templateUtils/templates.go
@@ -67,6 +67,7 @@ func LoadTemplate(tplFile string) (*template.Template, error) {
 	funcMap["extractNetmaskFromCIDR"] = ExtractNetmaskFromCIDR
 	funcMap["hasExtension"] = HasExtension
 	funcMap["sshPort"] = nodepools.SSHPort
+	funcMap["nodeSshPort"] = nodepools.NodeSSHPort
 
 	tpl, err := template.New("").Funcs(funcMap).Parse(tplFile)
 	if err != nil {

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/kuber
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/manager
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/manager
-  newTag: 8736ed3-4242
+  newTag: c375771-4243
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 8736ed3-4242
+  newTag: c375771-4243

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 8736ed3-4242
+  newTag: c375771-4243

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: cd82725-4239
+  newTag: 8736ed3-4242

--- a/proto/pb/spec/nodepool.pb.go
+++ b/proto/pb/spec/nodepool.pb.go
@@ -408,7 +408,15 @@ type Node struct {
 	// Username of a user with root privileges. Also used in SSH connection
 	Username string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
 	// Status of the node.
-	Status        NodeStatus `protobuf:"varint,6,opt,name=status,proto3,enum=spec.NodeStatus" json:"status,omitempty"`
+	Status NodeStatus `protobuf:"varint,6,opt,name=status,proto3,enum=spec.NodeStatus" json:"status,omitempty"`
+	// Per-node SSH port. Overrides NodePool.sshPort when > 0. Used by shared-IP /
+	// NAT nodes (e.g. CloudRift) where each VM gets its own mapped SSH port.
+	// 0 means inherit the node pool's sshPort (which itself defaults to 22).
+	SshPort int32 `protobuf:"varint,7,opt,name=sshPort,proto3" json:"sshPort,omitempty"`
+	// Per-node WireGuard endpoint port advertised to peers. Used when the
+	// host-mapped UDP port differs from the in-VM ListenPort (shared-IP / NAT
+	// nodes). 0 means use the default WireGuard listen port (51820).
+	WireguardPort int32 `protobuf:"varint,8,opt,name=wireguardPort,proto3" json:"wireguardPort,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -483,6 +491,20 @@ func (x *Node) GetStatus() NodeStatus {
 		return x.Status
 	}
 	return NodeStatus_Preparing
+}
+
+func (x *Node) GetSshPort() int32 {
+	if x != nil {
+		return x.SshPort
+	}
+	return 0
+}
+
+func (x *Node) GetWireguardPort() int32 {
+	if x != nil {
+		return x.WireguardPort
+	}
+	return 0
 }
 
 // DynamicNodePool represents dynamic node pool used in cluster.
@@ -849,14 +871,16 @@ const file_spec_nodepool_proto_rawDesc = "" +
 	"\x05Taint\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x16\n" +
-	"\x06effect\x18\x03 \x01(\tR\x06effect\"\xbe\x01\n" +
+	"\x06effect\x18\x03 \x01(\tR\x06effect\"\xfe\x01\n" +
 	"\x04Node\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aprivate\x18\x02 \x01(\tR\aprivate\x12\x16\n" +
 	"\x06public\x18\x03 \x01(\tR\x06public\x12*\n" +
 	"\bnodeType\x18\x04 \x01(\x0e2\x0e.spec.NodeTypeR\bnodeType\x12\x1a\n" +
 	"\busername\x18\x05 \x01(\tR\busername\x12(\n" +
-	"\x06status\x18\x06 \x01(\x0e2\x10.spec.NodeStatusR\x06status\"\xda\x03\n" +
+	"\x06status\x18\x06 \x01(\x0e2\x10.spec.NodeStatusR\x06status\x12\x18\n" +
+	"\asshPort\x18\a \x01(\x05R\asshPort\x12$\n" +
+	"\rwireguardPort\x18\b \x01(\x05R\rwireguardPort\"\xda\x03\n" +
 	"\x0fDynamicNodePool\x12\x1e\n" +
 	"\n" +
 	"serverType\x18\x01 \x01(\tR\n" +

--- a/proto/spec/nodepool.proto
+++ b/proto/spec/nodepool.proto
@@ -53,6 +53,15 @@ message Node {
 
   // Status of the node.
   NodeStatus status = 6;
+
+  // Per-node SSH port. Overrides NodePool.sshPort when > 0. Used by shared-IP /
+  // NAT nodes (e.g. CloudRift) where each VM gets its own mapped SSH port.
+  // 0 means inherit the node pool's sshPort (which itself defaults to 22).
+  int32 sshPort = 7;
+  // Per-node WireGuard endpoint port advertised to peers. Used when the
+  // host-mapped UDP port differs from the in-VM ListenPort (shared-IP / NAT
+  // nodes). 0 means use the default WireGuard listen port (51820).
+  int32 wireguardPort = 8;
 }
 
 // NodeType specifies the type of the node.

--- a/services/ansibler/ansible-playbooks/wireguard/templates/wg-dynamic.conf.j2
+++ b/services/ansibler/ansible-playbooks/wireguard/templates/wg-dynamic.conf.j2
@@ -7,7 +7,7 @@ ListenPort = {{ wg_listen_port }}
 {% if publickey.content | b64decode != hostvars[host].publickey.content | b64decode %}
 [Peer]
 PublicKey = {{ hostvars[host].publickey.content | b64decode }}
-Endpoint = {{ hostvars[host].ansible_host }}:{{ wg_listen_port }}
+Endpoint = {{ hostvars[host].ansible_host }}:{{ hostvars[host].wireguard_port | default(wg_listen_port, true) }}
 AllowedIps = {{ hostvars[host].private_ip }}/32
 PersistentKeepalive = 30
 {% endif %}

--- a/services/ansibler/ansible-playbooks/wireguard/templates/wg-static.conf.j2
+++ b/services/ansibler/ansible-playbooks/wireguard/templates/wg-static.conf.j2
@@ -7,7 +7,7 @@ ListenPort = {{ wg_listen_port }}
 {% if publickey.content | b64decode != hostvars[host].publickey.content | b64decode %}
 [Peer]
 PublicKey = {{ hostvars[host].publickey.content | b64decode }}
-Endpoint = {{ hostvars[host].ansible_host }}:{{ wg_listen_port }}
+Endpoint = {{ hostvars[host].ansible_host }}:{{ hostvars[host].wireguard_port | default(wg_listen_port, true) }}
 AllowedIps = {{ hostvars[host].private_ip }}/32
 PersistentKeepalive = 60
 {% endif %}
@@ -17,7 +17,7 @@ PersistentKeepalive = 60
 {% if publickey.content | b64decode != hostvars[host].publickey.content | b64decode %}
 [Peer]
 PublicKey = {{ hostvars[host].publickey.content | b64decode}}
-Endpoint = {{ hostvars[host].ansible_host }}:{{ wg_listen_port }}
+Endpoint = {{ hostvars[host].ansible_host }}:{{ hostvars[host].wireguard_port | default(wg_listen_port, true) }}
 AllowedIps = {{ hostvars[host].private_ip }}/32
 {% endif %}
 {% endfor %}

--- a/services/ansibler/templates/all-node-inventory.goini
+++ b/services/ansibler/templates/all-node-inventory.goini
@@ -2,7 +2,7 @@
 {{- range $nodepoolInfo := .NodepoolsInfo }}
     {{- range $nodepool := $nodepoolInfo.Nodepools.Dynamic }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} wireguard_port={{ $node.WireguardPort }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
@@ -11,7 +11,7 @@
 {{- range $nodepoolInfo := .NodepoolsInfo }}
     {{- range $nodepool := $nodepoolInfo.Nodepools.Static }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} wireguard_port={{ $node.WireguardPort }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/k8s-inventory.goini
+++ b/services/ansibler/templates/k8s-inventory.goini
@@ -2,7 +2,7 @@
 {{- range $nodepool := .K8sNodepools.Dynamic }}
     {{- if $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
@@ -10,7 +10,7 @@
 {{- range $nodepool := .K8sNodepools.Static }}
     {{- if $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
@@ -19,7 +19,7 @@
 {{- range $nodepool := .K8sNodepools.Dynamic }}
     {{- if not $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
@@ -27,7 +27,7 @@
 {{- range $nodepool := .K8sNodepools.Static }}
     {{- if not $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/lb-inventory.goini
+++ b/services/ansibler/templates/lb-inventory.goini
@@ -2,13 +2,13 @@
 {{- range $lbNodepool := $.LBnodepools.Dynamic }}
     {{- range $lbNode :=  $lbNodepool.Nodes }}
 {{/*key.pem is taken from a directory where ansible-playbook is called, thus it does not need to specify path relative to inventory.ini*/}}
-{{ trimPrefix (printf "%s-%s-" $.Name $.Hash) $lbNode.Name }} ansible_user=root ansible_host={{ $lbNode.Public }} ansible_port={{ sshPort $lbNodepool }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file={{ $lbNodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-%s-" $.Name $.Hash) $lbNode.Name }} ansible_user=root ansible_host={{ $lbNode.Public }} ansible_port={{ nodeSshPort $lbNodepool $lbNode }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file={{ $lbNodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
     {{- end }}
 {{- end }}
 
 {{- range $lbNodepool := $.LBnodepools.Static }}
     {{- range $lbNode :=  $lbNodepool.Nodes }}
 {{/*key.pem is taken from a directory where ansible-playbook is called, thus it does not need to specify path relative to inventory.ini*/}}
-{{ $lbNode.Name }} ansible_user={{ $lbNode.Username }} ansible_host={{ $lbNode.Public }} ansible_port={{ sshPort $lbNodepool }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file={{ $lbNode.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $lbNode.Name }} ansible_user={{ $lbNode.Username }} ansible_host={{ $lbNode.Public }} ansible_port={{ nodeSshPort $lbNodepool $lbNode }} private_ip={{ $lbNode.Private }} ansible_ssh_private_key_file={{ $lbNode.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/nat-hairpin-inventory.goini
+++ b/services/ansibler/templates/nat-hairpin-inventory.goini
@@ -3,7 +3,7 @@
     {{- range $nodepool := $nodepoolInfo.Nodepools.Dynamic }}
         {{- $dyn := $nodepool.GetDynamicNodePool }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes" hairpin_group={{ $dyn.Provider.SpecName }}__{{ $nodepoolInfo.ClusterID }}__{{ $dyn.Region }}
+{{ trimPrefix (printf "%s-" $nodepoolInfo.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} netmask={{ extractNetmaskFromCIDR $nodepoolInfo.ClusterNetwork }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes" hairpin_group={{ $dyn.Provider.SpecName }}__{{ $nodepoolInfo.ClusterID }}__{{ $dyn.Region }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/ansibler/templates/proxy-envs.goini
+++ b/services/ansibler/templates/proxy-envs.goini
@@ -2,14 +2,14 @@
 {{- range $nodepool := .K8sNodepools.Dynamic }}
     {{- if $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
 {{- range $nodepool := .K8sNodepools.Static }}
     {{- if $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
@@ -18,14 +18,14 @@
 {{- range $nodepool := .K8sNodepools.Dynamic }}
     {{- if not $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ trimPrefix (printf "%s-" $.ClusterID) $node.Name }} ansible_user=root ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $nodepool.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}
 {{- range $nodepool := .K8sNodepools.Static }}
     {{- if not $nodepool.IsControl }}
         {{- range $node :=  $nodepool.Nodes }}
-{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ sshPort $nodepool }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
+{{ $node.Name }} ansible_user={{ $node.Username }} ansible_host={{ $node.Public }} ansible_port={{ nodeSshPort $nodepool $node }} private_ip={{ $node.Private }} no_proxy_list={{ $.NoProxyList }} http_proxy_url={{ $.HttpProxyUrl }} ansible_ssh_private_key_file={{ $node.Name }}.pem ansible_ssh_extra_args="-o IdentitiesOnly=yes"
         {{- end }}
     {{- end }}
 {{- end }}

--- a/services/kube-eleven/internal/worker/service/internal/kube-eleven/kube_eleven.go
+++ b/services/kube-eleven/internal/worker/service/internal/kube-eleven/kube_eleven.go
@@ -195,11 +195,10 @@ func (k *KubeEleven) getClusterNodes() []*NodepoolInfo {
 				Zone:              sanitise.String(nodepool.GetDynamicNodePool().Zone),
 				CloudProviderName: sanitise.String(nodepool.GetDynamicNodePool().Provider.CloudProviderName),
 				ProviderName:      sanitise.String(nodepool.GetDynamicNodePool().Provider.SpecName),
-				Nodes: getNodeData(nodepool.Nodes, func(name string) string {
+				Nodes: getNodeData(nodepool, func(name string) string {
 					return strings.TrimPrefix(name, fmt.Sprintf("%s-", k.K8sCluster.ClusterInfo.Id()))
 				}),
 				IsDynamic: true,
-				SshPort:   nodepools.SSHPort(nodepool),
 			}
 		} else if nodepool.GetStaticNodePool() != nil {
 			nodepoolInfo = &NodepoolInfo{
@@ -208,9 +207,8 @@ func (k *KubeEleven) getClusterNodes() []*NodepoolInfo {
 				Zone:              sanitise.String(staticZone),
 				CloudProviderName: sanitise.String(staticProvider),
 				ProviderName:      sanitise.String(staticProviderName),
-				Nodes:             getNodeData(nodepool.Nodes, func(s string) string { return s }),
+				Nodes:             getNodeData(nodepool, func(s string) string { return s }),
 				IsDynamic:         false,
-				SshPort:           nodepools.SSHPort(nodepool),
 			}
 		}
 		nodepoolInfos = append(nodepoolInfos, nodepoolInfo)
@@ -235,11 +233,15 @@ func (k *KubeEleven) apiEndpoint() (string, bool, error) {
 }
 
 // getNodeData return template data for the nodes from the cluster.
-func getNodeData(nodes []*spec.Node, nameFunc func(string) string) []*NodeInfo {
-	n := make([]*NodeInfo, 0, len(nodes))
-	for _, node := range nodes {
+func getNodeData(nodepool *spec.NodePool, nameFunc func(string) string) []*NodeInfo {
+	n := make([]*NodeInfo, 0, len(nodepool.Nodes))
+	for _, node := range nodepool.Nodes {
 		nodeName := nameFunc(node.Name)
-		n = append(n, &NodeInfo{Name: nodeName, Node: node})
+		n = append(n, &NodeInfo{
+			Name:    nodeName,
+			Node:    node,
+			SshPort: nodepools.NodeSSHPort(nodepool, node),
+		})
 	}
 	return n
 }

--- a/services/kube-eleven/internal/worker/service/internal/kube-eleven/types.go
+++ b/services/kube-eleven/internal/worker/service/internal/kube-eleven/types.go
@@ -9,6 +9,10 @@ type (
 	NodeInfo struct {
 		Node *spec.Node
 		Name string
+		// SshPort is the effective SSH port for this specific node. It honors a
+		// per-node override (shared-IP / NAT nodes) and otherwise falls back to
+		// the node pool's port.
+		SshPort int32
 	}
 
 	// NodepoolInfo struct holds data necessary to define nodes in kubeone
@@ -21,7 +25,6 @@ type (
 		Zone              string
 		CloudProviderName string
 		ProviderName      string
-		SshPort           int32
 	}
 
 	// templateData struct holds the data which will be used in creating

--- a/services/kube-eleven/templates/kubeone.tpl
+++ b/services/kube-eleven/templates/kubeone.tpl
@@ -39,7 +39,7 @@ controlPlane:
     {{- if ge $nodeInfo.Node.NodeType 1}}
   - publicAddress: '{{ $nodeInfo.Node.Public }}'
     privateAddress: '{{ $nodeInfo.Node.Private }}'
-    sshPort: {{ $nodepool.SshPort }}
+    sshPort: {{ $nodeInfo.SshPort }}
     {{- if $nodepool.IsDynamic }}
     sshUsername: root
     sshPrivateKeyFile: '{{ $nodepool.NodepoolName }}.pem'
@@ -65,7 +65,7 @@ staticWorkers:
     {{- if eq $nodeInfo.Node.NodeType 0}}
   - publicAddress: '{{ $nodeInfo.Node.Public }}'
     privateAddress: '{{ $nodeInfo.Node.Private }}'
-    sshPort: {{ $nodepool.SshPort }}
+    sshPort: {{ $nodeInfo.SshPort }}
     {{- if $nodepool.IsDynamic }}
     sshUsername: root
     sshPrivateKeyFile: '{{ $nodepool.NodepoolName }}.pem'

--- a/services/manager/internal/service/managementcluster/internal/autoscaler/autoscaler_test.go
+++ b/services/manager/internal/service/managementcluster/internal/autoscaler/autoscaler_test.go
@@ -85,6 +85,10 @@ spec:
               value: ""
             - name: OPERATOR_PORT
               value: ""
+            - name: MANAGER_HOSTNAME
+              value: ""
+            - name: MANAGER_PORT
+              value: ""
           resources:
             requests:
               cpu: 80m

--- a/services/manager/internal/service/managementcluster/internal/autoscaler/cluster-autoscaler.goyaml
+++ b/services/manager/internal/service/managementcluster/internal/autoscaler/cluster-autoscaler.goyaml
@@ -66,6 +66,10 @@ spec:
               value: "{{ .OperatorHostname }}"
             - name: OPERATOR_PORT
               value: "{{ .OperatorPort }}"
+            - name: MANAGER_HOSTNAME
+              value: "{{ .ManagerHostname }}"
+            - name: MANAGER_PORT
+              value: "{{ .ManagerPort }}"
           resources:
             requests:
               cpu: 80m

--- a/services/manager/internal/service/managementcluster/internal/autoscaler/cluster_autoscaler.go
+++ b/services/manager/internal/service/managementcluster/internal/autoscaler/cluster_autoscaler.go
@@ -31,6 +31,8 @@ var (
 var (
 	operatorHostname = envs.GetOrDefault("OPERATOR_HOSTNAME", defaultOperatorHostname)
 	operatorPort     = envs.GetOrDefault("OPERATOR_PORT", defaultOperatorPort)
+	managerHostname  = envs.GetOrDefault("MANAGER_HOSTNAME", defaultManagerHostname)
+	managerPort      = envs.GetOrDefault("MANAGER_PORT", defaultManagerPort)
 )
 
 const (
@@ -45,6 +47,12 @@ const (
 
 	// Default port for Claudie operator.
 	defaultOperatorPort = "50058"
+
+	// Default hostname for Claudie manager.
+	defaultManagerHostname = "manager"
+
+	// Default port for Claudie manager.
+	defaultManagerPort = "50055"
 
 	// CA registry address to query for tags
 	clusterAutoscalerRegistry = "https://registry.k8s.io/v2/autoscaling/cluster-autoscaler/tags/list"
@@ -70,6 +78,8 @@ type autoscalerDeploymentData struct {
 	KubernetesVersion string
 	OperatorHostname  string
 	OperatorPort      string
+	ManagerHostname   string
+	ManagerPort       string
 }
 
 // TagResponse will carry the information about cluster-autoscaler tags
@@ -146,6 +156,8 @@ func (a *AutoscalerManager) generateFiles() error {
 			KubernetesVersion: version,
 			OperatorHostname:  operatorHostname,
 			OperatorPort:      operatorPort,
+			ManagerHostname:   managerHostname,
+			ManagerPort:       managerPort,
 		}
 
 		tpl = templateUtils.Templates{Directory: a.directory}
@@ -282,6 +294,8 @@ func Manifests(projectName string, c *spec.K8Scluster) ([]unstructured.Unstructu
 			KubernetesVersion: version,
 			OperatorHostname:  operatorHostname,
 			OperatorPort:      operatorPort,
+			ManagerHostname:   managerHostname,
+			ManagerPort:       managerPort,
 		}
 
 		tpl = templateUtils.Templates{}

--- a/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder.go
+++ b/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder.go
@@ -131,7 +131,7 @@ func (c ClusterBuilder) ReconcileNodePools() error {
 				if target != n.Name {
 					continue
 				}
-				ip, port, err := parseNodeOutput(val)
+				ip, sshPort, wgPort, err := parseNodeOutput(val)
 				if err != nil {
 					return fmt.Errorf("node %q from nodepool %q: %w", n.Name, nodepool.Name, err)
 				}
@@ -140,8 +140,11 @@ func (c ClusterBuilder) ReconcileNodePools() error {
 				}
 				found = true
 				n.Public = ip
-				if port > 0 {
-					nodepool.SshPort = port
+				if sshPort > 0 {
+					n.SshPort = sshPort
+				}
+				if wgPort > 0 {
+					n.WireguardPort = wgPort
 				}
 				break
 			}
@@ -296,31 +299,47 @@ func (c *ClusterBuilder) generateFiles(clusterDir string) error {
 	return nil
 }
 
-// parseNodeOutput extracts the IP and optional SSH port from a terraform output value.
-// Old templates output a string (just IP), new templates output [IP, port].
-func parseNodeOutput(val any) (ip string, port int32, err error) {
+// parseNodeOutput extracts the IP and optional per-node SSH and WireGuard ports
+// from a terraform output value. Templates may output any of:
+//   - a string (just the IP)
+//   - [IP, sshPort]
+//   - [IP, sshPort, wireguardPort]
+//
+// The ports are used by shared-IP / NAT nodes (e.g. CloudRift) where each VM is
+// reached on its own mapped host port. A zero/absent port means "use the default".
+func parseNodeOutput(val any) (ip string, sshPort, wgPort int32, err error) {
 	switch v := val.(type) {
 	case string:
-		return v, 0, nil
+		return v, 0, 0, nil
 	case []any:
 		if len(v) == 0 {
-			return "", 0, fmt.Errorf("empty output array")
+			return "", 0, 0, fmt.Errorf("empty output array")
 		}
 		ipStr := fmt.Sprint(v[0])
 		if len(v) >= 2 {
-			portStr := fmt.Sprint(v[1])
-			var p int
-			if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil && p > 0 {
-				return ipStr, int32(p), nil
-			}
+			sshPort = parsePort(v[1])
 		}
-		return ipStr, 0, nil
+		if len(v) >= 3 {
+			wgPort = parsePort(v[2])
+		}
+		return ipStr, sshPort, wgPort, nil
 	default:
 		if val == nil {
-			return "", 0, fmt.Errorf("nil output value")
+			return "", 0, 0, fmt.Errorf("nil output value")
 		}
-		return fmt.Sprint(val), 0, nil
+		return fmt.Sprint(val), 0, 0, nil
 	}
+}
+
+// parsePort parses a terraform output element into a positive port number,
+// returning 0 when it is empty, null, or not a valid port.
+func parsePort(val any) int32 {
+	portStr := fmt.Sprint(val)
+	var p int
+	if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil && p > 0 {
+		return int32(p)
+	}
+	return 0
 }
 
 // readIPs reads json output format from tofu and unmarshal it into map[string]map[string]string readable by Go.

--- a/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder.go
+++ b/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	comm "github.com/berops/claudie/internal/command"
 	"github.com/berops/claudie/internal/fileutils"
@@ -315,7 +317,10 @@ func parseNodeOutput(val any) (ip string, sshPort, wgPort int32, err error) {
 		if len(v) == 0 {
 			return "", 0, 0, fmt.Errorf("empty output array")
 		}
-		ipStr := fmt.Sprint(v[0])
+		ipStr, ok := v[0].(string)
+		if !ok || ipStr == "" {
+			return "", 0, 0, fmt.Errorf("invalid IP value type %T", v[0])
+		}
 		if len(v) >= 2 {
 			sshPort = parsePort(v[1])
 		}
@@ -327,19 +332,18 @@ func parseNodeOutput(val any) (ip string, sshPort, wgPort int32, err error) {
 		if val == nil {
 			return "", 0, 0, fmt.Errorf("nil output value")
 		}
-		return fmt.Sprint(val), 0, 0, nil
+		return "", 0, 0, fmt.Errorf("unsupported output value type %T", val)
 	}
 }
 
 // parsePort parses a terraform output element into a positive port number,
 // returning 0 when it is empty, null, or not a valid port.
 func parsePort(val any) int32 {
-	portStr := fmt.Sprint(val)
-	var p int
-	if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil && p > 0 {
-		return int32(p)
+	p, err := strconv.Atoi(strings.TrimSpace(fmt.Sprint(val)))
+	if err != nil || p < 1 || p > 65535 {
+		return 0
 	}
-	return 0
+	return int32(p)
 }
 
 // readIPs reads json output format from tofu and unmarshal it into map[string]map[string]string readable by Go.

--- a/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder_test.go
+++ b/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder_test.go
@@ -7,6 +7,43 @@ import (
 	"github.com/berops/claudie/services/terraformer/internal/worker/service/internal/templates"
 )
 
+func Test_parseNodeOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		val         any
+		wantIP      string
+		wantSSHPort int32
+		wantWGPort  int32
+		wantErr     bool
+	}{
+		{name: "legacy string IP", val: "1.2.3.4", wantIP: "1.2.3.4"},
+		// JSON numbers decode to float64, so mimic that for the array cases.
+		{name: "ip + ssh port (numbers)", val: []any{"1.2.3.4", float64(22522)}, wantIP: "1.2.3.4", wantSSHPort: 22522},
+		{name: "ip + ssh + wg ports (numbers)", val: []any{"1.2.3.4", float64(22222), float64(41234)}, wantIP: "1.2.3.4", wantSSHPort: 22222, wantWGPort: 41234},
+		// CloudRift template emits ports via tostring(), so they arrive as strings.
+		{name: "ip + ssh + wg ports (strings)", val: []any{"1.2.3.4", "22222", "41234"}, wantIP: "1.2.3.4", wantSSHPort: 22222, wantWGPort: 41234},
+		{name: "ip only array", val: []any{"1.2.3.4"}, wantIP: "1.2.3.4"},
+		{name: "zero/invalid ports fall back to 0", val: []any{"1.2.3.4", float64(0), "notaport"}, wantIP: "1.2.3.4"},
+		{name: "empty array errors", val: []any{}, wantErr: true},
+		{name: "nil errors", val: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, sshPort, wgPort, err := parseNodeOutput(tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseNodeOutput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if ip != tt.wantIP || sshPort != tt.wantSSHPort || wgPort != tt.wantWGPort {
+				t.Errorf("parseNodeOutput() = (%q, %d, %d), want (%q, %d, %d)",
+					ip, sshPort, wgPort, tt.wantIP, tt.wantSSHPort, tt.wantWGPort)
+			}
+		})
+	}
+}
+
 func Test_readIPs(t *testing.T) {
 	type args struct {
 		data string

--- a/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder_test.go
+++ b/services/terraformer/internal/worker/service/internal/cluster-builder/cluster_builder_test.go
@@ -24,6 +24,9 @@ func Test_parseNodeOutput(t *testing.T) {
 		{name: "ip + ssh + wg ports (strings)", val: []any{"1.2.3.4", "22222", "41234"}, wantIP: "1.2.3.4", wantSSHPort: 22222, wantWGPort: 41234},
 		{name: "ip only array", val: []any{"1.2.3.4"}, wantIP: "1.2.3.4"},
 		{name: "zero/invalid ports fall back to 0", val: []any{"1.2.3.4", float64(0), "notaport"}, wantIP: "1.2.3.4"},
+		{name: "port with suffix is rejected", val: []any{"1.2.3.4", "22222x", "41234x"}, wantIP: "1.2.3.4"},
+		{name: "out-of-range ports fall back to 0", val: []any{"1.2.3.4", float64(65536), float64(99999)}, wantIP: "1.2.3.4"},
+		{name: "non-string ip element errors", val: []any{float64(1234), "22222"}, wantErr: true},
 		{name: "empty array errors", val: []any{}, wantErr: true},
 		{name: "nil errors", val: nil, wantErr: true},
 	}

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -297,7 +297,7 @@ func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error
 			var isHairpinProvider bool
 
 			var sshKey string
-			port := nodepools.SSHPort(np)
+			port := nodepools.NodeSSHPort(np, n)
 			username := n.Username
 			if username == "" {
 				username = "root"


### PR DESCRIPTION
Some providers (for example CloudRift) place nodes behind a shared public IP and expose each node's SSH and WireGuard on randomly mapped ports instead of the usual 22 and 51820.

This adds per-node sshPort and wireguardPort to the Node spec, parses them from the terraformer output ([ip, ssh, wg]), and uses the per-node SSH port across the Ansible inventories and the KubeOne config, plus the per-node WireGuard endpoint port in the peer config.

When the ports are unset they fall back to the node pool port (and the 22 / 51820 defaults), so all existing providers are unaffected.

## Compatibility

The CloudRift shared-IP path here only works together with the matching claudie-config template change, which ships in **claudie-config v0.11.3**. To use it, point your InputManifest `Provider.Templates` at **claudie-config v0.11.3 (or later)** so the CloudRift templates emit the per-node `[ip, sshPort, wgPort]` output this PR parses.

The parsing stays backward compatible with the older template output (plain IP string and the 2-element `[ip, sshPort]` form), so clusters on earlier template versions are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-node SSH and WireGuard port overrides; per-node ports take precedence over pool/default
  * Inventory, WireGuard and cluster templates now emit per-node SSH/WireGuard ports
  * Cluster autoscaler deployment now accepts configurable manager hostname and port

* **Bug Fixes**
  * Correct SSH port selection so shared-IP/NAT nodes use node-specific ports

* **Tests**
  * Added unit tests for per-node SSH-port selection and node-output parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
