### PR TITLE
docs(cloudrift): document shared-IP instance support

### DIFF
--- a/docs/input-manifest/providers/cloudrift.md
+++ b/docs/input-manifest/providers/cloudrift.md
@@ -58,8 +58,8 @@ curl -s -X POST \
   | jq '.data.groups[].recipes[] | select(.details.VirtualMachine != null) | {name}'
 ```
 
-!!! warning "Shared public IP instances not supported"
-    CloudRift offers both dedicated and shared public IP instances. Claudie requires dedicated public IP instances. Shared-IP instances use non-standard port mappings and are **not supported**. Make sure to choose an instance type that provides a dedicated public IP.
+!!! note "Shared public IP instances"
+    CloudRift offers both dedicated and shared public IP instances. Shared-IP instances place each node behind a shared/NAT public IP and expose SSH and WireGuard on CloudRift-assigned mapped ports instead of the standard `22` / `51820`. These are supported since **Claudie v0.14.0** together with **claudie-config v0.11.3** (Claudie reads each node's mapped ports back from the provider). On earlier versions only dedicated public IP instances work, so there you must choose an instance type that provides a dedicated public IP.
 
 ## GPU instances
 CloudRift specializes in GPU compute, offering NVIDIA GPU instances (e.g., RTX 4090, RTX 5090). GPU instances are selected by setting the `serverType` to a GPU instance type (e.g., `rtx49-7-50-500-nr.1`). No additional `machineSpec` configuration is needed — the GPU is included in the instance type.

--- a/docs/input-manifest/providers/cloudrift.md
+++ b/docs/input-manifest/providers/cloudrift.md
@@ -93,7 +93,7 @@ spec:
       providerType: cloudrift
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.10.0
+        tag: v0.11.3
         path: "templates/terraformer/cloudrift"
       secretRef:
         name: cloudrift-secret-1
@@ -152,7 +152,7 @@ spec:
       providerType: cloudrift
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.10.0
+        tag: v0.11.3
         path: "templates/terraformer/cloudrift"
       secretRef:
         name: cloudrift-secret-1


### PR DESCRIPTION
Updates the CloudRift provider docs: shared public IP instances (nodes behind a NAT public IP, SSH and WireGuard on CloudRift-mapped ports) are supported since **Claudie v0.14.0** with **claudie-config v0.11.3**, instead of the previous note saying they are unsupported.

Docs-only change. The supporting code lands in #2130 (claudie) and the matching claudie-config templates (v0.11.3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that shared public-IP CloudRift instances are supported (requires Claudie v0.14.0 and claudie-config v0.11.3 or later) and described that SSH/WireGuard use provider-mapped non-standard ports rather than default ports.
  * Updated example templates to reference claudie-config v0.11.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->