### PR TITLE
add manifest state timestamp

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/manager
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 930a140-4255
+  newTag: 1f565b0-4261

--- a/proto/pb/spec/manifest.pb.go
+++ b/proto/pb/spec/manifest.pb.go
@@ -436,6 +436,7 @@ type Manifest struct {
 	Checksum            []byte                 `protobuf:"bytes,2,opt,name=checksum,proto3" json:"checksum,omitempty"`
 	LastAppliedChecksum []byte                 `protobuf:"bytes,3,opt,name=lastAppliedChecksum,proto3" json:"lastAppliedChecksum,omitempty"`
 	State               Manifest_State         `protobuf:"varint,4,opt,name=state,proto3,enum=spec.Manifest_State" json:"state,omitempty"`
+	StateTimestamp      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=stateTimestamp,proto3" json:"stateTimestamp,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -496,6 +497,13 @@ func (x *Manifest) GetState() Manifest_State {
 		return x.State
 	}
 	return Manifest_Pending
+}
+
+func (x *Manifest) GetStateTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StateTimestamp
+	}
+	return nil
 }
 
 type Counters struct {
@@ -5921,12 +5929,13 @@ const file_spec_manifest_proto_rawDesc = "" +
 	"\bclusters\x18\x05 \x03(\v2\x1a.spec.Config.ClustersEntryR\bclusters\x1aO\n" +
 	"\rClustersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12(\n" +
-	"\x05value\x18\x02 \x01(\v2\x12.spec.ClusterStateR\x05value:\x028\x01\"\xd0\x01\n" +
+	"\x05value\x18\x02 \x01(\v2\x12.spec.ClusterStateR\x05value:\x028\x01\"\x94\x02\n" +
 	"\bManifest\x12\x10\n" +
 	"\x03raw\x18\x01 \x01(\tR\x03raw\x12\x1a\n" +
 	"\bchecksum\x18\x02 \x01(\fR\bchecksum\x120\n" +
 	"\x13lastAppliedChecksum\x18\x03 \x01(\fR\x13lastAppliedChecksum\x12*\n" +
-	"\x05state\x18\x04 \x01(\x0e2\x14.spec.Manifest.StateR\x05state\"8\n" +
+	"\x05state\x18\x04 \x01(\x0e2\x14.spec.Manifest.StateR\x05state\x12B\n" +
+	"\x0estateTimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0estateTimestamp\"8\n" +
 	"\x05State\x12\v\n" +
 	"\aPending\x10\x00\x12\r\n" +
 	"\tScheduled\x10\x01\x12\b\n" +
@@ -6476,149 +6485,150 @@ var file_spec_manifest_proto_depIdxs = []int32{
 	7,   // 1: spec.Config.manifest:type_name -> spec.Manifest
 	28,  // 2: spec.Config.clusters:type_name -> spec.Config.ClustersEntry
 	3,   // 3: spec.Manifest.state:type_name -> spec.Manifest.State
-	29,  // 4: spec.Counters.k8sNodePoolScaleUpFailed:type_name -> spec.Counters.K8sNodePoolScaleUpFailedEntry
-	10,  // 5: spec.ClusterState.current:type_name -> spec.Clusters
-	14,  // 6: spec.ClusterState.state:type_name -> spec.Workflow
-	20,  // 7: spec.ClusterState.inFlight:type_name -> spec.TaskEvent
-	8,   // 8: spec.ClusterState.counters:type_name -> spec.Counters
-	15,  // 9: spec.Clusters.k8s:type_name -> spec.K8scluster
-	11,  // 10: spec.Clusters.loadBalancers:type_name -> spec.LoadBalancers
-	16,  // 11: spec.LoadBalancers.clusters:type_name -> spec.LBcluster
-	4,   // 12: spec.FinishedWorkflow.status:type_name -> spec.Workflow.Status
-	104, // 13: spec.FinishedWorkflow.timestamp:type_name -> google.protobuf.Timestamp
-	4,   // 14: spec.Workflow.status:type_name -> spec.Workflow.Status
-	13,  // 15: spec.Workflow.previous:type_name -> spec.FinishedWorkflow
-	17,  // 16: spec.K8scluster.clusterInfo:type_name -> spec.ClusterInfo
-	18,  // 17: spec.K8scluster.installationProxy:type_name -> spec.InstallationProxy
-	17,  // 18: spec.LBcluster.clusterInfo:type_name -> spec.ClusterInfo
-	19,  // 19: spec.LBcluster.roles:type_name -> spec.Role
-	105, // 20: spec.LBcluster.dns:type_name -> spec.DNS
-	106, // 21: spec.ClusterInfo.nodePools:type_name -> spec.NodePool
-	0,   // 22: spec.Role.roleType:type_name -> spec.RoleType
-	30,  // 23: spec.Role.settings:type_name -> spec.Role.Settings
-	104, // 24: spec.TaskEvent.timestamp:type_name -> google.protobuf.Timestamp
-	1,   // 25: spec.TaskEvent.event:type_name -> spec.Event
-	25,  // 26: spec.TaskEvent.task:type_name -> spec.Task
-	107, // 27: spec.TaskEvent.pipeline:type_name -> spec.Stage
-	20,  // 28: spec.TaskEvent.lowerPriority:type_name -> spec.TaskEvent
-	32,  // 29: spec.Unreachable.kubernetes:type_name -> spec.Unreachable.UnreachableNodePools
-	33,  // 30: spec.Unreachable.loadbalancers:type_name -> spec.Unreachable.LoadbalancersEntry
-	15,  // 31: spec.Create.k8s:type_name -> spec.K8scluster
-	16,  // 32: spec.Create.loadBalancers:type_name -> spec.LBcluster
-	35,  // 33: spec.Update.state:type_name -> spec.Update.State
-	36,  // 34: spec.Update.none:type_name -> spec.Update.None
-	41,  // 35: spec.Update.tfAddLoadBalancer:type_name -> spec.Update.TerraformerAddLoadBalancer
-	45,  // 36: spec.Update.tfAddLoadBalancerNodes:type_name -> spec.Update.TerraformerAddLoadBalancerNodes
-	50,  // 37: spec.Update.tfReplaceDns:type_name -> spec.Update.TerraformerReplaceDns
-	69,  // 38: spec.Update.tfAddK8sNodes:type_name -> spec.Update.TerraformerAddK8sNodes
-	48,  // 39: spec.Update.tfAddLoadBalancerRoles:type_name -> spec.Update.TerraformerAddLoadBalancerRoles
-	43,  // 40: spec.Update.tfDeleteLoadBalancerNodes:type_name -> spec.Update.TerraformerDeleteLoadBalancerNodes
-	37,  // 41: spec.Update.tfMoveNodePoolToAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolToAutoscaled
-	39,  // 42: spec.Update.tfMoveNodePoolFromAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolFromAutoscaled
-	58,  // 43: spec.Update.tfReplaceRoleExternalSettings:type_name -> spec.Update.TerraformerReplaceRoleExternalSettings
-	56,  // 44: spec.Update.ansReplaceProxy:type_name -> spec.Update.AnsiblerReplaceProxySettings
-	62,  // 45: spec.Update.ansReplaceTargetPools:type_name -> spec.Update.AnsiblerReplaceTargetPools
-	60,  // 46: spec.Update.ansReplaceRoleInternalSettings:type_name -> spec.Update.AnsiblerReplaceRoleInternalSettings
-	65,  // 47: spec.Update.kpatchNodes:type_name -> spec.Update.KuberPatchNodes
-	67,  // 48: spec.Update.kDeleteNodes:type_name -> spec.Update.KuberDeleteK8sNodes
-	42,  // 49: spec.Update.addedLoadBalancer:type_name -> spec.Update.AddedLoadBalancer
-	46,  // 50: spec.Update.addedLoadBalancerNodes:type_name -> spec.Update.AddedLoadBalancerNodes
-	51,  // 51: spec.Update.replacedDns:type_name -> spec.Update.ReplacedDns
-	70,  // 52: spec.Update.addedK8sNodes:type_name -> spec.Update.AddedK8sNodes
-	57,  // 53: spec.Update.replacedProxy:type_name -> spec.Update.ReplacedProxySettings
-	66,  // 54: spec.Update.patchedNodes:type_name -> spec.Update.PatchedNodes
-	49,  // 55: spec.Update.addedLoadBalancerRoles:type_name -> spec.Update.AddedLoadBalancerRoles
-	63,  // 56: spec.Update.replacedTargetPools:type_name -> spec.Update.ReplacedTargetPools
-	38,  // 57: spec.Update.movedNodePoolToAutoscaled:type_name -> spec.Update.MovedNodePoolToAutoscaled
-	40,  // 58: spec.Update.movedNodePoolFromAutoscaled:type_name -> spec.Update.MovedNodePoolFromAutoscaled
-	61,  // 59: spec.Update.replacedRoleInternalSettings:type_name -> spec.Update.ReplacedRoleInternalSettings
-	59,  // 60: spec.Update.replacedRoleExternalSettings:type_name -> spec.Update.ReplacedRoleExternalSettings
-	52,  // 61: spec.Update.deleteLoadBalancer:type_name -> spec.Update.DeleteLoadBalancer
-	68,  // 62: spec.Update.deletedK8sNodes:type_name -> spec.Update.DeletedK8sNodes
-	44,  // 63: spec.Update.deletedLoadBalancerNodes:type_name -> spec.Update.DeletedLoadBalancerNodes
-	47,  // 64: spec.Update.deleteLoadBalancerRoles:type_name -> spec.Update.DeleteLoadBalancerRoles
-	53,  // 65: spec.Update.apiEndpoint:type_name -> spec.Update.ApiEndpoint
-	55,  // 66: spec.Update.clusterApiPort:type_name -> spec.Update.ApiPortOnCluster
-	54,  // 67: spec.Update.k8sApiEndpoint:type_name -> spec.Update.K8sOnlyApiEndpoint
-	64,  // 68: spec.Update.upgradeVersion:type_name -> spec.Update.UpgradeVersion
-	15,  // 69: spec.Delete.k8s:type_name -> spec.K8scluster
-	16,  // 70: spec.Delete.loadBalancers:type_name -> spec.LBcluster
-	22,  // 71: spec.Task.create:type_name -> spec.Create
-	23,  // 72: spec.Task.update:type_name -> spec.Update
-	24,  // 73: spec.Task.delete:type_name -> spec.Delete
-	25,  // 74: spec.Work.task:type_name -> spec.Task
-	108, // 75: spec.Work.passes:type_name -> google.protobuf.Any
-	100, // 76: spec.TaskResult.error:type_name -> spec.TaskResult.Error
-	101, // 77: spec.TaskResult.none:type_name -> spec.TaskResult.None
-	102, // 78: spec.TaskResult.update:type_name -> spec.TaskResult.UpdateState
-	103, // 79: spec.TaskResult.clear:type_name -> spec.TaskResult.ClearState
-	9,   // 80: spec.Config.ClustersEntry.value:type_name -> spec.ClusterState
-	34,  // 81: spec.Unreachable.UnreachableNodePools.nodepools:type_name -> spec.Unreachable.UnreachableNodePools.NodepoolsEntry
-	32,  // 82: spec.Unreachable.LoadbalancersEntry.value:type_name -> spec.Unreachable.UnreachableNodePools
-	31,  // 83: spec.Unreachable.UnreachableNodePools.NodepoolsEntry.value:type_name -> spec.Unreachable.ListOfNodeEndpoints
-	15,  // 84: spec.Update.State.k8s:type_name -> spec.K8scluster
-	16,  // 85: spec.Update.State.loadBalancers:type_name -> spec.LBcluster
-	109, // 86: spec.Update.TerraformerMoveNodePoolToAutoscaled.config:type_name -> spec.AutoscalerConf
-	109, // 87: spec.Update.MovedNodePoolFromAutoscaled.config:type_name -> spec.AutoscalerConf
-	16,  // 88: spec.Update.TerraformerAddLoadBalancer.handle:type_name -> spec.LBcluster
-	21,  // 89: spec.Update.TerraformerDeleteLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
-	21,  // 90: spec.Update.DeletedLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
-	71,  // 91: spec.Update.DeletedLoadBalancerNodes.whole:type_name -> spec.Update.DeletedLoadBalancerNodes.WholeNodePool
-	72,  // 92: spec.Update.DeletedLoadBalancerNodes.partial:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial
-	74,  // 93: spec.Update.TerraformerAddLoadBalancerNodes.existing:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.Existing
-	75,  // 94: spec.Update.TerraformerAddLoadBalancerNodes.new:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.New
-	19,  // 95: spec.Update.TerraformerAddLoadBalancerRoles.roles:type_name -> spec.Role
-	105, // 96: spec.Update.TerraformerReplaceDns.dns:type_name -> spec.DNS
-	21,  // 97: spec.Update.DeleteLoadBalancer.unreachable:type_name -> spec.Unreachable
-	2,   // 98: spec.Update.ApiEndpoint.state:type_name -> spec.ApiEndpointChangeState
-	18,  // 99: spec.Update.AnsiblerReplaceProxySettings.proxy:type_name -> spec.InstallationProxy
-	0,   // 100: spec.Update.TerraformerReplaceRoleExternalSettings.roleType:type_name -> spec.RoleType
-	30,  // 101: spec.Update.AnsiblerReplaceRoleInternalSettings.settings:type_name -> spec.Role.Settings
-	77,  // 102: spec.Update.AnsiblerReplaceTargetPools.roles:type_name -> spec.Update.AnsiblerReplaceTargetPools.RolesEntry
-	79,  // 103: spec.Update.ReplacedTargetPools.roles:type_name -> spec.Update.ReplacedTargetPools.RolesEntry
-	86,  // 104: spec.Update.KuberPatchNodes.add:type_name -> spec.Update.KuberPatchNodes.AddBatch
-	85,  // 105: spec.Update.KuberPatchNodes.remove:type_name -> spec.Update.KuberPatchNodes.RemoveBatch
-	21,  // 106: spec.Update.KuberDeleteK8sNodes.unreachable:type_name -> spec.Unreachable
-	21,  // 107: spec.Update.DeletedK8sNodes.unreachable:type_name -> spec.Unreachable
-	95,  // 108: spec.Update.DeletedK8sNodes.whole:type_name -> spec.Update.DeletedK8sNodes.WholeNodePool
-	96,  // 109: spec.Update.DeletedK8sNodes.partial:type_name -> spec.Update.DeletedK8sNodes.Partial
-	98,  // 110: spec.Update.TerraformerAddK8sNodes.existing:type_name -> spec.Update.TerraformerAddK8sNodes.Existing
-	99,  // 111: spec.Update.TerraformerAddK8sNodes.new:type_name -> spec.Update.TerraformerAddK8sNodes.New
-	106, // 112: spec.Update.DeletedLoadBalancerNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
-	110, // 113: spec.Update.DeletedLoadBalancerNodes.Partial.nodes:type_name -> spec.Node
-	73,  // 114: spec.Update.DeletedLoadBalancerNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
-	110, // 115: spec.Update.TerraformerAddLoadBalancerNodes.Existing.nodes:type_name -> spec.Node
-	106, // 116: spec.Update.TerraformerAddLoadBalancerNodes.New.nodepool:type_name -> spec.NodePool
-	76,  // 117: spec.Update.AnsiblerReplaceTargetPools.RolesEntry.value:type_name -> spec.Update.AnsiblerReplaceTargetPools.TargetPools
-	78,  // 118: spec.Update.ReplacedTargetPools.RolesEntry.value:type_name -> spec.Update.ReplacedTargetPools.TargetPools
-	111, // 119: spec.Update.KuberPatchNodes.ListOfTaints.taints:type_name -> spec.Taint
-	87,  // 120: spec.Update.KuberPatchNodes.MapOfLabels.labels:type_name -> spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
-	88,  // 121: spec.Update.KuberPatchNodes.MapOfAnnotations.annotations:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
-	89,  // 122: spec.Update.KuberPatchNodes.RemoveBatch.taints:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
-	90,  // 123: spec.Update.KuberPatchNodes.RemoveBatch.annotations:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
-	91,  // 124: spec.Update.KuberPatchNodes.RemoveBatch.labels:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
-	92,  // 125: spec.Update.KuberPatchNodes.AddBatch.taints:type_name -> spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
-	93,  // 126: spec.Update.KuberPatchNodes.AddBatch.labels:type_name -> spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
-	94,  // 127: spec.Update.KuberPatchNodes.AddBatch.annotations:type_name -> spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
-	80,  // 128: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
-	82,  // 129: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfAnnotationKeys
-	81,  // 130: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfLabelKeys
-	80,  // 131: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
-	83,  // 132: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfLabels
-	84,  // 133: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations
-	106, // 134: spec.Update.DeletedK8sNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
-	110, // 135: spec.Update.DeletedK8sNodes.Partial.nodes:type_name -> spec.Node
-	97,  // 136: spec.Update.DeletedK8sNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
-	110, // 137: spec.Update.TerraformerAddK8sNodes.Existing.nodes:type_name -> spec.Node
-	106, // 138: spec.Update.TerraformerAddK8sNodes.New.nodepool:type_name -> spec.NodePool
-	5,   // 139: spec.TaskResult.Error.kind:type_name -> spec.TaskResult.Error.Kind
-	15,  // 140: spec.TaskResult.UpdateState.k8s:type_name -> spec.K8scluster
-	11,  // 141: spec.TaskResult.UpdateState.loadBalancers:type_name -> spec.LoadBalancers
-	142, // [142:142] is the sub-list for method output_type
-	142, // [142:142] is the sub-list for method input_type
-	142, // [142:142] is the sub-list for extension type_name
-	142, // [142:142] is the sub-list for extension extendee
-	0,   // [0:142] is the sub-list for field type_name
+	104, // 4: spec.Manifest.stateTimestamp:type_name -> google.protobuf.Timestamp
+	29,  // 5: spec.Counters.k8sNodePoolScaleUpFailed:type_name -> spec.Counters.K8sNodePoolScaleUpFailedEntry
+	10,  // 6: spec.ClusterState.current:type_name -> spec.Clusters
+	14,  // 7: spec.ClusterState.state:type_name -> spec.Workflow
+	20,  // 8: spec.ClusterState.inFlight:type_name -> spec.TaskEvent
+	8,   // 9: spec.ClusterState.counters:type_name -> spec.Counters
+	15,  // 10: spec.Clusters.k8s:type_name -> spec.K8scluster
+	11,  // 11: spec.Clusters.loadBalancers:type_name -> spec.LoadBalancers
+	16,  // 12: spec.LoadBalancers.clusters:type_name -> spec.LBcluster
+	4,   // 13: spec.FinishedWorkflow.status:type_name -> spec.Workflow.Status
+	104, // 14: spec.FinishedWorkflow.timestamp:type_name -> google.protobuf.Timestamp
+	4,   // 15: spec.Workflow.status:type_name -> spec.Workflow.Status
+	13,  // 16: spec.Workflow.previous:type_name -> spec.FinishedWorkflow
+	17,  // 17: spec.K8scluster.clusterInfo:type_name -> spec.ClusterInfo
+	18,  // 18: spec.K8scluster.installationProxy:type_name -> spec.InstallationProxy
+	17,  // 19: spec.LBcluster.clusterInfo:type_name -> spec.ClusterInfo
+	19,  // 20: spec.LBcluster.roles:type_name -> spec.Role
+	105, // 21: spec.LBcluster.dns:type_name -> spec.DNS
+	106, // 22: spec.ClusterInfo.nodePools:type_name -> spec.NodePool
+	0,   // 23: spec.Role.roleType:type_name -> spec.RoleType
+	30,  // 24: spec.Role.settings:type_name -> spec.Role.Settings
+	104, // 25: spec.TaskEvent.timestamp:type_name -> google.protobuf.Timestamp
+	1,   // 26: spec.TaskEvent.event:type_name -> spec.Event
+	25,  // 27: spec.TaskEvent.task:type_name -> spec.Task
+	107, // 28: spec.TaskEvent.pipeline:type_name -> spec.Stage
+	20,  // 29: spec.TaskEvent.lowerPriority:type_name -> spec.TaskEvent
+	32,  // 30: spec.Unreachable.kubernetes:type_name -> spec.Unreachable.UnreachableNodePools
+	33,  // 31: spec.Unreachable.loadbalancers:type_name -> spec.Unreachable.LoadbalancersEntry
+	15,  // 32: spec.Create.k8s:type_name -> spec.K8scluster
+	16,  // 33: spec.Create.loadBalancers:type_name -> spec.LBcluster
+	35,  // 34: spec.Update.state:type_name -> spec.Update.State
+	36,  // 35: spec.Update.none:type_name -> spec.Update.None
+	41,  // 36: spec.Update.tfAddLoadBalancer:type_name -> spec.Update.TerraformerAddLoadBalancer
+	45,  // 37: spec.Update.tfAddLoadBalancerNodes:type_name -> spec.Update.TerraformerAddLoadBalancerNodes
+	50,  // 38: spec.Update.tfReplaceDns:type_name -> spec.Update.TerraformerReplaceDns
+	69,  // 39: spec.Update.tfAddK8sNodes:type_name -> spec.Update.TerraformerAddK8sNodes
+	48,  // 40: spec.Update.tfAddLoadBalancerRoles:type_name -> spec.Update.TerraformerAddLoadBalancerRoles
+	43,  // 41: spec.Update.tfDeleteLoadBalancerNodes:type_name -> spec.Update.TerraformerDeleteLoadBalancerNodes
+	37,  // 42: spec.Update.tfMoveNodePoolToAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolToAutoscaled
+	39,  // 43: spec.Update.tfMoveNodePoolFromAutoscaled:type_name -> spec.Update.TerraformerMoveNodePoolFromAutoscaled
+	58,  // 44: spec.Update.tfReplaceRoleExternalSettings:type_name -> spec.Update.TerraformerReplaceRoleExternalSettings
+	56,  // 45: spec.Update.ansReplaceProxy:type_name -> spec.Update.AnsiblerReplaceProxySettings
+	62,  // 46: spec.Update.ansReplaceTargetPools:type_name -> spec.Update.AnsiblerReplaceTargetPools
+	60,  // 47: spec.Update.ansReplaceRoleInternalSettings:type_name -> spec.Update.AnsiblerReplaceRoleInternalSettings
+	65,  // 48: spec.Update.kpatchNodes:type_name -> spec.Update.KuberPatchNodes
+	67,  // 49: spec.Update.kDeleteNodes:type_name -> spec.Update.KuberDeleteK8sNodes
+	42,  // 50: spec.Update.addedLoadBalancer:type_name -> spec.Update.AddedLoadBalancer
+	46,  // 51: spec.Update.addedLoadBalancerNodes:type_name -> spec.Update.AddedLoadBalancerNodes
+	51,  // 52: spec.Update.replacedDns:type_name -> spec.Update.ReplacedDns
+	70,  // 53: spec.Update.addedK8sNodes:type_name -> spec.Update.AddedK8sNodes
+	57,  // 54: spec.Update.replacedProxy:type_name -> spec.Update.ReplacedProxySettings
+	66,  // 55: spec.Update.patchedNodes:type_name -> spec.Update.PatchedNodes
+	49,  // 56: spec.Update.addedLoadBalancerRoles:type_name -> spec.Update.AddedLoadBalancerRoles
+	63,  // 57: spec.Update.replacedTargetPools:type_name -> spec.Update.ReplacedTargetPools
+	38,  // 58: spec.Update.movedNodePoolToAutoscaled:type_name -> spec.Update.MovedNodePoolToAutoscaled
+	40,  // 59: spec.Update.movedNodePoolFromAutoscaled:type_name -> spec.Update.MovedNodePoolFromAutoscaled
+	61,  // 60: spec.Update.replacedRoleInternalSettings:type_name -> spec.Update.ReplacedRoleInternalSettings
+	59,  // 61: spec.Update.replacedRoleExternalSettings:type_name -> spec.Update.ReplacedRoleExternalSettings
+	52,  // 62: spec.Update.deleteLoadBalancer:type_name -> spec.Update.DeleteLoadBalancer
+	68,  // 63: spec.Update.deletedK8sNodes:type_name -> spec.Update.DeletedK8sNodes
+	44,  // 64: spec.Update.deletedLoadBalancerNodes:type_name -> spec.Update.DeletedLoadBalancerNodes
+	47,  // 65: spec.Update.deleteLoadBalancerRoles:type_name -> spec.Update.DeleteLoadBalancerRoles
+	53,  // 66: spec.Update.apiEndpoint:type_name -> spec.Update.ApiEndpoint
+	55,  // 67: spec.Update.clusterApiPort:type_name -> spec.Update.ApiPortOnCluster
+	54,  // 68: spec.Update.k8sApiEndpoint:type_name -> spec.Update.K8sOnlyApiEndpoint
+	64,  // 69: spec.Update.upgradeVersion:type_name -> spec.Update.UpgradeVersion
+	15,  // 70: spec.Delete.k8s:type_name -> spec.K8scluster
+	16,  // 71: spec.Delete.loadBalancers:type_name -> spec.LBcluster
+	22,  // 72: spec.Task.create:type_name -> spec.Create
+	23,  // 73: spec.Task.update:type_name -> spec.Update
+	24,  // 74: spec.Task.delete:type_name -> spec.Delete
+	25,  // 75: spec.Work.task:type_name -> spec.Task
+	108, // 76: spec.Work.passes:type_name -> google.protobuf.Any
+	100, // 77: spec.TaskResult.error:type_name -> spec.TaskResult.Error
+	101, // 78: spec.TaskResult.none:type_name -> spec.TaskResult.None
+	102, // 79: spec.TaskResult.update:type_name -> spec.TaskResult.UpdateState
+	103, // 80: spec.TaskResult.clear:type_name -> spec.TaskResult.ClearState
+	9,   // 81: spec.Config.ClustersEntry.value:type_name -> spec.ClusterState
+	34,  // 82: spec.Unreachable.UnreachableNodePools.nodepools:type_name -> spec.Unreachable.UnreachableNodePools.NodepoolsEntry
+	32,  // 83: spec.Unreachable.LoadbalancersEntry.value:type_name -> spec.Unreachable.UnreachableNodePools
+	31,  // 84: spec.Unreachable.UnreachableNodePools.NodepoolsEntry.value:type_name -> spec.Unreachable.ListOfNodeEndpoints
+	15,  // 85: spec.Update.State.k8s:type_name -> spec.K8scluster
+	16,  // 86: spec.Update.State.loadBalancers:type_name -> spec.LBcluster
+	109, // 87: spec.Update.TerraformerMoveNodePoolToAutoscaled.config:type_name -> spec.AutoscalerConf
+	109, // 88: spec.Update.MovedNodePoolFromAutoscaled.config:type_name -> spec.AutoscalerConf
+	16,  // 89: spec.Update.TerraformerAddLoadBalancer.handle:type_name -> spec.LBcluster
+	21,  // 90: spec.Update.TerraformerDeleteLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
+	21,  // 91: spec.Update.DeletedLoadBalancerNodes.unreachable:type_name -> spec.Unreachable
+	71,  // 92: spec.Update.DeletedLoadBalancerNodes.whole:type_name -> spec.Update.DeletedLoadBalancerNodes.WholeNodePool
+	72,  // 93: spec.Update.DeletedLoadBalancerNodes.partial:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial
+	74,  // 94: spec.Update.TerraformerAddLoadBalancerNodes.existing:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.Existing
+	75,  // 95: spec.Update.TerraformerAddLoadBalancerNodes.new:type_name -> spec.Update.TerraformerAddLoadBalancerNodes.New
+	19,  // 96: spec.Update.TerraformerAddLoadBalancerRoles.roles:type_name -> spec.Role
+	105, // 97: spec.Update.TerraformerReplaceDns.dns:type_name -> spec.DNS
+	21,  // 98: spec.Update.DeleteLoadBalancer.unreachable:type_name -> spec.Unreachable
+	2,   // 99: spec.Update.ApiEndpoint.state:type_name -> spec.ApiEndpointChangeState
+	18,  // 100: spec.Update.AnsiblerReplaceProxySettings.proxy:type_name -> spec.InstallationProxy
+	0,   // 101: spec.Update.TerraformerReplaceRoleExternalSettings.roleType:type_name -> spec.RoleType
+	30,  // 102: spec.Update.AnsiblerReplaceRoleInternalSettings.settings:type_name -> spec.Role.Settings
+	77,  // 103: spec.Update.AnsiblerReplaceTargetPools.roles:type_name -> spec.Update.AnsiblerReplaceTargetPools.RolesEntry
+	79,  // 104: spec.Update.ReplacedTargetPools.roles:type_name -> spec.Update.ReplacedTargetPools.RolesEntry
+	86,  // 105: spec.Update.KuberPatchNodes.add:type_name -> spec.Update.KuberPatchNodes.AddBatch
+	85,  // 106: spec.Update.KuberPatchNodes.remove:type_name -> spec.Update.KuberPatchNodes.RemoveBatch
+	21,  // 107: spec.Update.KuberDeleteK8sNodes.unreachable:type_name -> spec.Unreachable
+	21,  // 108: spec.Update.DeletedK8sNodes.unreachable:type_name -> spec.Unreachable
+	95,  // 109: spec.Update.DeletedK8sNodes.whole:type_name -> spec.Update.DeletedK8sNodes.WholeNodePool
+	96,  // 110: spec.Update.DeletedK8sNodes.partial:type_name -> spec.Update.DeletedK8sNodes.Partial
+	98,  // 111: spec.Update.TerraformerAddK8sNodes.existing:type_name -> spec.Update.TerraformerAddK8sNodes.Existing
+	99,  // 112: spec.Update.TerraformerAddK8sNodes.new:type_name -> spec.Update.TerraformerAddK8sNodes.New
+	106, // 113: spec.Update.DeletedLoadBalancerNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
+	110, // 114: spec.Update.DeletedLoadBalancerNodes.Partial.nodes:type_name -> spec.Node
+	73,  // 115: spec.Update.DeletedLoadBalancerNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedLoadBalancerNodes.Partial.StaticNodeKeysEntry
+	110, // 116: spec.Update.TerraformerAddLoadBalancerNodes.Existing.nodes:type_name -> spec.Node
+	106, // 117: spec.Update.TerraformerAddLoadBalancerNodes.New.nodepool:type_name -> spec.NodePool
+	76,  // 118: spec.Update.AnsiblerReplaceTargetPools.RolesEntry.value:type_name -> spec.Update.AnsiblerReplaceTargetPools.TargetPools
+	78,  // 119: spec.Update.ReplacedTargetPools.RolesEntry.value:type_name -> spec.Update.ReplacedTargetPools.TargetPools
+	111, // 120: spec.Update.KuberPatchNodes.ListOfTaints.taints:type_name -> spec.Taint
+	87,  // 121: spec.Update.KuberPatchNodes.MapOfLabels.labels:type_name -> spec.Update.KuberPatchNodes.MapOfLabels.LabelsEntry
+	88,  // 122: spec.Update.KuberPatchNodes.MapOfAnnotations.annotations:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations.AnnotationsEntry
+	89,  // 123: spec.Update.KuberPatchNodes.RemoveBatch.taints:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry
+	90,  // 124: spec.Update.KuberPatchNodes.RemoveBatch.annotations:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry
+	91,  // 125: spec.Update.KuberPatchNodes.RemoveBatch.labels:type_name -> spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry
+	92,  // 126: spec.Update.KuberPatchNodes.AddBatch.taints:type_name -> spec.Update.KuberPatchNodes.AddBatch.TaintsEntry
+	93,  // 127: spec.Update.KuberPatchNodes.AddBatch.labels:type_name -> spec.Update.KuberPatchNodes.AddBatch.LabelsEntry
+	94,  // 128: spec.Update.KuberPatchNodes.AddBatch.annotations:type_name -> spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry
+	80,  // 129: spec.Update.KuberPatchNodes.RemoveBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
+	82,  // 130: spec.Update.KuberPatchNodes.RemoveBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfAnnotationKeys
+	81,  // 131: spec.Update.KuberPatchNodes.RemoveBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfLabelKeys
+	80,  // 132: spec.Update.KuberPatchNodes.AddBatch.TaintsEntry.value:type_name -> spec.Update.KuberPatchNodes.ListOfTaints
+	83,  // 133: spec.Update.KuberPatchNodes.AddBatch.LabelsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfLabels
+	84,  // 134: spec.Update.KuberPatchNodes.AddBatch.AnnotationsEntry.value:type_name -> spec.Update.KuberPatchNodes.MapOfAnnotations
+	106, // 135: spec.Update.DeletedK8sNodes.WholeNodePool.nodepool:type_name -> spec.NodePool
+	110, // 136: spec.Update.DeletedK8sNodes.Partial.nodes:type_name -> spec.Node
+	97,  // 137: spec.Update.DeletedK8sNodes.Partial.staticNodeKeys:type_name -> spec.Update.DeletedK8sNodes.Partial.StaticNodeKeysEntry
+	110, // 138: spec.Update.TerraformerAddK8sNodes.Existing.nodes:type_name -> spec.Node
+	106, // 139: spec.Update.TerraformerAddK8sNodes.New.nodepool:type_name -> spec.NodePool
+	5,   // 140: spec.TaskResult.Error.kind:type_name -> spec.TaskResult.Error.Kind
+	15,  // 141: spec.TaskResult.UpdateState.k8s:type_name -> spec.K8scluster
+	11,  // 142: spec.TaskResult.UpdateState.loadBalancers:type_name -> spec.LoadBalancers
+	143, // [143:143] is the sub-list for method output_type
+	143, // [143:143] is the sub-list for method input_type
+	143, // [143:143] is the sub-list for extension type_name
+	143, // [143:143] is the sub-list for extension extendee
+	0,   // [0:143] is the sub-list for field type_name
 }
 
 func init() { file_spec_manifest_proto_init() }

--- a/proto/spec/manifest.proto
+++ b/proto/spec/manifest.proto
@@ -35,6 +35,7 @@ message Manifest {
   bytes checksum = 2;
   bytes lastAppliedChecksum = 3;
   State state = 4;
+  google.protobuf.Timestamp stateTimestamp = 5;
 }
 
 message Counters {

--- a/services/manager/internal/service/handler_upsert_manifest.go
+++ b/services/manager/internal/service/handler_upsert_manifest.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.yaml.in/yaml/v3"
 
@@ -47,9 +48,10 @@ func (s *Service) UpsertManifest(ctx context.Context, request *pb.UpsertManifest
 				Namespace: request.GetK8SCtx().GetNamespace(),
 			},
 			Manifest: store.Manifest{
-				Raw:      request.Manifest.Raw,
-				Checksum: request.Manifest.Checksum,
-				State:    request.Manifest.State.String(),
+				Raw:            request.Manifest.Raw,
+				Checksum:       request.Manifest.Checksum,
+				State:          request.Manifest.State.String(),
+				StateTimestamp: time.Now().UTC().Format(time.RFC3339),
 			},
 		}
 

--- a/services/manager/internal/service/watchers.go
+++ b/services/manager/internal/service/watchers.go
@@ -18,6 +18,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -179,6 +180,7 @@ func (s *Service) WatchForScheduledDocuments(ctx context.Context) error {
 				continue
 			}
 
+			scheduled.Manifest.StateTimestamp = time.Now().UTC().Format(time.RFC3339)
 			scheduled.Manifest.State = newManifestState.String()
 			if err := s.store.UpdateConfig(ctx, scheduled); err != nil {
 				if errors.Is(err, store.ErrNotFoundOrDirty) {
@@ -232,10 +234,12 @@ func (s *Service) WatchForPendingDocuments(ctx context.Context) error {
 			logger.Debug().Msgf("manifest is not ready to be scheduled, retrying again later")
 		case Reschedule:
 			pending.Manifest.State = spec.Manifest_Scheduled
+			pending.Manifest.StateTimestamp = timestamppb.New(time.Now().UTC())
 			logger.Debug().Msgf("Scheduling for intermediate tasks after which the config will be rescheduled again")
 		case NoReschedule:
 			logger.Debug().Msgf("Scheduling for tasks after which the config will not be rescheduled again")
 			pending.Manifest.State = spec.Manifest_Scheduled
+			pending.Manifest.StateTimestamp = timestamppb.New(time.Now().UTC())
 			pending.Manifest.LastAppliedChecksum = pending.Manifest.Checksum
 		}
 
@@ -294,6 +298,7 @@ func (s *Service) WatchForDoneOrErrorDocuments(ctx context.Context) error {
 			}
 
 			idle.Manifest.State = manifest.Pending.String()
+			idle.Manifest.StateTimestamp = time.Now().UTC().Format(time.RFC3339)
 
 			for cluster, state := range idle.Clusters {
 				currentEmpty := len(state.Current.K8s) == 0 && len(state.Current.LoadBalancers) == 0

--- a/services/manager/internal/store/api.go
+++ b/services/manager/internal/store/api.go
@@ -76,6 +76,7 @@ type Manifest struct {
 	Checksum            []byte `bson:"checksum"`
 	LastAppliedChecksum []byte `bson:"lastAppliedChecksum"`
 	State               string `bson:"state"`
+	StateTimestamp      string `bson:"stateTimestamp"`
 }
 
 type ClusterState struct {

--- a/services/manager/internal/store/convert_db_grpc.go
+++ b/services/manager/internal/store/convert_db_grpc.go
@@ -298,15 +298,18 @@ func ConvertFromGRPCWorkflow(w *spec.Workflow) Workflow {
 func ConvertToGRPCWorkflow(w Workflow) *spec.Workflow {
 	var previous []*spec.FinishedWorkflow
 	for _, p := range w.Previous {
+		var wftimestamp *timestamppb.Timestamp
 		t, err := time.Parse(time.RFC3339, p.Timestamp)
 		if err != nil {
-			t = time.Now().UTC()
+			wftimestamp = nil
+		} else {
+			wftimestamp = timestamppb.New(t)
 		}
 		t = t.UTC()
 		fw := &spec.FinishedWorkflow{
 			Status:          spec.Workflow_Status(spec.Workflow_Status_value[p.Status]),
 			TaskDescription: p.TaskDescription,
-			Timestamp:       timestamppb.New(t),
+			Timestamp:       wftimestamp,
 			Stage:           string(p.Stage),
 		}
 		previous = append(previous, fw)
@@ -360,9 +363,12 @@ func ConvertFromGRPC(cfg *spec.Config) (*Config, error) {
 // For clusters, it mimics the GRPC unmarshalling style where if a field was
 // not set within a message it will be nil instead of a zero value for that type.
 func ConvertToGRPC(cfg *Config) (*spec.Config, error) {
+	var manifestStateTimestamp *timestamppb.Timestamp
 	t, err := time.Parse(time.RFC3339, cfg.Manifest.StateTimestamp)
 	if err != nil {
-		t = time.Now().UTC()
+		manifestStateTimestamp = nil
+	} else {
+		manifestStateTimestamp = timestamppb.New(t)
 	}
 
 	grpc := spec.Config{
@@ -377,7 +383,7 @@ func ConvertToGRPC(cfg *Config) (*spec.Config, error) {
 			Checksum:            cfg.Manifest.Checksum,
 			LastAppliedChecksum: cfg.Manifest.LastAppliedChecksum,
 			State:               spec.Manifest_State(spec.Manifest_State_value[cfg.Manifest.State]),
-			StateTimestamp:      timestamppb.New(t),
+			StateTimestamp:      manifestStateTimestamp,
 		},
 		Clusters: nil,
 	}

--- a/services/manager/internal/store/convert_db_grpc.go
+++ b/services/manager/internal/store/convert_db_grpc.go
@@ -303,9 +303,8 @@ func ConvertToGRPCWorkflow(w Workflow) *spec.Workflow {
 		if err != nil {
 			wftimestamp = nil
 		} else {
-			wftimestamp = timestamppb.New(t)
+			wftimestamp = timestamppb.New(t.UTC())
 		}
-		t = t.UTC()
 		fw := &spec.FinishedWorkflow{
 			Status:          spec.Workflow_Status(spec.Workflow_Status_value[p.Status]),
 			TaskDescription: p.TaskDescription,

--- a/services/manager/internal/store/convert_db_grpc.go
+++ b/services/manager/internal/store/convert_db_grpc.go
@@ -300,7 +300,7 @@ func ConvertToGRPCWorkflow(w Workflow) *spec.Workflow {
 	for _, p := range w.Previous {
 		t, err := time.Parse(time.RFC3339, p.Timestamp)
 		if err != nil {
-			t = time.Now()
+			t = time.Now().UTC()
 		}
 		t = t.UTC()
 		fw := &spec.FinishedWorkflow{
@@ -334,6 +334,7 @@ func ConvertFromGRPC(cfg *spec.Config) (*Config, error) {
 			Checksum:            cfg.GetManifest().GetChecksum(),
 			LastAppliedChecksum: cfg.GetManifest().GetLastAppliedChecksum(),
 			State:               cfg.GetManifest().GetState().String(),
+			StateTimestamp:      cfg.GetManifest().GetStateTimestamp().AsTime().UTC().Format(time.RFC3339),
 		},
 		Clusters: nil,
 	}
@@ -359,6 +360,11 @@ func ConvertFromGRPC(cfg *spec.Config) (*Config, error) {
 // For clusters, it mimics the GRPC unmarshalling style where if a field was
 // not set within a message it will be nil instead of a zero value for that type.
 func ConvertToGRPC(cfg *Config) (*spec.Config, error) {
+	t, err := time.Parse(time.RFC3339, cfg.Manifest.StateTimestamp)
+	if err != nil {
+		t = time.Now().UTC()
+	}
+
 	grpc := spec.Config{
 		Version: cfg.Version,
 		Name:    cfg.Name,
@@ -371,6 +377,7 @@ func ConvertToGRPC(cfg *Config) (*spec.Config, error) {
 			Checksum:            cfg.Manifest.Checksum,
 			LastAppliedChecksum: cfg.Manifest.LastAppliedChecksum,
 			State:               spec.Manifest_State(spec.Manifest_State_value[cfg.Manifest.State]),
+			StateTimestamp:      timestamppb.New(t),
 		},
 		Clusters: nil,
 	}

--- a/services/manager/internal/store/convert_db_grpc_test.go
+++ b/services/manager/internal/store/convert_db_grpc_test.go
@@ -252,9 +252,7 @@ func TestConvertToGRPCWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			before := time.Now().UTC()
 			got := store.ConvertToGRPCWorkflow(tt.input)
-			after := time.Now().UTC()
 
 			// Special handling for the invalid timestamp case:
 			// the function falls back to time.Now(), so we verify
@@ -264,9 +262,7 @@ func TestConvertToGRPCWorkflow(t *testing.T) {
 				assert.Equal(t, "done", got.Description)
 				assert.Len(t, got.Previous, 1)
 
-				fallbackTs := got.Previous[0].Timestamp.AsTime().UTC()
-				assert.False(t, fallbackTs.Before(before.Truncate(time.Second)))
-				assert.False(t, fallbackTs.After(after.Add(time.Second)))
+				assert.Nil(t, got.Previous[0].Timestamp)
 
 				assert.Equal(t, spec.Workflow_DONE, got.Previous[0].Status)
 				assert.Equal(t, "previous", got.Previous[0].TaskDescription)
@@ -1153,9 +1149,10 @@ func TestConvertToDBAndBack(t *testing.T) {
 			Namespace: "test-04",
 		},
 		Manifest: &spec.Manifest{
-			Raw:      "random-manifest",
-			Checksum: hash.Digest("random-manifest"),
-			State:    spec.Manifest_Pending,
+			Raw:            "random-manifest",
+			Checksum:       hash.Digest("random-manifest"),
+			State:          spec.Manifest_Pending,
+			StateTimestamp: timestamppb.Now(),
 		},
 		Clusters: map[string]*spec.ClusterState{
 			"test-03": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests now include and persist a dedicated state timestamp whenever their state changes.

* **Bug Fixes**
  * Timestamp handling standardized: unparsable timestamps are no longer auto-replaced with the current time and will be returned as empty/null.

* **Tests**
  * Tests updated to cover the new state timestamp field and the revised behavior for invalid timestamps.

* **Chores**
  * Container image tags updated for deployment manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->