### PR TITLE
chore: update mongo to 8.3

### DIFF
--- a/manifests/claudie/mongo/mongodb.yaml
+++ b/manifests/claudie/mongo/mongodb.yaml
@@ -26,7 +26,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/db
-          image: mongo:8.0
+          image: mongo:8.3
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2051

Since this will require manual steps the next claudie release needs to bump the minor version.
(Backups of Mongo will need to be done before upgrading)

Before deploying the new Claudie version with the updated Mongo **the deployment needs to be scaled down to 0**

```bash
kubectl scale deploy/mongodb -n claudie --replicas=0
```

After deploying the new Claudie with the updated mongodb

1. Check if the version running in the primary replica is 8.3 via

```
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand({ buildInfo: 1 }).version"
```

2. Set the feature set to version 8.3

```bash
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand( { setFeatureCompatibilityVersion: '8.3', confirm: true } )"
```

This command must perform writes to an internal system collection. If for any reason the command does not complete successfully, you can safely retry the command as the operation is idempotent.

3. Verify the command successfully updated the feature set.

```bash
kubectl exec -it <primary-mongo-pod> -n claudie -- mongosh \
  -u <username> -p <password> --authenticationDatabase admin \
  --eval "db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })"
```

The command should return `8.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB container image to version 8.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->