### PR TITLE
fix reconciliation cycle

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,16 +56,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/autoscaler-adapter
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/manager
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 1f565b0-4261
+  newTag: 4f42164-4266

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -177,7 +177,12 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 
 			clusterResult[cluster] = Noop
 
-			{
+			// There might be an inFlight task stored that has a copy of the previous
+			// state that failed and the diff will reconciliate it so that it is rolledback.
+			//
+			// The rollback would invalidate the changes made in this block thus only
+			// update the TargetSize if there is no failed InFlight task.
+			if state.InFlight == nil {
 				// Check historical counters for any loopback changes that
 				// needs to be done before looking at scheduling tasks,
 				for np, counter := range state.Counters.K8SNodePoolScaleUpFailed {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting node pool target-size updates when a rollback is already in-flight, improving stability during autoscaling failure recovery.
* **Chores**
  * Pinned multiple component container images to a new shared tag.
  * Updated the testing framework container image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->