### PR TITLE
Support GCP Spot VMs in dynamic nodepools

### DIFF
--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -359,6 +359,22 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 
   To see the default taints Claudie applies on each node, refer to [this section](#default-taints).
 
+- `spot` *(optional, bool, GCP only)*
+
+  When set to `true`, Claudie provisions the nodes in this nodepool as [GCP Spot VMs](https://cloud.google.com/compute/docs/instances/spot). Spot VMs are spare capacity instances offered at a 60–91% discount compared to on-demand pricing. In exchange, GCP may reclaim them with approximately 30 seconds of notice when capacity is needed elsewhere.
+
+  Constraints:
+
+  - Only supported for `gcp` provider nodepools. Setting `spot: true` on any other provider is rejected by the webhook.
+  - Only supported on worker (compute) nodepools. Setting `spot: true` on a control-plane nodepool is rejected by the webhook.
+
+  When `spot: true` is set, Claudie automatically applies the following to every node in the pool:
+
+  - Label: `claudie.io/spot=true`
+  - Taint: `claudie.io/spot=true:NoSchedule`
+
+  The taint prevents regular workloads from scheduling onto spot nodes. Only pods that explicitly declare a matching toleration will be scheduled there. See the [GCP Spot VM example](../gpu-example.md#gcp-spot-vm-example) for a complete usage example including the required pod toleration.
+
 ## Provider Spec
 
 Provider spec is an additional specification built on top of the data from any of the provider instance. Here are provider configuration examples for each individual provider: [aws](providers/aws.md), [azure](providers/azure.md), [cloudrift](providers/cloudrift.md), [exoscale](providers/exoscale.md), [gcp](providers/gcp.md), [cloudflare](providers/cloudflare.md), [hetzner](providers/hetzner.md), [oci](providers/oci.md), [ovh](providers/ovh.md) and [verda](providers/verda.md).
@@ -598,7 +614,10 @@ Collection of data Claudie uses to create a DNS record for the loadbalancer.
   | `kubernetes.io/os`               | Os family of the node.                           |
   | `kubernetes.io/arch`             | Architecture type of the CPU.                    |
   | `v1.kubeone.io/operating-system` | Os type of the node.                             |
+  | `claudie.io/spot`                | `true` — present only on GCP Spot VM nodepools.  |
 
 ### Default taints
 
   By default, Claudie applies only `node-role.kubernetes.io/control-plane` taint for control plane nodes, with effect `NoSchedule`, together with those defined by the user.
+
+  For GCP Spot VM nodepools (`spot: true`), Claudie additionally applies `claudie.io/spot=true:NoSchedule` on every node in the pool.

--- a/docs/input-manifest/gpu-example.md
+++ b/docs/input-manifest/gpu-example.md
@@ -122,6 +122,148 @@ spec:
     - Common GPU types: `nvidia-tesla-t4`, `nvidia-tesla-v100`, `nvidia-tesla-a100`, `nvidia-l4`
     - GPU instances cannot be live migrated, so they will be terminated during maintenance events
 
+## GCP Spot VM Example
+
+[GCP Spot VMs](https://cloud.google.com/compute/docs/instances/spot) offer 60–91% cost savings over on-demand pricing. GCP may reclaim spot instances with approximately 30 seconds of notice. This makes them well suited for fault-tolerant, stateless workloads such as batch inference or autoscaled GPU workers.
+
+To request a spot nodepool, set `spot: true` on a GCP dynamic nodepool. Spot is only supported on worker (compute) nodepools and is rejected by the webhook on control-plane nodepools or non-GCP providers.
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: gcp-spot-example
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: gcp-1
+      providerType: gcp
+      secretRef:
+        name: gcp-secret
+        namespace: secrets
+
+  nodePools:
+    dynamic:
+    - name: control-gcp
+      providerSpec:
+        name: gcp-1
+        region: us-central1
+        zone: us-central1-a
+      count: 1
+      serverType: e2-medium
+      image: ubuntu-2404-noble-amd64-v20251001
+
+    - name: spot-workers
+      providerSpec:
+        name: gcp-1
+        region: us-central1
+        zone: us-central1-a
+      count: 2
+      serverType: n1-standard-4
+      image: ubuntu-2404-noble-amd64-v20251001
+      storageDiskSize: 50
+      # Request GCP Spot VMs for this nodepool (worker pools only).
+      spot: true
+
+  kubernetes:
+    clusters:
+      - name: spot-example
+        version: v1.34.0
+        network: 172.16.3.0/24
+        pools:
+          control:
+            - control-gcp
+          compute:
+            - spot-workers
+```
+
+Claudie automatically applies the label `claudie.io/spot=true` and the taint `claudie.io/spot=true:NoSchedule` to every node in the pool. To schedule a workload onto spot nodes, add a matching toleration to the pod spec:
+
+```yaml
+tolerations:
+  - key: claudie.io/spot
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+```
+
+## GCP Spot GPU Inference Example (Autoscaled)
+
+The example below combines GCP Spot VMs with GPU attachment and autoscaling, which is a common pattern for cost-effective GPU inference. The nodepool scales from zero when workloads are submitted and back down when idle.
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: gcp-spot-gpu-autoscaled
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: gcp-1
+      providerType: gcp
+      secretRef:
+        name: gcp-secret
+        namespace: secrets
+
+  nodePools:
+    dynamic:
+    - name: control-gcp
+      providerSpec:
+        name: gcp-1
+        region: us-central1
+        zone: us-central1-a
+      count: 1
+      serverType: e2-medium
+      image: ubuntu-2404-noble-amd64-v20251001
+
+    - name: spot-gpu-workers
+      providerSpec:
+        name: gcp-1
+        region: us-central1
+        zone: us-central1-a
+      # Use autoscaler instead of a fixed count; scales to zero when idle.
+      autoscaler:
+        min: 0
+        max: 4
+      serverType: n1-standard-4
+      image: ubuntu-2404-noble-amd64-v20251001
+      storageDiskSize: 50
+      machineSpec:
+        nvidiaGpuCount: 1
+        nvidiaGpuType: nvidia-tesla-t4
+      # GCP Spot VMs — significant cost savings for interruptible inference workloads.
+      spot: true
+
+  kubernetes:
+    clusters:
+      - name: spot-gpu-cluster
+        version: v1.34.0
+        network: 172.16.4.0/24
+        pools:
+          control:
+            - control-gcp
+          compute:
+            - spot-gpu-workers
+```
+
+!!! warning "Spot reclamation"
+    GCP may reclaim spot instances with approximately 30 seconds of notice. Design workloads on spot nodepools to handle abrupt termination gracefully (e.g. checkpoint frequently, use job restart policies).
+
+Pods that need to run on this nodepool must include both a spot toleration and a GPU resource request:
+
+```yaml
+tolerations:
+  - key: claudie.io/spot
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+resources:
+  limits:
+    nvidia.com/gpu: 1
+```
+
 ## Exoscale GPU Example
 
 For [Exoscale](providers/exoscale.md), GPU instances have the GPU built into the instance type (like AWS), so no additional `machineSpec` configuration is needed. Simply use a GPU instance type such as `gpu2.small` as the `serverType`:

--- a/docs/input-manifest/providers/gcp.md
+++ b/docs/input-manifest/providers/gcp.md
@@ -116,6 +116,12 @@ Common NVIDIA GPU accelerator types available on GCP:
 
 For a complete GPU deployment example including the NVIDIA GPU Operator installation, see the [GPU Example](../gpu-example.md).
 
+## Spot VM Support
+
+GCP Spot VMs are supported for worker nodepools. Set `spot: true` on any dynamic GCP nodepool to provision instances as [Spot VMs](https://cloud.google.com/compute/docs/instances/spot), which offer 60–91% cost savings over on-demand pricing at the cost of potential reclamation with ~30 seconds of notice.
+
+Spot is not supported on control-plane nodepools. See the [GCP Spot VM example](../gpu-example.md#gcp-spot-vm-example) for full usage details and the required pod toleration.
+
 ## Input manifest examples
 ### Single provider, multi region cluster example
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -9,7 +9,7 @@ Unplanned features (wishlist; talk to us for prioritization):
 - [ ] CLI read-only interface
 - [ ] Override for all manifest defaults
 - [ ] Service type: loadbalancer
-- [ ] Support for Spot & preemptible instances
+- [ ] Support for Spot & preemptible instances (GCP Spot VMs: done; other providers: planned)
 - [ ] Roadwarrior/Edge mode (on-premises node behind a NAT)
 
 v0.10.0:

--- a/internal/api/manifest/manifest.go
+++ b/internal/api/manifest/manifest.go
@@ -216,6 +216,12 @@ type DynamicNodePool struct {
 	Taints []k8sV1.Taint `validate:"omitempty" yaml:"taints" json:"taints"`
 	// MachineSpec further describe the properties of the selected server type.
 	MachineSpec *MachineSpec `validate:"omitempty" yaml:"machineSpec,omitempty" json:"machineSpec,omitempty"`
+	// Spot requests a discounted, pre-emptible instance from the cloud provider.
+	// The instance can be reclaimed at any time with short notice (~30s on GCP).
+	// Suitable for fault-tolerant, stateless, or autoscaled-from-0 workloads.
+	// Worker pools only. Currently supported on: GCP.
+	// +optional
+	Spot bool `validate:"omitempty" yaml:"spot,omitempty" json:"spot,omitempty"`
 }
 
 // Autoscaler configuration on per nodepool basis. Defines the number of nodes, autoscaler will scale up or down specific nodepool.

--- a/internal/api/manifest/utils.go
+++ b/internal/api/manifest/utils.go
@@ -436,6 +436,7 @@ func (ds *Manifest) CreateNodepools(pools []string, isControl bool) ([]*spec.Nod
 						Provider:            provider,
 						AutoscalerConfig:    autoscalerConf,
 						MachineSpec:         machineSpec,
+						Spot:                nodePool.Spot,
 					},
 				},
 			})

--- a/internal/api/manifest/validate_node_pool.go
+++ b/internal/api/manifest/validate_node_pool.go
@@ -130,6 +130,11 @@ func (d *DynamicNodePool) Validate(m *Manifest) error {
 		return err
 	}
 
+	// Validate Spot instance constraints
+	if err := d.validateSpot(m); err != nil {
+		return err
+	}
+
 	validate := validator.New()
 
 	if err := validate.RegisterValidation("external_net", validateExternalNet); err != nil {
@@ -168,6 +173,42 @@ func (d *DynamicNodePool) validateGCPGpuConfig(m *Manifest) error {
 
 	if gpuCount > 0 && d.MachineSpec.NvidiaGpuType == "" {
 		return fmt.Errorf("nvidiaGpuType is required for GCP when nvidiaGpuCount > 0")
+	}
+
+	return nil
+}
+
+// isControlPlane reports whether a nodepool name appears in any cluster's control-plane pool list.
+func isControlPlane(name string, m *Manifest) bool {
+	for _, k8s := range m.Kubernetes.Clusters {
+		for _, control := range k8s.Pools.Control {
+			if control == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validateSpot checks that spot instances are only requested on GCP worker pools.
+func (d *DynamicNodePool) validateSpot(m *Manifest) error {
+	if !d.Spot {
+		return nil
+	}
+
+	providerType, err := m.GetProviderType(d.ProviderSpec.Name)
+	if err != nil {
+		// Provider existence is validated in [NodePool.Validate] before
+		// calling [DynamicNodePool.Validate].
+		return nil
+	}
+
+	if providerType != "gcp" {
+		return fmt.Errorf("spot instances are only supported on GCP, provider %q has type %q", d.ProviderSpec.Name, providerType)
+	}
+
+	if isControlPlane(d.Name, m) {
+		return fmt.Errorf("spot instances are not allowed on control-plane nodepools (etcd data-corruption hazard)")
 	}
 
 	return nil

--- a/internal/api/manifest/validate_node_pool_test.go
+++ b/internal/api/manifest/validate_node_pool_test.go
@@ -1,0 +1,141 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSpot verifies the spot instance constraints for dynamic nodepools.
+func TestValidateSpot(t *testing.T) {
+	gcpManifest := &Manifest{
+		Providers: Provider{
+			GCP: []GCP{{
+				Name:        "gcp-1",
+				Credentials: "fake-credentials",
+				GCPProject:  "fake-project",
+			}},
+		},
+		Kubernetes: Kubernetes{
+			Clusters: []Cluster{
+				{
+					Name:    "cluster-1",
+					Network: "10.0.0.0/8",
+					Version: "v1.33.0",
+					Pools: Pool{
+						Control: []string{"control-np"},
+						Compute: []string{"worker-np"},
+					},
+				},
+			},
+		},
+	}
+
+	hetznerManifest := &Manifest{
+		Providers: Provider{
+			Hetzner: []Hetzner{{
+				Name:        "hetzner-1",
+				Credentials: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}},
+		},
+		Kubernetes: Kubernetes{
+			Clusters: []Cluster{
+				{
+					Name:    "cluster-1",
+					Network: "10.0.0.0/8",
+					Version: "v1.33.0",
+					Pools: Pool{
+						Compute: []string{"worker-np"},
+					},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		nodepool  *DynamicNodePool
+		manifest  *Manifest
+		wantError bool
+	}{
+		{
+			name: "spot on GCP worker pool passes",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "e2-medium",
+				Image:      "ubuntu-2204",
+				Count:      1,
+				Spot:       true,
+				ProviderSpec: ProviderSpec{
+					Name:   "gcp-1",
+					Region: "us-central1",
+					Zone:   "us-central1-a",
+				},
+			},
+			manifest:  gcpManifest,
+			wantError: false,
+		},
+		{
+			name: "spot on non-GCP provider fails",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "cx21",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				Spot:       true,
+				ProviderSpec: ProviderSpec{
+					Name:   "hetzner-1",
+					Region: "fsn1",
+					Zone:   "fsn1-dc14",
+				},
+			},
+			manifest:  hetznerManifest,
+			wantError: true,
+		},
+		{
+			name: "spot on GCP control-plane pool fails",
+			nodepool: &DynamicNodePool{
+				Name:       "control-np",
+				ServerType: "e2-medium",
+				Image:      "ubuntu-2204",
+				Count:      1,
+				Spot:       true,
+				ProviderSpec: ProviderSpec{
+					Name:   "gcp-1",
+					Region: "us-central1",
+					Zone:   "us-central1-a",
+				},
+			},
+			manifest:  gcpManifest,
+			wantError: true,
+		},
+		{
+			name: "spot=false on any provider passes",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "cx21",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				Spot:       false,
+				ProviderSpec: ProviderSpec{
+					Name:   "hetzner-1",
+					Region: "fsn1",
+					Zone:   "fsn1-dc14",
+				},
+			},
+			manifest:  hetznerManifest,
+			wantError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.nodepool.validateSpot(tc.manifest)
+			if tc.wantError {
+				require.Error(t, err, "expected error but got nil")
+			} else {
+				require.NoError(t, err, "expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/nodes/metadata.go
+++ b/internal/nodes/metadata.go
@@ -30,6 +30,7 @@ const (
 	KubernetesOs     LabelKey = "kubernetes.io~1os"
 	KubernetesArch   LabelKey = "kubernetes.io~1arch"
 	KubeoneOs        LabelKey = "v1.kubeone.io~1operating-system"
+	Spot             LabelKey = "claudie.io~1spot"
 )
 
 const (
@@ -77,6 +78,10 @@ func GetAllLabels(
 		m[string(KubernetesZone)] = sanitise.String(n.Zone)
 		m[string(KubernetesRegion)] = sanitise.String(n.Region)
 
+		if n.Spot {
+			m[string(Spot)] = "true"
+		}
+
 		if resolver != nil {
 			arch, err := resolver.Arch(np)
 			if err != nil {
@@ -116,6 +121,14 @@ func GetAllTaints(np *spec.NodePool, additionalTaints []*spec.Taint) []k8sV1.Tai
 			Effect: k8sV1.TaintEffect(t.Effect),
 		}
 		uniq[t] = struct{}{}
+	}
+
+	if n := np.GetDynamicNodePool(); n != nil && n.Spot {
+		uniq[k8sV1.Taint{
+			Key:    "claudie.io/spot",
+			Value:  "true",
+			Effect: k8sV1.TaintEffectNoSchedule,
+		}] = struct{}{}
 	}
 
 	// Claudie assigned taints.

--- a/internal/nodes/metadata_test.go
+++ b/internal/nodes/metadata_test.go
@@ -1,0 +1,116 @@
+package nodes
+
+import (
+	"testing"
+
+	"github.com/berops/claudie/proto/pb/spec"
+	k8sV1 "k8s.io/api/core/v1"
+)
+
+// dynamicNodePool builds a minimal *spec.NodePool with a DynamicNodePool inside.
+func dynamicNodePool(spot bool) *spec.NodePool {
+	return &spec.NodePool{
+		Name: "test-pool",
+		Type: &spec.NodePool_DynamicNodePool{
+			DynamicNodePool: &spec.DynamicNodePool{
+				Provider: &spec.Provider{
+					CloudProviderName: "gcp",
+					SpecName:          "my-gcp",
+				},
+				Region: "us-central1",
+				Zone:   "us-central1-a",
+				Spot:   spot,
+			},
+		},
+	}
+}
+
+// staticNodePool builds a minimal *spec.NodePool with a StaticNodePool inside.
+func staticNodePool() *spec.NodePool {
+	return &spec.NodePool{
+		Name: "static-pool",
+		Type: &spec.NodePool_StaticNodePool{
+			StaticNodePool: &spec.StaticNodePool{},
+		},
+	}
+}
+
+func TestGetAllLabels_SpotDynamicNodePool(t *testing.T) {
+	np := dynamicNodePool(true)
+
+	labels, err := GetAllLabels(np, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, ok := labels[string(Spot)]; !ok || got != "true" {
+		t.Errorf("expected label %q=true, got %q (present=%v)", Spot, got, ok)
+	}
+}
+
+func TestGetAllLabels_NonSpotDynamicNodePool(t *testing.T) {
+	np := dynamicNodePool(false)
+
+	labels, err := GetAllLabels(np, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, ok := labels[string(Spot)]; ok {
+		t.Errorf("expected no spot label, but got %q=%q", Spot, got)
+	}
+}
+
+func TestGetAllLabels_StaticNodePool_NoSpotLabel(t *testing.T) {
+	np := staticNodePool()
+
+	labels, err := GetAllLabels(np, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, ok := labels[string(Spot)]; ok {
+		t.Errorf("expected no spot label on static nodepool, but got %q=%q", Spot, got)
+	}
+}
+
+func TestGetAllTaints_SpotDynamicNodePool(t *testing.T) {
+	np := dynamicNodePool(true)
+
+	taints := GetAllTaints(np, nil)
+
+	var found bool
+	for _, taint := range taints {
+		if taint.Key == "claudie.io/spot" && taint.Value == "true" && taint.Effect == k8sV1.TaintEffectNoSchedule {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected NoSchedule taint claudie.io/spot=true, got %v", taints)
+	}
+}
+
+func TestGetAllTaints_NonSpotDynamicNodePool(t *testing.T) {
+	np := dynamicNodePool(false)
+
+	taints := GetAllTaints(np, nil)
+
+	for _, taint := range taints {
+		if taint.Key == "claudie.io/spot" {
+			t.Errorf("expected no spot taint, but got %v", taint)
+		}
+	}
+}
+
+func TestGetAllTaints_StaticNodePool_NoSpotTaint(t *testing.T) {
+	np := staticNodePool()
+
+	taints := GetAllTaints(np, nil)
+
+	for _, taint := range taints {
+		if taint.Key == "claudie.io/spot" {
+			t.Errorf("expected no spot taint on static nodepool, but got %v", taint)
+		}
+	}
+}

--- a/manifests/claudie/crd/claudie.io_inputmanifests.yaml
+++ b/manifests/claudie/crd/claudie.io_inputmanifests.yaml
@@ -364,6 +364,13 @@ spec:
                           description: "\tType of the machines in the nodepool. Currently,
                             only AMD64 machines are supported."
                           type: string
+                        spot:
+                          description: |-
+                            Spot requests a discounted, pre-emptible instance from the cloud provider.
+                            The instance can be reclaimed at any time with short notice (~30s on GCP).
+                            Suitable for fault-tolerant, stateless, or autoscaled-from-0 workloads.
+                            Worker pools only. Currently supported on: GCP.
+                          type: boolean
                         storageDiskSize:
                           description: |-
                             Size of the storage disk on the nodes in the nodepool in GB. The OS disk is created automatically
@@ -389,9 +396,8 @@ spec:
                                   to a node.
                                 type: string
                               timeAdded:
-                                description: |-
-                                  TimeAdded represents the time at which the taint was added.
-                                  It is only written for NoExecute taints.
+                                description: TimeAdded represents the time at which
+                                  the taint was added.
                                 format: date-time
                                 type: string
                               value:
@@ -486,9 +492,8 @@ spec:
                                   to a node.
                                 type: string
                               timeAdded:
-                                description: |-
-                                  TimeAdded represents the time at which the taint was added.
-                                  It is only written for NoExecute taints.
+                                description: TimeAdded represents the time at which
+                                  the taint was added.
                                 format: date-time
                                 type: string
                               value:

--- a/proto/pb/spec/nodepool.pb.go
+++ b/proto/pb/spec/nodepool.pb.go
@@ -535,8 +535,10 @@ type DynamicNodePool struct {
 	Cidr string `protobuf:"bytes,14,opt,name=cidr,proto3" json:"cidr,omitempty"`
 	// Network Name with public IPs (required for Openstack)
 	ExternalNetworkName string `protobuf:"bytes,15,opt,name=externalNetworkName,proto3" json:"externalNetworkName,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP.
+	Spot          bool `protobuf:"varint,16,opt,name=spot,proto3" json:"spot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DynamicNodePool) Reset() {
@@ -658,6 +660,13 @@ func (x *DynamicNodePool) GetExternalNetworkName() string {
 		return x.ExternalNetworkName
 	}
 	return ""
+}
+
+func (x *DynamicNodePool) GetSpot() bool {
+	if x != nil {
+		return x.Spot
+	}
+	return false
 }
 
 // MachineSpec further specifies the requested server type.
@@ -880,7 +889,7 @@ const file_spec_nodepool_proto_rawDesc = "" +
 	"\busername\x18\x05 \x01(\tR\busername\x12(\n" +
 	"\x06status\x18\x06 \x01(\x0e2\x10.spec.NodeStatusR\x06status\x12\x18\n" +
 	"\asshPort\x18\a \x01(\x05R\asshPort\x12$\n" +
-	"\rwireguardPort\x18\b \x01(\x05R\rwireguardPort\"\xda\x03\n" +
+	"\rwireguardPort\x18\b \x01(\x05R\rwireguardPort\"\xee\x03\n" +
 	"\x0fDynamicNodePool\x12\x1e\n" +
 	"\n" +
 	"serverType\x18\x01 \x01(\tR\n" +
@@ -899,7 +908,8 @@ const file_spec_nodepool_proto_rawDesc = "" +
 	"privateKey\x18\f \x01(\tR\n" +
 	"privateKey\x12\x12\n" +
 	"\x04cidr\x18\x0e \x01(\tR\x04cidr\x120\n" +
-	"\x13externalNetworkName\x18\x0f \x01(\tR\x13externalNetworkName\"\x8f\x01\n" +
+	"\x13externalNetworkName\x18\x0f \x01(\tR\x13externalNetworkName\x12\x12\n" +
+	"\x04spot\x18\x10 \x01(\bR\x04spot\"\x8f\x01\n" +
 	"\vMachineSpec\x12\x1a\n" +
 	"\bcpuCount\x18\x01 \x01(\x05R\bcpuCount\x12\x16\n" +
 	"\x06memory\x18\x02 \x01(\x05R\x06memory\x12&\n" +

--- a/proto/spec/nodepool.proto
+++ b/proto/spec/nodepool.proto
@@ -119,6 +119,8 @@ message DynamicNodePool {
   string cidr = 14;
   // Network Name with public IPs (required for Openstack)
   string externalNetworkName = 15;
+  // Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP.
+  bool spot = 16;
 }
 
 // MachineSpec further specifies the requested server type.


### PR DESCRIPTION
Adds an optional `spot` field to dynamic nodepools. On a GCP worker pool the nodes are provisioned as GCP Spot VMs (`provisioning_model = SPOT`), which cuts cost for fault-tolerant or autoscaled-from-zero workloads.

- New `spot` bool on DynamicNodePool (proto, manifest, CRD).
- Validation rejects `spot` on non-GCP providers and on control-plane pools.
- Spot nodes get the `claudie.io/spot=true` label and a `claudie.io/spot=true:NoSchedule` taint, so only tolerating pods land there.
- Docs plus a GPU inference example.

Needs the matching template change: berops/claudie-config#37.

Closes #2078