### PR TITLE
Support Verda spot instances in dynamic nodepools

### DIFF
--- a/docs/autoscaling/autoscaling.md
+++ b/docs/autoscaling/autoscaling.md
@@ -35,7 +35,10 @@ As Claudie just extends Cluster Autoscaler, it is important that you follow thei
 
 ## GPUs
 
-The custom Claudie-Provider for the [Cluster-Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) does not automatically determine whether the provided instance types have GPU capabilities. If you want autoscaling for a nodepool with GPUs, you must explicitly specify how many GPUs each node in the nodepool has.
+For most providers the custom Claudie-Provider for the [Cluster-Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) does not automatically determine whether the provided instance types have GPU capabilities. If you want autoscaling for a nodepool with GPUs, you must explicitly specify how many GPUs each node in the nodepool has.
+
+!!! note "Verda"
+    Verda is an exception: its instance-type catalog reports the GPU count per type, so Claudie derives it from the `serverType` automatically. For Verda GPU nodepools you do **not** need to set `machineSpec.nvidiaGpuCount` — picking a GPU `serverType` (e.g. `1A100.22V`) is enough for scale-from-zero to work.
 
 ```
 - name: autoscaled

--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -359,13 +359,13 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
 
   To see the default taints Claudie applies on each node, refer to [this section](#default-taints).
 
-- `spot` *(optional, bool, GCP only)*
+- `spot` *(optional, bool, GCP and Verda only)*
 
-  When set to `true`, Claudie provisions the nodes in this nodepool as [GCP Spot VMs](https://cloud.google.com/compute/docs/instances/spot). Spot VMs are spare capacity instances offered at a 60–91% discount compared to on-demand pricing. In exchange, GCP may reclaim them with approximately 30 seconds of notice when capacity is needed elsewhere.
+  When set to `true`, Claudie provisions the nodes in this nodepool as spot instances. Spot instances are spare capacity offered at a steep discount compared to on-demand pricing. In exchange, the provider may reclaim them with little notice when capacity is needed elsewhere (approximately 30 seconds on [GCP Spot VMs](https://cloud.google.com/compute/docs/instances/spot); Verda may evict at any time).
 
   Constraints:
 
-  - Only supported for `gcp` provider nodepools. Setting `spot: true` on any other provider is rejected by the webhook.
+  - Only supported for `gcp` and `verda` provider nodepools. Setting `spot: true` on any other provider is rejected by the webhook.
   - Only supported on worker (compute) nodepools. Setting `spot: true` on a control-plane nodepool is rejected by the webhook.
 
   When `spot: true` is set, Claudie automatically applies the following to every node in the pool:
@@ -373,7 +373,7 @@ Dynamic nodepools are defined for cloud provider machines that Claudie is expect
   - Label: `claudie.io/spot=true`
   - Taint: `claudie.io/spot=true:NoSchedule`
 
-  The taint prevents regular workloads from scheduling onto spot nodes. Only pods that explicitly declare a matching toleration will be scheduled there. See [GCP Spot VM support](providers/gcp.md#spot-vm-support) for a complete usage example including the required pod toleration.
+  The taint prevents regular workloads from scheduling onto spot nodes. Only pods that explicitly declare a matching toleration will be scheduled there. See [GCP Spot VM support](providers/gcp.md#spot-vm-support) or [Verda spot instance support](providers/verda.md#spot-instance-support) for a complete usage example including the required pod toleration.
 
 ## Provider Spec
 
@@ -614,10 +614,10 @@ Collection of data Claudie uses to create a DNS record for the loadbalancer.
   | `kubernetes.io/os`               | Os family of the node.                           |
   | `kubernetes.io/arch`             | Architecture type of the CPU.                    |
   | `v1.kubeone.io/operating-system` | Os type of the node.                             |
-  | `claudie.io/spot`                | `true` — present only on GCP Spot VM nodepools.  |
+  | `claudie.io/spot`                | `true` — present only on spot nodepools (GCP, Verda). |
 
 ### Default taints
 
   By default, Claudie applies only `node-role.kubernetes.io/control-plane` taint for control plane nodes, with effect `NoSchedule`, together with those defined by the user.
 
-  For GCP Spot VM nodepools (`spot: true`), Claudie additionally applies `claudie.io/spot=true:NoSchedule` on every node in the pool.
+  For spot nodepools (`spot: true`, supported on GCP and Verda), Claudie additionally applies `claudie.io/spot=true:NoSchedule` on every node in the pool.

--- a/docs/input-manifest/providers/verda.md
+++ b/docs/input-manifest/providers/verda.md
@@ -79,6 +79,74 @@ Verda specializes in GPU compute (A100, H100, B200, etc.). GPU instances are sel
 
 Like all Claudie-managed nodes, Verda VMs listen for SSH on **port 22522**. The cloud-init script reconfigures `sshd_config` and the `ssh.socket` listener accordingly during node provisioning.
 
+## Spot instance support
+
+Verda spot instances are supported for worker nodepools. Set `spot: true` on any dynamic Verda nodepool to provision the instances as spot (`is_spot = true` on the underlying `verda_instance`), which offers a discount over on-demand pricing. In exchange, Verda may evict spot instances at any time when capacity is needed. Spot is only supported on worker (compute) nodepools and is rejected by the webhook on control-plane nodepools or on non-supported providers.
+
+Claudie automatically applies the label `claudie.io/spot=true` and the taint `claudie.io/spot=true:NoSchedule` to every node in the pool, so only pods with a matching toleration are scheduled there.
+
+```yaml
+apiVersion: claudie.io/v1beta1
+kind: InputManifest
+metadata:
+  name: verda-spot-example
+  labels:
+    app.kubernetes.io/part-of: claudie
+spec:
+  providers:
+    - name: verda-1
+      providerType: verda
+      templates:
+        repository: "https://github.com/berops/claudie-config"
+        tag: v0.11.5
+        path: "templates/terraformer/verda"
+      secretRef:
+        name: verda-secret-1
+        namespace: <your-namespace>
+
+  nodePools:
+    dynamic:
+      - name: control-verda
+        providerSpec:
+          name: verda-1
+          region: FIN-01
+        count: 1
+        serverType: CPU.4V.16G
+        image: "ubuntu-24.04"
+
+      - name: spot-workers
+        providerSpec:
+          name: verda-1
+          region: FIN-01
+        count: 2
+        serverType: CPU.4V.16G
+        image: "ubuntu-24.04"
+        storageDiskSize: 100
+        # Request Verda spot instances for this nodepool (worker pools only).
+        spot: true
+
+  kubernetes:
+    clusters:
+      - name: verda-spot
+        version: "1.34.0"
+        network: 192.168.2.0/24
+        pools:
+          control:
+            - control-verda
+          compute:
+            - spot-workers
+```
+
+To schedule a workload onto spot nodes, add a matching toleration to the pod spec:
+
+```yaml
+tolerations:
+  - key: claudie.io/spot
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+```
+
 ## Input manifest examples
 
 ### Create a secret for Verda provider
@@ -106,7 +174,7 @@ spec:
       providerType: verda
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.11.1
+        tag: v0.11.5
         path: "templates/terraformer/verda"
       secretRef:
         name: verda-secret-1
@@ -162,7 +230,7 @@ spec:
       providerType: verda
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.11.1
+        tag: v0.11.5
         path: "templates/terraformer/verda"
       secretRef:
         name: verda-secret-1
@@ -216,7 +284,7 @@ spec:
       providerType: verda
       templates:
         repository: "https://github.com/berops/claudie-config"
-        tag: v0.11.1
+        tag: v0.11.5
         path: "templates/terraformer/verda"
       secretRef:
         name: verda-secret-1

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -9,7 +9,7 @@ Unplanned features (wishlist; talk to us for prioritization):
 - [ ] CLI read-only interface
 - [ ] Override for all manifest defaults
 - [ ] Service type: loadbalancer
-- [ ] Support for Spot & preemptible instances (GCP Spot VMs: done; other providers: planned)
+- [ ] Support for Spot & preemptible instances (GCP Spot VMs and Verda spot: done; other providers: planned)
 - [ ] Roadwarrior/Edge mode (on-premises node behind a NAT)
 
 v0.10.0:

--- a/internal/api/manifest/manifest.go
+++ b/internal/api/manifest/manifest.go
@@ -219,7 +219,7 @@ type DynamicNodePool struct {
 	// Spot requests a discounted, pre-emptible instance from the cloud provider.
 	// The instance can be reclaimed at any time with short notice (~30s on GCP).
 	// Suitable for fault-tolerant, stateless, or autoscaled-from-0 workloads.
-	// Worker pools only. Currently supported on: GCP.
+	// Worker pools only. Currently supported on: GCP, Verda.
 	// +optional
 	Spot bool `validate:"omitempty" yaml:"spot,omitempty" json:"spot,omitempty"`
 }

--- a/internal/api/manifest/validate_node_pool.go
+++ b/internal/api/manifest/validate_node_pool.go
@@ -190,7 +190,7 @@ func isControlPlane(name string, m *Manifest) bool {
 	return false
 }
 
-// validateSpot checks that spot instances are only requested on GCP worker pools.
+// validateSpot checks that spot instances are only requested on GCP or Verda worker pools.
 func (d *DynamicNodePool) validateSpot(m *Manifest) error {
 	if !d.Spot {
 		return nil
@@ -203,8 +203,8 @@ func (d *DynamicNodePool) validateSpot(m *Manifest) error {
 		return nil
 	}
 
-	if providerType != "gcp" {
-		return fmt.Errorf("spot instances are only supported on GCP, provider %q has type %q", d.ProviderSpec.Name, providerType)
+	if providerType != "gcp" && providerType != "verda" {
+		return fmt.Errorf("spot instances are only supported on GCP and Verda, provider %q has type %q", d.ProviderSpec.Name, providerType)
 	}
 
 	if isControlPlane(d.Name, m) {

--- a/internal/api/manifest/validate_node_pool_test.go
+++ b/internal/api/manifest/validate_node_pool_test.go
@@ -52,6 +52,28 @@ func TestValidateSpot(t *testing.T) {
 		},
 	}
 
+	verdaManifest := &Manifest{
+		Providers: Provider{
+			Verda: []Verda{{
+				Name:         "verda-1",
+				ClientId:     "fake-client-id",
+				ClientSecret: "fake-client-secret",
+			}},
+		},
+		Kubernetes: Kubernetes{
+			Clusters: []Cluster{
+				{
+					Name:    "cluster-1",
+					Network: "10.0.0.0/8",
+					Version: "v1.33.0",
+					Pools: Pool{
+						Compute: []string{"worker-np"},
+					},
+				},
+			},
+		},
+	}
+
 	cases := []struct {
 		name            string
 		nodepool        *DynamicNodePool
@@ -59,6 +81,22 @@ func TestValidateSpot(t *testing.T) {
 		wantError       bool
 		wantErrContains string
 	}{
+		{
+			name: "spot on Verda worker pool passes",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "Standard-1",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				Spot:       true,
+				ProviderSpec: ProviderSpec{
+					Name:   "verda-1",
+					Region: "eu-north-1",
+				},
+			},
+			manifest:  verdaManifest,
+			wantError: false,
+		},
 		{
 			name: "spot on GCP worker pool passes",
 			nodepool: &DynamicNodePool{

--- a/manifests/claudie/crd/claudie.io_inputmanifests.yaml
+++ b/manifests/claudie/crd/claudie.io_inputmanifests.yaml
@@ -369,7 +369,7 @@ spec:
                             Spot requests a discounted, pre-emptible instance from the cloud provider.
                             The instance can be reclaimed at any time with short notice (~30s on GCP).
                             Suitable for fault-tolerant, stateless, or autoscaled-from-0 workloads.
-                            Worker pools only. Currently supported on: GCP.
+                            Worker pools only. Currently supported on: GCP, Verda.
                           type: boolean
                         storageDiskSize:
                           description: |-

--- a/proto/pb/spec/nodepool.pb.go
+++ b/proto/pb/spec/nodepool.pb.go
@@ -535,7 +535,7 @@ type DynamicNodePool struct {
 	Cidr string `protobuf:"bytes,14,opt,name=cidr,proto3" json:"cidr,omitempty"`
 	// Network Name with public IPs (required for Openstack)
 	ExternalNetworkName string `protobuf:"bytes,15,opt,name=externalNetworkName,proto3" json:"externalNetworkName,omitempty"`
-	// Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP.
+	// Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP, Verda.
 	Spot          bool `protobuf:"varint,16,opt,name=spot,proto3" json:"spot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/spec/nodepool.proto
+++ b/proto/spec/nodepool.proto
@@ -119,7 +119,7 @@ message DynamicNodePool {
   string cidr = 14;
   // Network Name with public IPs (required for Openstack)
   string externalNetworkName = 15;
-  // Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP.
+  // Spot requests a discounted, pre-emptible (Spot) instance. Worker pools only. Currently supported on GCP, Verda.
   bool spot = 16;
 }
 


### PR DESCRIPTION
Allow `spot: true` on Verda worker nodepools (previously GCP-only). The spot label (`claudie.io/spot=true`) and taint (`claudie.io/spot=true:NoSchedule`) plumbing is already provider-agnostic, so this relaxes the validation gate to also permit Verda, refreshes the generated CRD and proto comment, and updates the docs.

Verda rendering (`is_spot = true` on `verda_instance`) lives in the companion claudie-config change. Verda GPU autoscaling capacity is fixed separately in berops/claudie-autoscaler.

Validated live on a Verda cluster: spot nodes provisioned with `is_spot`, carrying the spot label and taint; control plane unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verda provider now supports spot instances for dynamic worker nodepools, enabling cost-optimized cluster deployments.

* **Documentation**
  * Added comprehensive spot instance guidance for Verda, including configuration examples and scheduling mechanics with labels and taints.
  * Updated API reference and autoscaling documentation to reflect spot support across GCP and Verda.
  * Roadmap updated to show spot instance support completion for GCP and Verda.

* **Updates**
  * Template version examples updated to v0.11.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->