### PR TITLE
Faster handling of nodes with unknown status

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -1,69 +1,69 @@
 namespace: claudie
 resources:
-  - crd
-  - ns.yaml
-  - operator.yaml
-  - terraformer.yaml
-  - ansibler.yaml
-  - kube-eleven.yaml
-  - kuber.yaml
-  - manager.yaml
-  - cluster-rbac
-  - mongo
-  - minio
-  - nats
+- crd
+- ns.yaml
+- operator.yaml
+- terraformer.yaml
+- ansibler.yaml
+- kube-eleven.yaml
+- kuber.yaml
+- manager.yaml
+- cluster-rbac
+- mongo
+- minio
+- nats
 
 # Alter ValidatingWebhookConfiguration and Certificate fields, so they will match the generated namespace
 replacements:
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
-          - webhooks.*.clientConfig.service.namespace
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-  - source:
-      fieldPath: metadata.name
-      kind: Namespace
-    targets:
-      - fieldPaths:
-          - metadata.annotations.cert-manager\.io/inject-ca-from
-        options:
-          delimiter: /
-        select:
-          kind: ValidatingWebhookConfiguration
-          name: claudie-webhook
-      - fieldPaths:
-          - spec.dnsNames.*
-        options:
-          delimiter: .
-          index: 1
-        select:
-          kind: Certificate
-          name: claudie-webhook-certificate
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+- source:
+    fieldPath: metadata.name
+    kind: Namespace
+  targets:
+  - fieldPaths:
+    - metadata.annotations.cert-manager\.io/inject-ca-from
+    options:
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: claudie-webhook
+  - fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: .
+      index: 1
+    select:
+      kind: Certificate
+      name: claudie-webhook-certificate
 
 configMapGenerator:
-  - envs:
-      - .env
-    name: env
-    options:
-      labels:
-        app.kubernetes.io/part-of: claudie
+- envs:
+  - .env
+  name: env
+  options:
+    labels:
+      app.kubernetes.io/part-of: claudie
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: ghcr.io/berops/claudie/ansibler
-    newTag: 6b3f6e6-4300
-  - name: ghcr.io/berops/claudie/claudie-operator
-    newTag: 6b3f6e6-4300
-  - name: ghcr.io/berops/claudie/kube-eleven
-    newTag: 6b3f6e6-4300
-  - name: ghcr.io/berops/claudie/kuber
-    newTag: 6b3f6e6-4300
-  - name: ghcr.io/berops/claudie/manager
-    newTag: 6b3f6e6-4300
-  - name: ghcr.io/berops/claudie/terraformer
-    newTag: 6b3f6e6-4300
+- name: ghcr.io/berops/claudie/ansibler
+  newTag: 7a3283a-4304
+- name: ghcr.io/berops/claudie/claudie-operator
+  newTag: 7a3283a-4304
+- name: ghcr.io/berops/claudie/kube-eleven
+  newTag: 7a3283a-4304
+- name: ghcr.io/berops/claudie/kuber
+  newTag: 7a3283a-4304
+- name: ghcr.io/berops/claudie/manager
+  newTag: 7a3283a-4304
+- name: ghcr.io/berops/claudie/terraformer
+  newTag: 7a3283a-4304

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301
 - name: ghcr.io/berops/claudie/manager
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294
 - name: ghcr.io/berops/claudie/manager
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -2,91 +2,91 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: claudie
 resources:
-  - testing-framework.yaml
+- testing-framework.yaml
 
 secretGenerator:
-  - files:
-      - test-sets/test-set1/1.yaml
-      - test-sets/test-set1/2.yaml
-    name: test-set1
-  - files:
-      - test-sets/test-set2/1.yaml
-      - test-sets/test-set2/2.yaml
-      - test-sets/test-set2/3.yaml
-    name: test-set2
-  - files:
-      - test-sets/test-set3/1.yaml
-      - test-sets/test-set3/2.yaml
-      - test-sets/test-set3/3.yaml
-      - test-sets/test-set3/4.yaml
-    name: test-set3
-  - files:
-      - test-sets/test-set4/1.yaml
-      - test-sets/test-set4/2.yaml
-      - test-sets/test-set4/3.yaml
-    name: test-set4
-  - files:
-      - test-sets/test-set5/1.yaml
-      - test-sets/test-set5/2.yaml
-      - test-sets/test-set5/3.yaml
-    name: test-set5
-  - files:
-      - test-sets/rolling-update/1.yaml
-      - test-sets/rolling-update/2.yaml
-    name: rolling-update
-  - files:
-      - test-sets/rolling-update-2/1.yaml
-      - test-sets/rolling-update-2/2.yaml
-    name: rolling-update-2
-  - files:
-      - test-sets/autoscaling-1/1.yaml
-      - test-sets/autoscaling-1/2.yaml
-      - test-sets/autoscaling-1/3.yaml
-    name: autoscaling-1
-  - files:
-      - test-sets/autoscaling-2/1.yaml
-      - test-sets/autoscaling-2/2.yaml
-    name: autoscaling-2
-  - files:
-      - test-sets/proxy-with-hetzner/1.yaml
-      - test-sets/proxy-with-hetzner/2.yaml
-      - test-sets/proxy-with-hetzner/3.yaml
-      - test-sets/proxy-with-hetzner/4.yaml
-      - test-sets/proxy-with-hetzner/5.yaml
-      - test-sets/proxy-with-hetzner/6.yaml
-      - test-sets/proxy-with-hetzner/7.yaml
-    name: proxy-with-hetzner
-  - files:
-      - test-sets/proxy-without-hetzner/1.yaml
-      - test-sets/proxy-without-hetzner/2.yaml
-      - test-sets/proxy-without-hetzner/3.yaml
-      - test-sets/proxy-without-hetzner/4.yaml
-      - test-sets/proxy-without-hetzner/5.yaml
-      - test-sets/proxy-without-hetzner/6.yaml
-      - test-sets/proxy-without-hetzner/7.yaml
-      - test-sets/proxy-without-hetzner/8.yaml
-      - test-sets/proxy-without-hetzner/9.yaml
-      - test-sets/proxy-without-hetzner/10.yaml
-    name: proxy-without-hetzner
-  - files:
-      - test-sets/succeeds-on-last-1/1.yaml
-      - test-sets/succeeds-on-last-1/2.yaml
-    name: succeeds-on-last-1
-  - files:
-      - test-sets/succeeds-on-last-2/1.yaml
-      - test-sets/succeeds-on-last-2/2.yaml
-      - test-sets/succeeds-on-last-2/3.yaml
-    name: succeeds-on-last-2
-  - files:
-      - test-sets/succeeds-on-last-3/1.yaml
-      - test-sets/succeeds-on-last-3/2.yaml
-    name: succeeds-on-last-3
-  - files:
-      - test-sets/succeeds-on-last-4/1.yaml
-      - test-sets/succeeds-on-last-4/2.yaml
-      - test-sets/succeeds-on-last-4/3.yaml
-    name: succeeds-on-last-4
+- files:
+  - test-sets/test-set1/1.yaml
+  - test-sets/test-set1/2.yaml
+  name: test-set1
+- files:
+  - test-sets/test-set2/1.yaml
+  - test-sets/test-set2/2.yaml
+  - test-sets/test-set2/3.yaml
+  name: test-set2
+- files:
+  - test-sets/test-set3/1.yaml
+  - test-sets/test-set3/2.yaml
+  - test-sets/test-set3/3.yaml
+  - test-sets/test-set3/4.yaml
+  name: test-set3
+- files:
+  - test-sets/test-set4/1.yaml
+  - test-sets/test-set4/2.yaml
+  - test-sets/test-set4/3.yaml
+  name: test-set4
+- files:
+  - test-sets/test-set5/1.yaml
+  - test-sets/test-set5/2.yaml
+  - test-sets/test-set5/3.yaml
+  name: test-set5
+- files:
+  - test-sets/rolling-update/1.yaml
+  - test-sets/rolling-update/2.yaml
+  name: rolling-update
+- files:
+  - test-sets/rolling-update-2/1.yaml
+  - test-sets/rolling-update-2/2.yaml
+  name: rolling-update-2
+- files:
+  - test-sets/autoscaling-1/1.yaml
+  - test-sets/autoscaling-1/2.yaml
+  - test-sets/autoscaling-1/3.yaml
+  name: autoscaling-1
+- files:
+  - test-sets/autoscaling-2/1.yaml
+  - test-sets/autoscaling-2/2.yaml
+  name: autoscaling-2
+- files:
+  - test-sets/proxy-with-hetzner/1.yaml
+  - test-sets/proxy-with-hetzner/2.yaml
+  - test-sets/proxy-with-hetzner/3.yaml
+  - test-sets/proxy-with-hetzner/4.yaml
+  - test-sets/proxy-with-hetzner/5.yaml
+  - test-sets/proxy-with-hetzner/6.yaml
+  - test-sets/proxy-with-hetzner/7.yaml
+  name: proxy-with-hetzner
+- files:
+  - test-sets/proxy-without-hetzner/1.yaml
+  - test-sets/proxy-without-hetzner/2.yaml
+  - test-sets/proxy-without-hetzner/3.yaml
+  - test-sets/proxy-without-hetzner/4.yaml
+  - test-sets/proxy-without-hetzner/5.yaml
+  - test-sets/proxy-without-hetzner/6.yaml
+  - test-sets/proxy-without-hetzner/7.yaml
+  - test-sets/proxy-without-hetzner/8.yaml
+  - test-sets/proxy-without-hetzner/9.yaml
+  - test-sets/proxy-without-hetzner/10.yaml
+  name: proxy-without-hetzner
+- files:
+  - test-sets/succeeds-on-last-1/1.yaml
+  - test-sets/succeeds-on-last-1/2.yaml
+  name: succeeds-on-last-1
+- files:
+  - test-sets/succeeds-on-last-2/1.yaml
+  - test-sets/succeeds-on-last-2/2.yaml
+  - test-sets/succeeds-on-last-2/3.yaml
+  name: succeeds-on-last-2
+- files:
+  - test-sets/succeeds-on-last-3/1.yaml
+  - test-sets/succeeds-on-last-3/2.yaml
+  name: succeeds-on-last-3
+- files:
+  - test-sets/succeeds-on-last-4/1.yaml
+  - test-sets/succeeds-on-last-4/2.yaml
+  - test-sets/succeeds-on-last-4/3.yaml
+  name: succeeds-on-last-4
 
 images:
-  - name: ghcr.io/berops/claudie/testing-framework
-    newTag: 6b3f6e6-4300
+- name: ghcr.io/berops/claudie/testing-framework
+  newTag: 7a3283a-4304

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 39de96f-4294
+  newTag: ac1db09-4301

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ae314d1-4287
+  newTag: 39de96f-4294

--- a/services/ansibler/internal/worker/service/internal/ansible.go
+++ b/services/ansibler/internal/worker/service/internal/ansible.go
@@ -19,7 +19,7 @@ const (
 	InventoryFileName = "inventory.ini"
 
 	// maxAnsibleRetries defines how many times should be playbook retried before returning error.
-	maxAnsibleRetries = 4
+	maxAnsibleRetries = 3
 )
 
 // defaultAnsibleForks defines how many forks ansible uses (on how many nodes can ansible perform a task at the same time).

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -261,9 +261,12 @@ func HealthCheck(logger zerolog.Logger, state *spec.Clusters) HealthCheckStatus 
 					if cond.Status != corev1.ConditionTrue {
 						logger.
 							Warn().
-							Msgf("Kubernetes node %q is unhealthy with status: %q",
+							Msgf(
+								"Kubernetes node %q is unhealthy with status: %q, "+
+									"if the node does not become healthy, scheduling a reconciliation in %q",
 								n.Metadata.Name,
 								cond.Status,
+								max(TimeForNodeDeletion-time.Since(transitionTime.Time), 0*time.Second),
 							)
 
 						isReady = false

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -59,12 +59,15 @@ type UnknownNodeStatus struct {
 	//
 	// This structure contains nodes that are:
 	//  - nodes with no reachable endpoint.
-	//  - present in the current state but not in the kubernetes cluster.
 	//  - present in the kubernetes cluster but not in the current state
 	//  - present in both but with Unknown status.
 	//
 	// If the Api server of the cluster is unreachable, this will be empty.
 	UnknownKubernetesNodes map[string][]NodeDescription
+
+	// Nodepools and their nodes that were not joined into the kubernetes
+	// cluster but are present in the tracked currenct state.
+	NotJoinedKubernetesNodes map[string][]NodeDescription
 
 	// Loadbalancers attached to the kubernetes cluster and for each
 	// of them Nodepools with the nodes for which the pings have failed.
@@ -101,20 +104,18 @@ type HealthCheckStatus struct {
 	}
 }
 
-// HealthCheckNodeReachability performs healthchecks across the nodes of the passed in [spec.Clusters] state.
-// If there are any issues with the pinging of the nodes a non-nil error is returned which can be interpreted
-// as failing to fully determine if a node is reachable or not.
-func HealthCheckNodeReachability(
-	logger zerolog.Logger,
-	state *spec.Clusters,
-	hc HealthCheckStatus,
-) (UnknownNodeStatus, error) {
+// CheckNodeStatus reads the status across the nodes of the passed in [spec.Clusters] state.
+// For loadbalancers the machines are SSH pinged, if there are any issues with the pinging a
+// non-nil error is returned which can be interpreted as failing to fully determine if a node
+// is reachable or not.
+func CheckNodesStatus(logger zerolog.Logger, state *spec.Clusters, hc HealthCheckStatus) (UnknownNodeStatus, error) {
 	var (
 		err error
 
 		result = UnknownNodeStatus{
 			UnknownKubernetesNodes:    make(map[string][]NodeDescription),
 			UnknownLoadBalancersNodes: make(map[string]UnreachableIPv4Map),
+			NotJoinedKubernetesNodes:  map[string][]NodeDescription{},
 		}
 	)
 
@@ -147,7 +148,16 @@ func HealthCheckNodeReachability(
 							LastTransitionTime: v.LastTransitionTime.DeepCopy(),
 						})
 					}
-					continue
+				} else {
+					result.NotJoinedKubernetesNodes[np.Name] = append(result.NotJoinedKubernetesNodes[np.Name], NodeDescription{
+						K8sName:            strippedName,
+						Ready:              false,
+						IsStatic:           np.GetStaticNodePool() != nil,
+						NodePool:           np.Name,
+						PublicIPv4:         n.Public,
+						IsControl:          np.IsControl,
+						LastTransitionTime: nil,
+					})
 				}
 			}
 		}

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -258,6 +258,12 @@ func HealthCheck(logger zerolog.Logger, state *spec.Clusters) HealthCheckStatus 
 			for _, cond := range n.Status.Conditions {
 				if cond.Type == corev1.NodeReady {
 					transitionTime = cond.LastTransitionTime.DeepCopy()
+
+					t := time.Time{}
+					if transitionTime != nil {
+						t = transitionTime.Time
+					}
+
 					if cond.Status != corev1.ConditionTrue {
 						logger.
 							Warn().
@@ -266,7 +272,7 @@ func HealthCheck(logger zerolog.Logger, state *spec.Clusters) HealthCheckStatus 
 									"if the node does not become healthy, scheduling a reconciliation in %q",
 								n.Metadata.Name,
 								cond.Status,
-								max(TimeForNodeDeletion-time.Since(transitionTime.Time), 0*time.Second),
+								max(TimeForNodeDeletion-time.Since(t), 0*time.Second),
 							)
 
 						isReady = false

--- a/services/manager/internal/service/reconciliate_unreachable_nodes.go
+++ b/services/manager/internal/service/reconciliate_unreachable_nodes.go
@@ -135,16 +135,16 @@ func HandleKubernetesUnknownNodes(logger zerolog.Logger, r KubernetesUnreachable
 			}
 
 			diff := NodePoolsDiffResult{
-				Deleted: make(NodePoolsViewType, len(nodes)),
+				PartiallyDeleted: make(NodePoolsViewType, len(nodes)),
 			}
 
 			for _, n := range nodes {
 				if n.IsStatic {
-					diff.Deleted[cnp.Name] = append(diff.Deleted[cnp.Name], n.K8sName)
+					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], n.K8sName)
 				} else {
 					// k8s names have the cluster ID stripped.
 					fullname := fmt.Sprintf("%s-%s", r.Current.K8S.ClusterInfo.Id(), n.K8sName)
-					diff.Deleted[cnp.Name] = append(diff.Deleted[cnp.Name], fullname)
+					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], fullname)
 				}
 			}
 

--- a/services/manager/internal/service/reconciliate_unreachable_nodes.go
+++ b/services/manager/internal/service/reconciliate_unreachable_nodes.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -25,8 +26,8 @@ type KubernetesUnreachableNodes struct {
 	Desired    *spec.Clusters
 }
 
-// Based on the provided data via the [HealthCheckStatus] and [UnreachableNodes] determines what should be
-// done to unblock the unreachable nodes, the decision is returned via the (*[spec.TaskEvent], [error]) pair
+// Based on the provided data via the [HealthCheckStatus] and [UnknownNodeStatus] determines what should be
+// done to unblock the nodes with unknown status, the decision is returned via the (*[spec.TaskEvent], [error]) pair
 //
 // If an error is returned it means that the task cannot be scheduled due to needing input from the user as to
 // what should be done next with the unreachable state.
@@ -36,7 +37,17 @@ type KubernetesUnreachableNodes struct {
 //   - Nothing is returned (nil, nil), meaning that there is no task and also no error, the infrastructure is ok and reachable.
 //
 // If an [*spec.TaskEvent] is scheduled it does not point to or share any memory with the two passed in states.
-func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreachableNodes) (*spec.TaskEvent, error) {
+func HandleKubernetesUnknownNodes(logger zerolog.Logger, r KubernetesUnreachableNodes) (*spec.TaskEvent, error) {
+	unknownK8sNodes := make(map[string][]NodeDescription)
+
+	// Merge both cases, unknown status, and nodes that were not
+	// able to be joined into the cluster and consider them
+	// as unreachable forcing to be reconciled in the future.
+	maps.Copy(unknownK8sNodes, r.NodeStatus.UnknownKubernetesNodes)
+	for k, v := range r.NodeStatus.NotJoinedKubernetesNodes {
+		unknownK8sNodes[k] = append(unknownK8sNodes[k], v...)
+	}
+
 	var (
 		// error that is gradually populated with the unreachable nodes info.
 		errUnreachable error
@@ -50,7 +61,7 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 		}
 	)
 
-	for np, nodes := range r.NodeStatus.UnknownKubernetesNodes {
+	for np, nodes := range unknownK8sNodes {
 		var endpoints []string
 
 		for _, n := range nodes {
@@ -74,7 +85,7 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 		}
 	}
 
-	for np, nodes := range r.NodeStatus.UnknownKubernetesNodes {
+	for np, nodes := range unknownK8sNodes {
 		// cnp could be nil if a node is in the k8s cluster that
 		// is not tracked by claudie.
 		cnp := nodepools.FindByName(np, r.Current.K8S.ClusterInfo.NodePools)
@@ -87,7 +98,7 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 					// Deleting nodes from the last control plane nodepool will result in an invalid cluster.
 					errUnreachable = errors.Join(
 						errUnreachable,
-						fmt.Errorf("can't delete unreachable nodes from nodepool %q, the "+
+						fmt.Errorf("can't delete nodes with unknown status from nodepool %q, the "+
 							"nodepool is the last control nodepool, the deletion would result in a broken cluster",
 							np,
 						),
@@ -106,7 +117,7 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 					// risky, but a way out of the deadlock.
 					errUnreachable = errors.Join(
 						errUnreachable,
-						fmt.Errorf("can't delete nodepool %q with unreachable nodes, the "+
+						fmt.Errorf("can't delete nodepool %q with unknown node status, the "+
 							"nodepool has the kubeapi server endpoint which would result in a broken cluster",
 							np,
 						),
@@ -124,35 +135,39 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 			}
 
 			diff := NodePoolsDiffResult{
-				PartiallyDeleted: make(NodePoolsViewType, len(nodes)),
+				Deleted: make(NodePoolsViewType, len(nodes)),
 			}
 
 			for _, n := range nodes {
 				if n.IsStatic {
-					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], n.K8sName)
+					diff.Deleted[cnp.Name] = append(diff.Deleted[cnp.Name], n.K8sName)
 				} else {
 					// k8s names have the cluster ID stripped.
 					fullname := fmt.Sprintf("%s-%s", r.Current.K8S.ClusterInfo.Id(), n.K8sName)
-					diff.PartiallyDeleted[cnp.Name] = append(diff.PartiallyDeleted[cnp.Name], fullname)
+					diff.Deleted[cnp.Name] = append(diff.Deleted[cnp.Name], fullname)
 				}
 			}
+
+			logger.
+				Info().
+				Msgf(
+					"Nodepool %q is scheduled for deletion as it has no desired state and nodes with unhealthy status", cnp.Name,
+				)
 
 			next := ScheduleDeletionsInNodePools(r.Current, &diff, opts)
 			return next, nil
 		}
 
-		for _, n := range nodes {
-			fullname := fmt.Sprintf("%s-%s", r.Current.K8S.ClusterInfo.Id(), n.K8sName)
+		var canDelete []NodeDescription
 
+		// Keep only nodes we can delete.
+		for _, n := range nodes {
 			if n.LastTransitionTime != nil && time.Since(n.LastTransitionTime.Time) <= TimeForNodeDeletion {
 				continue
 			}
 
 			if n.IsStatic {
-				// static nodes do not have the cluster prefix.
-				fullname = n.K8sName
-
-				nn, node := nodepools.FindNode(r.Desired.K8S.ClusterInfo.NodePools, fullname)
+				nn, node := nodepools.FindNode(r.Desired.K8S.ClusterInfo.NodePools, n.K8sName)
 				if node != nil && nn.GetStaticNodePool() != nil {
 					if _, ok := r.Hc.Cluster.Nodes[n.K8sName]; ok {
 						errUnreachable = errors.Join(
@@ -177,33 +192,48 @@ func HandleKubernetesUnreachableNodes(logger zerolog.Logger, r KubernetesUnreach
 					}
 					continue
 				}
+
 				// fallthrough
 			}
 
-			if n.IsStatic {
-				logger.Info().Msgf("Removing node %q from the cluster", fullname)
-			} else {
-				logger.
-					Info().
-					Msgf("Replacing node %q in the cluster, as it was unhealthy for more than %s", fullname, TimeForNodeDeletion)
-			}
+			canDelete = append(canDelete, n)
+		}
 
-			opts := K8sNodeDeletionOptions{
+		if len(canDelete) < 1 {
+			continue
+		}
+
+		var (
+			diff = NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{}}
+			opts = K8sNodeDeletionOptions{
 				UseProxy:     r.Diff.Proxy.CurrentUsed,
 				HasApiServer: r.Diff.ApiEndpoint.Current != "",
-				IsStatic:     n.IsStatic,
+				IsStatic:     canDelete[0].IsStatic,
 				Unreachable:  &unreachableInfra,
 			}
+		)
 
-			diff := NodePoolsDiffResult{
-				PartiallyDeleted: NodePoolsViewType{
-					np: []string{fullname},
-				},
+		for _, n := range canDelete {
+			var fullname string
+			if n.IsStatic {
+				fullname = n.K8sName
+			} else {
+				fullname = fmt.Sprintf("%s-%s", r.Current.K8S.ClusterInfo.Id(), n.K8sName)
 			}
-
-			next := ScheduleDeletionsInNodePools(r.Current, &diff, opts)
-			return next, nil
+			diff.PartiallyDeleted[np] = append(diff.PartiallyDeleted[np], fullname)
 		}
+
+		logger.
+			Info().
+			Msgf(
+				"Reconciling %d nodes from nodepool %q due to being unhealthy: %v",
+				len(canDelete),
+				np,
+				slices.Collect(maps.Values(diff.PartiallyDeleted)),
+			)
+
+		next := ScheduleDeletionsInNodePools(r.Current, &diff, opts)
+		return next, nil
 	}
 
 	if errUnreachable != nil {
@@ -237,7 +267,7 @@ type LoadBalancerUnreachableNodes struct {
 }
 
 // Similar as [HandleKubernetesUnreachableNodes] but works with the loadbalancer nodes.
-func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.TaskEvent, error) {
+func HandleLoadBalancerUnknownNodes(r LoadBalancerUnreachableNodes) (*spec.TaskEvent, error) {
 	// for each loadbalancer check if the nodepool with the unreachable nodes is present in the desired
 	// state. If not issue a delete, if yes wait for either the connectivity issue to be resolved or the
 	// removal of the nodepool from the desired state.
@@ -257,7 +287,16 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 		}
 	)
 
-	for np, d := range r.NodeStatus.UnknownKubernetesNodes {
+	// Merge both cases, unknown status, and nodes that were not
+	// able to be joined into the cluster and consider them
+	// as unreachable forcing to be reconciled in the future.
+	unknownK8sNodes := make(map[string][]NodeDescription)
+	maps.Copy(unknownK8sNodes, r.NodeStatus.UnknownKubernetesNodes)
+	for k, v := range r.NodeStatus.NotJoinedKubernetesNodes {
+		unknownK8sNodes[k] = append(unknownK8sNodes[k], v...)
+	}
+
+	for np, d := range unknownK8sNodes {
 		var endpoints []string
 		for _, n := range d {
 			endpoints = append(endpoints, n.PublicIPv4)
@@ -285,7 +324,7 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 
 		clb := r.Current.LoadBalancers.Clusters[cid]
 		if did < 0 {
-			// cluster with the unrechable ips has been deleted from the desired state.
+			// cluster with the unreachable ips has been deleted from the desired state.
 			if clb.IsApiEndpoint() {
 				// deleted api endpoint in desired
 				//
@@ -296,10 +335,9 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 				// but a way out of the deadlock.
 				errUnreachable = errors.Join(
 					errUnreachable,
-					fmt.Errorf("can't delete loadbalancer %q with unreachable nodes, the loadbalancer is targeting"+
+					fmt.Errorf("can't delete loadbalancer %q containing nodes with unknown status, the loadbalancer is targeting"+
 						" the kube-api server and deleting it from the desired state would result in a broken kubernetes cluster", lb),
 				)
-
 				continue
 			}
 
@@ -345,6 +383,19 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 				return next, nil
 			}
 
+			// Note:
+			//
+			// in future this could delete the unreachable nodes
+			// as the loadbalancers has a manadatory DNS
+			// record which points to the VMs. the DNS
+			// wouldn't be deleted just updated with 0 nodes
+			// and then again updated with newly reconciled
+			// nodes.
+			//
+			// However for this to work we need to track for how
+			// long a loadbalancer is unresponsive for, which currently
+			// is not.
+
 			errMsg := strings.Builder{}
 			errMsg.WriteString("[")
 			for _, ip := range ips {
@@ -358,7 +409,7 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 			errMsg.WriteByte(']')
 			errUnreachable = errors.Join(
 				errUnreachable,
-				fmt.Errorf("nodepool %q from loadbalancer %q has %v unreachable loadbalancer node/s:\n %s", np, lb, len(ips), errMsg.String()),
+				fmt.Errorf("nodepool %q from loadbalancer %q has %v loadbalancer node/s with unknown status:\n %s", np, lb, len(ips), errMsg.String()),
 			)
 		}
 	}
@@ -366,7 +417,7 @@ func HandleLoadBalancerUnreachableNodes(r LoadBalancerUnreachableNodes) (*spec.T
 	if errUnreachable != nil {
 		// nolint
 		errUnreachable = fmt.Errorf(`
-Nodes within loadbalancers attached to the kubernetes cluster
+Node/s within loadbalancers attached to the kubernetes cluster
 have reachability problems.
 
 Fix the unreachable nodes by either:

--- a/services/manager/internal/service/reconciliate_unreachable_nodes.go
+++ b/services/manager/internal/service/reconciliate_unreachable_nodes.go
@@ -200,6 +200,7 @@ func HandleKubernetesUnknownNodes(logger zerolog.Logger, r KubernetesUnreachable
 		}
 
 		if len(canDelete) < 1 {
+			// Nothing to reconciliate, go to next nodepool.
 			continue
 		}
 
@@ -395,6 +396,10 @@ func HandleLoadBalancerUnknownNodes(r LoadBalancerUnreachableNodes) (*spec.TaskE
 			// However for this to work we need to track for how
 			// long a loadbalancer is unresponsive for, which currently
 			// is not.
+			//
+			// Need to also consider the fact where claudie will not
+			// have internet access and no schedule a unwanted removal
+			// as a result of that.
 
 			errMsg := strings.Builder{}
 			errMsg.WriteString("[")

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -425,24 +425,9 @@ Failed to extract state from failed 'InFlight' state: %v
 					// should be issued.
 					clusterResult[cluster] = NotReady
 
-					state.State.TicksUntilRefresh = max(state.State.TicksUntilRefresh, 0)
-					state.State.TicksUntilRefresh -= 1
-
-					if state.State.TicksUntilRefresh <= 0 {
-						clusterResult[cluster] = Reschedule
-
-						logger.
-							Info().
-							Msg("No task was scheduled for a while, issuing a refresh of the infrastructure")
-
-						logger.
-							Info().
-							Msg("Verifying reachability of the cluster before scheduling task to work on")
-
-						// Before scheduling any new task, healthcheck the reachability of the
-						// build infrastructure to avoid any issues with unreachable nodes during
-						// the building of the task, in which case this takes a higher priority
-						// then the scheduled task.
+					if len(nodesStatus.NotJoinedKubernetesNodes)+len(nodesStatus.UnknownKubernetesNodes) > 0 {
+						// Check the reachability of the build infrastructure to avoid any
+						// ssues with unreachable nodes.
 						//
 						// For handling unreachable nodes use the actual `desiredState` as is in the
 						// InputManifest needs to be used as nodes could have been manually deleted by the user.
@@ -475,6 +460,17 @@ Failed to extract state from failed 'InFlight' state: %v
 							state.InFlight = next
 							break event_switch
 						}
+					}
+
+					state.State.TicksUntilRefresh = max(state.State.TicksUntilRefresh, 0)
+					state.State.TicksUntilRefresh -= 1
+
+					if state.State.TicksUntilRefresh <= 0 {
+						clusterResult[cluster] = Reschedule
+
+						logger.
+							Info().
+							Msg("No task was scheduled for a while, issuing a refresh of the infrastructure")
 
 						state.InFlight = ScheduleRefreshInfrastructure(current)
 					}

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -284,6 +284,19 @@ Failed to extract state from failed 'InFlight' state: %v
 
 			hc := HealthCheck(logger, current)
 			diff := Diff(current, localDesired)
+			nodesStatus, err := CheckNodesStatus(logger, current, hc)
+			if err != nil {
+				clusterResult[cluster] = NotReady
+
+				state.State.Status = spec.Workflow_ERROR
+				state.State.Description = fmt.Sprintf(
+					"Can't schedule task, failed to determine reachability of nodes of the clusters: %v",
+					err,
+				)
+
+				logger.Error().Msg(state.State.Description)
+				break event_switch
+			}
 
 			if shouldRescheduleInFlight(lastTask) {
 				clusterResult[cluster] = Reschedule
@@ -296,28 +309,15 @@ Failed to extract state from failed 'InFlight' state: %v
 				// built infrastructure to avoid any issues with unreachable nodes during
 				// the building of the task, in which case this takes a higher priority
 				// then the scheduled task.
-				rhc, err := HealthCheckNodeReachability(logger, current, hc)
-				if err != nil {
-					clusterResult[cluster] = NotReady
-
-					state.State.Status = spec.Workflow_ERROR
-					state.State.Description = fmt.Sprintf(
-						"Can't schedule task, failed to determine reachability of nodes of the clusters: %v",
-						err,
-					)
-
-					logger.Error().Msg(state.State.Description)
-					break event_switch
-				}
-
+				//
 				// For handling unreachable nodes use the actual `desiredState` as is in the
 				// InputManifest needs to be used as nodes could have been manually deleted by the user.
 				// Otherwise these changes will never be tracked and form a endless loop.
-				next, err := handleClusterReachability(logger, current, desiredState, diff, rhc, hc)
+				next, err := handleClusterUnknownNodes(logger, current, desiredState, diff, nodesStatus, hc)
 				if err != nil {
 					logger.
 						Debug().
-						Msg("Propagating error for unreachable nodes without working on any task")
+						Msg("Propagating error for nodes with unknown status without working on any task")
 
 					// Higher priority task can't be scheduled due to wait on user
 					// input on the unreachable nodes.
@@ -342,7 +342,7 @@ Failed to extract state from failed 'InFlight' state: %v
 				if next != nil && !areScheduledTasksEqual(lastTask, next) {
 					logger.
 						Info().
-						Msg("Scheduled Task with higher priority for unreachable nodes on the kubernetes level")
+						Msg("Scheduled Task with higher priority for nodes with unknown status on the kubernetes level")
 
 					next.LowerPriority = lastTask
 					state.InFlight = next
@@ -378,30 +378,17 @@ Failed to extract state from failed 'InFlight' state: %v
 				// build infrastructure to avoid any issues with unreachable nodes during
 				// the building of the task, in which case this takes a higher priority
 				// then the scheduled task.
-				rhc, err := HealthCheckNodeReachability(logger, current, hc)
-				if err != nil {
-					clusterResult[cluster] = NotReady
-
-					state.State.Status = spec.Workflow_ERROR
-					state.State.Description = fmt.Sprintf(
-						"Can't schedule task, failed to determine reachability of nodes of the clusters: %v",
-						err,
-					)
-
-					logger.Error().Msg(state.State.Description)
-					break event_switch
-				}
-
+				//
 				// For handling unreachable nodes use the actual `desiredState` as is in the
 				// InputManifest needs to be used as nodes could have been manually deleted by the user.
 				// Otherwise these changes will never be tracked and form a endless loop.
-				next, err := handleClusterReachability(logger, current, desiredState, diff, rhc, hc)
+				next, err := handleClusterUnknownNodes(logger, current, desiredState, diff, nodesStatus, hc)
 				if err != nil {
 					clusterResult[cluster] = NotReady
 
 					logger.
 						Debug().
-						Msg("Propagating error for unreachable nodes without working on any task")
+						Msg("Propagating error for nodes with unknown status without working on any task")
 
 					state.State.Status = spec.Workflow_ERROR
 					state.State.Description = err.Error()
@@ -417,7 +404,7 @@ Failed to extract state from failed 'InFlight' state: %v
 
 					logger.
 						Info().
-						Msg("Scheduled Task with higher priority for unreachable nodes on the kubernetes level")
+						Msg("Scheduled Task with higher priority for nodes with unknown status on the kubernetes level")
 
 					next.LowerPriority = lastTask
 					state.InFlight = next
@@ -456,30 +443,17 @@ Failed to extract state from failed 'InFlight' state: %v
 						// build infrastructure to avoid any issues with unreachable nodes during
 						// the building of the task, in which case this takes a higher priority
 						// then the scheduled task.
-						rhc, err := HealthCheckNodeReachability(logger, current, hc)
-						if err != nil {
-							clusterResult[cluster] = NotReady
-
-							state.State.Status = spec.Workflow_ERROR
-							state.State.Description = fmt.Sprintf(
-								"Can't schedule task, failed to determine reachability of nodes of the clusters: %v",
-								err,
-							)
-
-							logger.Error().Msg(state.State.Description)
-							break event_switch
-						}
-
+						//
 						// For handling unreachable nodes use the actual `desiredState` as is in the
 						// InputManifest needs to be used as nodes could have been manually deleted by the user.
 						// Otherwise these changes will never be tracked and form a endless loop.
-						next, err := handleClusterReachability(logger, current, desiredState, diff, rhc, hc)
+						next, err := handleClusterUnknownNodes(logger, current, desiredState, diff, nodesStatus, hc)
 						if err != nil {
 							clusterResult[cluster] = NotReady
 
 							logger.
 								Debug().
-								Msg("Propagating error for unreachable nodes without working on any task")
+								Msg("Propagating error for nodes with unknown status without working on any task")
 
 							state.State.Status = spec.Workflow_ERROR
 							state.State.Description = err.Error()
@@ -495,7 +469,7 @@ Failed to extract state from failed 'InFlight' state: %v
 
 							logger.
 								Info().
-								Msg("Scheduled Task with higher priority for unreachable nodes on the kubernetes level")
+								Msg("Scheduled Task with higher priority for nodes with unknown status on the kubernetes level")
 
 							next.LowerPriority = lastTask
 							state.InFlight = next
@@ -813,7 +787,7 @@ func shouldRescheduleInFlight(inFlight *spec.TaskEvent) bool {
 	}
 }
 
-func handleClusterReachability(
+func handleClusterUnknownNodes(
 	logger zerolog.Logger,
 	current *spec.Clusters,
 	desired *spec.Clusters,
@@ -821,6 +795,22 @@ func handleClusterReachability(
 	ns UnknownNodeStatus,
 	hc HealthCheckStatus,
 ) (*spec.TaskEvent, error) {
+	lbr := LoadBalancerUnreachableNodes{
+		NodeStatus: ns,
+		Diff:       &diff.Kubernetes,
+		Current:    current,
+		Desired:    desired,
+	}
+
+	// Handle loadbalancers first.
+	next, err := HandleLoadBalancerUnknownNodes(lbr)
+	if err != nil {
+		return nil, err
+	}
+	if next != nil {
+		return next, nil
+	}
+
 	kr := KubernetesUnreachableNodes{
 		Hc:         hc,
 		NodeStatus: ns,
@@ -829,23 +819,7 @@ func handleClusterReachability(
 		Desired:    desired,
 	}
 
-	next, err := HandleKubernetesUnreachableNodes(logger, kr)
-	if err != nil {
-		return nil, err
-	}
-	if next != nil {
-		return next, nil
-	}
-
-	// Same as with the kubernetes unreachable nodes.
-	lbr := LoadBalancerUnreachableNodes{
-		NodeStatus: ns,
-		Diff:       &diff.Kubernetes,
-		Current:    current,
-		Desired:    desired,
-	}
-
-	return HandleLoadBalancerUnreachableNodes(lbr)
+	return HandleKubernetesUnknownNodes(logger, kr)
 }
 
 // Compares if two [spec.TaskEvent] tasks are equal, while ignoring

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -425,7 +425,11 @@ Failed to extract state from failed 'InFlight' state: %v
 					// should be issued.
 					clusterResult[cluster] = NotReady
 
-					if len(nodesStatus.NotJoinedKubernetesNodes)+len(nodesStatus.UnknownKubernetesNodes) > 0 {
+					pendingUnhealthy := len(nodesStatus.NotJoinedKubernetesNodes) +
+						len(nodesStatus.UnknownKubernetesNodes) +
+						len(nodesStatus.UnknownLoadBalancersNodes)
+
+					if pendingUnhealthy > 0 {
 						// Check the reachability of the build infrastructure to avoid any
 						// ssues with unreachable nodes.
 						//

--- a/services/manager/internal/service/service.go
+++ b/services/manager/internal/service/service.go
@@ -45,7 +45,7 @@ var (
 
 	// Time after which if the Node's Ready status is still false will be
 	// replaced by claudie.
-	TimeForNodeDeletion = time.Duration(envs.GetOrDefaultInt("MANAGER_TIME_FOR_NODE_DELETION", 12)) * time.Minute
+	TimeForNodeDeletion = time.Duration(envs.GetOrDefaultInt("MANAGER_TIME_FOR_NODE_DELETION", 10)) * time.Minute
 )
 
 var _ pb.ManagerServiceServer = (*Service)(nil)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for nodes present in system state but not yet joined to the cluster, including them in status evaluation.
  * Reconciliation now prioritizes handling nodes with unknown status (including not-joined nodes) before other scheduled actions.

* **Bug Fixes**
  * Improved Kubernetes and load balancer behavior when node health is unknown or mixed.
  * Healthcheck warning logs now include additional reconciliation/scheduling timing context.
  * Node replacement/delete scheduling now defaults to **10 minutes** (was **12**) when unset.

* **Chores**
  * Reduced default Ansible playbook retry attempts by one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->