### PR TITLE
fix nil panic

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310
 - name: ghcr.io/berops/claudie/manager
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307
 - name: ghcr.io/berops/claudie/manager
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311
 - name: ghcr.io/berops/claudie/manager
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 1b5a274-4307
+  newTag: 80b6563-4310

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 7a3283a-4304
+  newTag: 1b5a274-4307

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -89,4 +89,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 80b6563-4310
+  newTag: 3d94fba-4311

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -893,7 +893,7 @@ func updateCredentials(current, desired *spec.Clusters) (updated bool) {
 		}
 
 		// DNS can be nil if they fail to be built.
-		if clb.Dns == nil || dlb.Dns == nil { return }
+		if clb.Dns != nil && dlb.Dns != nil {
 			if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
 				if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
 					updated = true

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -893,11 +893,15 @@ func updateCredentials(current, desired *spec.Clusters) (updated bool) {
 		}
 
 		// DNS can be nil if they fail to be built.
-		if clb.Dns != nil && dlb.Dns != nil {
-			if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
-				if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
-					updated = true
-				}
+		// A DNS is either created as a whole or not at all
+		// thats, why a DNS can be nil on failure.
+		if clb.Dns == nil || dlb.Dns == nil {
+			continue
+		}
+
+		if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
+			if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
+				updated = true
 			}
 		}
 	}

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -892,9 +892,12 @@ func updateCredentials(current, desired *spec.Clusters) (updated bool) {
 			}
 		}
 
-		if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
-			if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
-				updated = true
+		// DNS can be nil if they fail to be built.
+		if clb.Dns != nil && dlb.Dns != nil {
+			if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
+				if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
+					updated = true
+				}
 			}
 		}
 	}

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -893,7 +893,7 @@ func updateCredentials(current, desired *spec.Clusters) (updated bool) {
 		}
 
 		// DNS can be nil if they fail to be built.
-		if clb.Dns != nil && dlb.Dns != nil {
+		if clb.Dns == nil || dlb.Dns == nil { return }
 			if !clb.Dns.Provider.CredentialsEqual(dlb.Dns.Provider) {
 				if clb.Dns.Provider.CopyCredentials(dlb.Dns.Provider) {
 					updated = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential reconciliation to safely handle missing DNS settings for load balancer clusters.
  * Prevented potential crashes by only propagating DNS provider credentials when DNS details exist on both sides.
* **Chores**
  * Updated Claudie-related manifest image tags for both the Claudie and testing framework deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->