### PR TITLE
update kubeconfig name to omit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ For adding support for other cloud providers or on-premises environments, open a
     ***Deleting existing InputManifest resource deletes provisioned infrastructure!***
 
 ### Connect to your cluster
-Claudie outputs base64 encoded kubeconfig secret `<cluster-name>-<cluster-hash>-kubeconfig` in the namespace where it is deployed:
+Claudie outputs base64 encoded kubeconfig secret `<input-manifest-namespace>-<input-manifest-name>-<cluster-name>-kubeconfig` in the namespace where it is deployed:
 
 1. Recover kubeconfig of your cluster by running:
     ```bash

--- a/docs/commands/commands.md
+++ b/docs/commands/commands.md
@@ -33,8 +33,8 @@ Claudie creates kubeconfig secret in claudie namespace:
   kubectl get secrets -n claudie -l claudie.io/output=kubeconfig
   ```
   ```
-  NAME                                  TYPE     DATA   AGE
-  my-super-cluster-6ktx6rb-kubeconfig   Opaque   1      134m
+  NAME                                                TYPE     DATA   AGE
+  default-manifest-name-my-super-cluster-kubeconfig   Opaque   1      134m
   ```
 
   You can **recover kubeconfig** for your cluster with the following command:

--- a/docs/getting-started/detailed-guide.md
+++ b/docs/getting-started/detailed-guide.md
@@ -290,8 +290,8 @@ This detailed guide for Claudie serves as a resource for providing an overview o
     kubectl get secrets -n claudie -l claudie.io/output=kubeconfig
     ```
     ```
-    NAME                                  TYPE     DATA   AGE
-    my-super-cluster-6ktx6rb-kubeconfig   Opaque   1      134m
+    NAME                                                 TYPE     DATA   AGE
+    default-cloud-bursting-my-super-cluster-kubeconfig   Opaque   1      134m
     ```
 
     You can recover kubeconfig for your cluster with the following command:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -248,7 +248,7 @@ EOF
 
 ### Connect to your cluster(https://docs.claudie.io/latest/getting-started/get-started-using-claudie/\#connect-to-your-cluster)
 
-Claudie outputs base64 encoded kubeconfig secret `<cluster-name>-<cluster-hash>-kubeconfig` in the namespace where it is deployed:
+Claudie outputs base64 encoded kubeconfig secret `<input-manifest-namespace>-<input-manifest-name>-<cluster-name>-kubeconfig` in the namespace where it is deployed:
 
 1. Recover kubeconfig of your cluster by running:
 
@@ -623,8 +623,8 @@ In this example, two AWS providers are used — one with access to compute resou
     ```
 
     ```
-    NAME                                  TYPE     DATA   AGE
-    my-super-cluster-6ktx6rb-kubeconfig   Opaque   1      134m
+    NAME                                                 TYPE     DATA   AGE
+    default-cloud-bursting-my-super-cluster-kubeconfig   Opaque   1      134m
 
     ```
 
@@ -5291,8 +5291,8 @@ kubectl get secrets -n claudie -l claudie.io/output=kubeconfig
 ```
 
 ```
-NAME                                  TYPE     DATA   AGE
-my-super-cluster-6ktx6rb-kubeconfig   Opaque   1      134m
+NAME                                                TYPE     DATA   AGE
+default-manifest-name-my-super-cluster-kubeconfig   Opaque   1      134m
 
 ```
 

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427
 - name: ghcr.io/berops/claudie/manager
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386
 - name: ghcr.io/berops/claudie/kuber
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386
 - name: ghcr.io/berops/claudie/manager
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 3876bcc-4424
+  newTag: 6314238-4427

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: b4c932d-4362
+  newTag: 6ad6a1a-4386

--- a/services/manager/internal/service/managementcluster/delete_kubeconfig.go
+++ b/services/manager/internal/service/managementcluster/delete_kubeconfig.go
@@ -11,19 +11,17 @@ import (
 
 // DeleteKubeconfig deletes the K8s secret (in the management cluster) containing kubeconfig
 // for the given K8s cluster.
-func DeleteKubeconfig(clusters *spec.Clusters) error {
+func DeleteKubeconfig(manifestName string, clusters *spec.Clusters) error {
 	namespace := envs.Namespace
-	clusterID := clusters.K8S.ClusterInfo.Id()
 	if namespace == "" {
 		return nil
 	}
 
 	kc := kubectl.Kubectl{
 		MaxKubectlRetries: kubectl.NoRetries,
+		Stdout:            comm.GetStdOut(clusters.K8S.ClusterInfo.Id()),
+		Stderr:            comm.GetStdErr(clusters.K8S.ClusterInfo.Id()),
 	}
 
-	kc.Stdout = comm.GetStdOut(clusterID)
-	kc.Stderr = comm.GetStdErr(clusterID)
-
-	return kc.KubectlDeleteResource("secret", fmt.Sprintf("%s-kubeconfig", clusterID), "-n", namespace)
+	return kc.KubectlDeleteResource("secret", fmt.Sprintf("%s-%s-kubeconfig", manifestName, clusters.K8S.ClusterInfo.Name), "-n", namespace)
 }

--- a/services/manager/internal/service/managementcluster/delete_metadata.go
+++ b/services/manager/internal/service/managementcluster/delete_metadata.go
@@ -11,19 +11,17 @@ import (
 
 // DeleteClusterMetadata deletes the K8s secret (from the management cluster) containing cluster
 // metadata for the given K8s cluster.
-func DeleteClusterMetadata(clusters *spec.Clusters) error {
+func DeleteClusterMetadata(manifestName string, clusters *spec.Clusters) error {
 	namespace := envs.Namespace
-	clusterID := clusters.K8S.ClusterInfo.Id()
-
 	if namespace == "" {
 		return nil
 	}
 
 	kc := kubectl.Kubectl{
 		MaxKubectlRetries: kubectl.NoRetries,
-		Stdout:            comm.GetStdOut(clusterID),
-		Stderr:            comm.GetStdErr(clusterID),
+		Stdout:            comm.GetStdOut(clusters.K8S.ClusterInfo.Id()),
+		Stderr:            comm.GetStdErr(clusters.K8S.ClusterInfo.Id()),
 	}
 
-	return kc.KubectlDeleteResource("secret", fmt.Sprintf("%s-metadata", clusterID), "-n", namespace)
+	return kc.KubectlDeleteResource("secret", fmt.Sprintf("%s-%s-metadata", manifestName, clusters.K8S.ClusterInfo.Name), "-n", namespace)
 }

--- a/services/manager/internal/service/managementcluster/secret.go
+++ b/services/manager/internal/service/managementcluster/secret.go
@@ -24,7 +24,7 @@ const (
 // SecretMetadata returns metadata for secrets created in the management cluster.
 func SecretMetadata(ci *spec.ClusterInfo, projectName string, outputType OutputType) Metadata {
 	return Metadata{
-		Name: fmt.Sprintf("%s-%s", ci.Id(), outputType),
+		Name: fmt.Sprintf("%s-%s-%s", projectName, ci.Name, outputType),
 		Labels: map[string]string{
 			"claudie.io/project":        projectName,
 			"claudie.io/cluster":        ci.Name,

--- a/services/manager/internal/service/reconciliation.go
+++ b/services/manager/internal/service/reconciliation.go
@@ -133,11 +133,11 @@ func reconciliate(pending *spec.Config, desiredStates map[string]*spec.Clusters)
 				del = clustersUnion(current, cs)
 			}
 
-			if err := managementcluster.DeleteKubeconfig(del); err != nil {
+			if err := managementcluster.DeleteKubeconfig(pending.Name, del); err != nil {
 				logger.Err(err).Msg("Failed to delete kubeconfig secret in the management cluster")
 			}
 
-			if err := managementcluster.DeleteClusterMetadata(del); err != nil {
+			if err := managementcluster.DeleteClusterMetadata(pending.Name, del); err != nil {
 				logger.Err(err).Msg("Failed to delete metadata secret in the management cluster")
 			}
 


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubeconfig and cluster metadata secrets now use predictable names based on the manifest/project and cluster names.
  * Updated cleanup behavior to remove secrets using the new naming format.

* **Documentation**
  * Updated the README, guides, command examples, and reference documentation with the new secret naming convention.

* **Chores**
  * Updated platform component images to the latest release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->