### PR TITLE
update kubeone

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For adding support for other cloud providers or on-premises environments, open a
       kubernetes:
           clusters:
           - name: aws-cluster
-              version: 1.27.0
+              version: 1.36.0
               network: 192.168.2.0/24
               pools:
                 control:
@@ -247,7 +247,7 @@ Claudie outputs base64 encoded kubeconfig secret `<cluster-name>-<cluster-hash>-
       kubernetes:
         clusters:
     #      - name: aws-cluster
-    #          version: 1.27.0
+    #          version: 1.36.0
     #          network: 192.168.2.0/24
     #          pools:
     #            control:

--- a/docs/http-proxy/http-proxy.md
+++ b/docs/http-proxy/http-proxy.md
@@ -19,7 +19,7 @@ In case you don't want to utilize the HTTP proxy at all (even when there are nod
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "off"
@@ -31,7 +31,7 @@ On the other hand, if you wish to use the HTTP proxy whenever building a K8s clu
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"
@@ -43,7 +43,7 @@ If you want to utilize your own HTTP proxy you can set its URL in `endpoint` (se
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"
@@ -61,7 +61,7 @@ By default, `endpoint` value is set to `http://proxy.claudie.io:8880`. In case y
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"

--- a/docs/input-manifest/api-reference.md
+++ b/docs/input-manifest/api-reference.md
@@ -559,7 +559,7 @@ Collection of data used to define a Kubernetes cluster.
 
   Kubernetes version of the cluster.
 
-  Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.12.0`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.12/architecture/compatibility/supported-versions/).
+  Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.14.1`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.14/architecture/compatibility/supported-versions/).
 
 - `network`
 

--- a/docs/input-manifest/example.md
+++ b/docs/input-manifest/example.md
@@ -312,7 +312,7 @@ spec:
   kubernetes:
     clusters:
       - name: dev-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -328,7 +328,7 @@ spec:
           endpoint: http://proxy.claudie.io:8880 # you can use your own HTTP proxy. If not specified http://proxy.claudie.io:8880 is the default value.
 
       - name: prod-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -347,7 +347,7 @@ spec:
           mode: "off" # can be on, off or default
 
       - name: hybrid-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:

--- a/docs/input-manifest/providers/on-premises.md
+++ b/docs/input-manifest/providers/on-premises.md
@@ -67,7 +67,7 @@ spec:
   kubernetes:
     clusters:
       - name: private-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -151,7 +151,7 @@ spec:
   kubernetes:
     clusters:
       - name: hybrid-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -233,7 +233,7 @@ nodePools:
 kubernetes:
       clusters:
       - name: aws-cluster
-          version: 1.27.0
+          version: 1.36.0
           network: 192.168.2.0/24
           pools:
             control:
@@ -305,7 +305,7 @@ nodePools:
 kubernetes:
     clusters:
 #      - name: aws-cluster
-#          version: 1.27.0
+#          version: 1.36.0
 #          network: 192.168.2.0/24
 #          pools:
 #            control:
@@ -2643,7 +2643,7 @@ spec:
   kubernetes:
     clusters:
       - name: private-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -2709,7 +2709,7 @@ spec:
   kubernetes:
     clusters:
       - name: hybrid-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -3035,7 +3035,7 @@ spec:
   kubernetes:
     clusters:
       - name: dev-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -3051,7 +3051,7 @@ spec:
           endpoint: http://proxy.claudie.io:8880 # you can use your own HTTP proxy. If not specified http://proxy.claudie.io:8880 is the default value.
 
       - name: prod-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -3070,7 +3070,7 @@ spec:
           mode: "off" # can be on, off or default
 
       - name: hybrid-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -3909,7 +3909,7 @@ Name of the Kubernetes cluster. The name is limited by 28 characters. Each clust
 
 Kubernetes version of the cluster.
 
-Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.12.0`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.12/architecture/compatibility/supported-versions/).
+Version should be defined in format `vX.Y`. In terms of supported versions of Kubernetes, Claudie follows `kubeone` releases and their supported versions. The current `kubeone` version used in Claudie is `1.14.1`. To see the list of supported versions, please refer to `kubeone` [documentation](https://docs.kubermatic.com/kubeone/v1.14/architecture/compatibility/supported-versions/).
 
 - `network`
 
@@ -4369,7 +4369,7 @@ spec:
   kubernetes:
     clusters:
       - name: my-awesome-claudie-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:
@@ -5150,7 +5150,7 @@ in the Input Manifest of the already build cluster.
 kubernetes:
   clusters:
     - name: claudie-cluster
-      version: v1.30.0
+      version: v1.34.0
       network: 192.168.2.0/24
       pools:
         ...
@@ -5163,7 +5163,7 @@ kubernetes:
 kubernetes:
   clusters:
     - name: claudie-cluster
-      version: 1.31.0
+      version: 1.35.0
       network: 192.168.2.0/24
       pools:
         ...
@@ -5400,7 +5400,7 @@ In case you don't want to utilize the HTTP proxy at all (even when there are nod
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "off"
@@ -5413,7 +5413,7 @@ On the other hand, if you wish to use the HTTP proxy whenever building a K8s clu
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"
@@ -5426,7 +5426,7 @@ If you want to utilize your own HTTP proxy you can set its URL in `endpoint` (se
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"
@@ -5445,7 +5445,7 @@ The below example allows to bypass the Proxy for any endpoint ending with `.suse
 kubernetes:
     clusters:
       - name: proxy-example
-        version: "1.30.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
             mode: "on"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5375,7 +5375,11 @@ In the following table, you can find the supported Kubernetes and OS versions fo
 | v0.8.0 | 1.25.x, 1.26.x, 1.27.x | Ubuntu 22.04 |
 | v0.8.1 | 1.27.x, 1.28.x, 1.29.x | Ubuntu 22.04 |
 | v0.9.0 | 1.27.x, 1.28.x, 1.29.x, 1.30.x | Ubuntu 22.04 (Ubuntu 24.04 on Hetzner and Azure) |
-| v0.9.1 | 1.29.x, 1.30.x 1.31.x | Ubuntu 22.04 (Ubuntu 24.04 on Hetzner and Azure) |
+| v0.9.1 | 1.29.x, 1.30.x, 1.31.x | Ubuntu 22.04 (Ubuntu 24.04 on Hetzner and Azure) |
+| v0.9.11 | 1.30.x, 1.31.x, 1.32.x | Ubuntu 22.04, Ubuntu 24.04 |
+| v0.10.0 | 1.32.x, 1.33.x, 1.34.x | Ubuntu 22.04, Ubuntu 24.04 |
+| v0.13.0 | 1.33.x, 1.34.x, 1.35.x | Ubuntu 22.04, Ubuntu 24.04 |
+| v0.16.0 | 1.34.x, 1.35.x, 1.36.x | Ubuntu 22.04, Ubuntu 24.04 |
 
 [Skip to content](https://docs.claudie.io/latest/http-proxy/http-proxy/#usage-of-http-proxy)
 

--- a/docs/storage/storage-solution.md
+++ b/docs/storage/storage-solution.md
@@ -98,7 +98,7 @@ spec:
   kubernetes:
     clusters:
       - name: my-awesome-claudie-cluster
-        version: 1.27.0
+        version: 1.36.0
         network: 192.168.2.0/24
         pools:
           control:

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -14,7 +14,7 @@ in the Input Manifest of the already build cluster.
 kubernetes:
   clusters:
     - name: claudie-cluster
-      version: v1.30.0
+      version: v1.34.0
       network: 192.168.2.0/24
       pools:
         ...
@@ -26,7 +26,7 @@ kubernetes:
 kubernetes:
   clusters:
     - name: claudie-cluster
-      version: 1.31.0
+      version: 1.35.0
       network: 192.168.2.0/24
       pools:
         ...

--- a/docs/version-matrix/version-matrix.md
+++ b/docs/version-matrix/version-matrix.md
@@ -13,3 +13,5 @@ In the following table, you can find the supported Kubernetes and OS versions fo
 | v0.9.1 | 1.29.x, 1.30.x, 1.31.x | Ubuntu 22.04 (Ubuntu 24.04 on Hetzner and Azure) |
 | v0.9.11 | 1.30.x, 1.31.x, 1.32.x | Ubuntu 22.04, Ubuntu 24.04 |
 | v0.10.0 | 1.32.x, 1.33.x, 1.34.x | Ubuntu 22.04, Ubuntu 24.04 |
+| v0.13.0 | 1.33.x, 1.34.x, 1.35.x | Ubuntu 22.04, Ubuntu 24.04 |
+| v0.16.0 | 1.34.x, 1.35.x, 1.36.x | Ubuntu 22.04, Ubuntu 24.04 |

--- a/internal/api/manifest/manifest.go
+++ b/internal/api/manifest/manifest.go
@@ -309,9 +309,9 @@ type Cluster struct {
 	Name string `validate:"required,max=28" yaml:"name" json:"name"`
 	// Version should be defined in format vX.Y. In terms of supported versions of Kubernetes,
 	// Claudie follows kubeone releases and their supported versions.
-	// The current kubeone version used in Claudie is 1.12.1.
+	// The current kubeone version used in Claudie is 1.14.1.
 	// To see the list of supported versions, please refer to kubeone documentation.
-	// https://docs.kubermatic.com/kubeone/v1.12/architecture/compatibility/supported-versions/
+	// https://docs.kubermatic.com/kubeone/v1.14/architecture/compatibility/supported-versions/
 	Version string `validate:"required,ver" yaml:"version" json:"version"`
 	// Network range for the VPN of the cluster. The value should be defined in format A.B.C.D/mask.
 	// +kubebuilder:validation:MaxLength=50

--- a/internal/api/manifest/validate.go
+++ b/internal/api/manifest/validate.go
@@ -85,7 +85,7 @@ func prettyPrintValidationError(err error) error {
 		case "cidrv4":
 			nerr = fmt.Errorf("field '%s' is required to have a valid CIDRv4 value", err.StructField())
 		case "ver":
-			nerr = fmt.Errorf("field '%s' is required to have a kubernetes version of: 1.33.x, 1.34.x, 1.35.x", err.StructField())
+			nerr = fmt.Errorf("field '%s' is required to have a kubernetes version of: 1.34.x, 1.35.x, 1.36.x", err.StructField())
 		case "proxyMode":
 			nerr = fmt.Errorf("field '%s' is required to have a valid proxy mode value of \"on\", \"off\", \"default\"", err.StructField())
 		case "semver2":

--- a/internal/api/manifest/validate_kubernetes.go
+++ b/internal/api/manifest/validate_kubernetes.go
@@ -14,7 +14,7 @@ var (
 	// NOTE:
 	// first/second capturing group MUST be changed whenever new kubeone version is introduced in Claudie
 	// so validation will catch unsupported versions
-	kubernetesVersionRegexString = `^(1)\.(33|34|35)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+	kubernetesVersionRegexString = `^(1)\.(34|35|36)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 
 	// semverRegex is a regex using the semverRegexString.
 	// It's used to verify the version inside the manifest,

--- a/internal/api/manifest/validate_node_pool_test.go
+++ b/internal/api/manifest/validate_node_pool_test.go
@@ -21,7 +21,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools: Pool{
 						Control: []string{"control-np"},
 						Compute: []string{"worker-np"},
@@ -43,7 +43,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools: Pool{
 						Compute: []string{"worker-np"},
 					},
@@ -65,7 +65,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools: Pool{
 						Compute: []string{"worker-np"},
 					},
@@ -87,7 +87,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools:   Pool{Compute: []string{"worker-np"}},
 				},
 			},
@@ -109,7 +109,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools:   Pool{Compute: []string{"worker-np"}},
 				},
 			},
@@ -132,7 +132,7 @@ func TestValidateSpot(t *testing.T) {
 				{
 					Name:    "cluster-1",
 					Network: "10.0.0.0/8",
-					Version: "v1.33.0",
+					Version: "v1.34.0",
 					Pools:   Pool{Compute: []string{"worker-np"}},
 				},
 			},

--- a/internal/api/manifest/validate_test.go
+++ b/internal/api/manifest/validate_test.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	testManifest                = &Manifest{NodePools: NodePool{Dynamic: []DynamicNodePool{{Name: "np1"}}}}
-	testClusterVersionPass      = &Kubernetes{Clusters: []Cluster{{Name: "cluster1", Network: "10.0.0.0/8", Version: "v1.33.0", Pools: Pool{Control: []string{"np1"}}}}}
+	testClusterVersionPass      = &Kubernetes{Clusters: []Cluster{{Name: "cluster1", Network: "10.0.0.0/8", Version: "v1.34.0", Pools: Pool{Control: []string{"np1"}}}}}
 	testClusterVersionFailMinor = &Kubernetes{Clusters: []Cluster{{Name: "cluster1", Network: "10.0.0.0/8", Version: "v1.21.0", Pools: Pool{Control: []string{"np1"}}}}}
 	testClusterVersionFailMajor = &Kubernetes{Clusters: []Cluster{{Name: "cluster1", Network: "10.0.0.0/8", Version: "v2.22.0", Pools: Pool{Control: []string{"np1"}}}}}
 
@@ -43,7 +43,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "Off",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -57,7 +57,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "On",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -71,7 +71,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -85,7 +85,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "Default",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -99,7 +99,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "on",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -113,7 +113,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "off",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -127,7 +127,7 @@ var (
 				Control: []string{"np1"},
 			},
 				Network: "10.0.0.0/8",
-				Version: "v1.33.0",
+				Version: "v1.34.0",
 				InstallationProxy: &InstallationProxy{
 					Mode:     "default",
 					Endpoint: "http://proxy.claudie.io:8880",
@@ -179,7 +179,7 @@ var (
 			Clusters: []Cluster{
 				{
 					Name:    "foooo",
-					Version: "v1.33.2",
+					Version: "v1.34.2",
 					Network: "192.168.1.0/24",
 					Pools: Pool{
 						Control: []string{"control-1", "control-2"},

--- a/manifests/claudie/crd/claudie.io_inputmanifests.yaml
+++ b/manifests/claudie/crd/claudie.io_inputmanifests.yaml
@@ -118,9 +118,9 @@ spec:
                           description: |-
                             Version should be defined in format vX.Y. In terms of supported versions of Kubernetes,
                             Claudie follows kubeone releases and their supported versions.
-                            The current kubeone version used in Claudie is 1.12.1.
+                            The current kubeone version used in Claudie is 1.14.1.
                             To see the list of supported versions, please refer to kubeone documentation.
-                            https://docs.kubermatic.com/kubeone/v1.12/architecture/compatibility/supported-versions/
+                            https://docs.kubermatic.com/kubeone/v1.14/architecture/compatibility/supported-versions/
                           type: string
                       required:
                       - name

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399
 - name: ghcr.io/berops/claudie/manager
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388
 - name: ghcr.io/berops/claudie/kuber
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388
 - name: ghcr.io/berops/claudie/manager
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 0502ce9-4388
+  newTag: f8bb660-4399

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: b4c932d-4362
+  newTag: 0502ce9-4388

--- a/manifests/testing-framework/test-sets/autoscaling-1/1.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/1.yaml
@@ -48,7 +48,7 @@ spec:
   kubernetes:
     clusters:
       - name: autoscaling-cluster-test-set
-        version: "1.34.0"
+        version: "1.35.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/autoscaling-1/2.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/2.yaml
@@ -46,7 +46,7 @@ spec:
   kubernetes:
     clusters:
       - name: autoscaling-cluster-test-set
-        version: "1.34.0"
+        version: "1.35.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/autoscaling-1/3.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-1/3.yaml
@@ -44,7 +44,7 @@ spec:
   kubernetes:
     clusters:
       - name: autoscaling-cluster-test-set
-        version: "1.34.0"
+        version: "1.35.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/autoscaling-2/1.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-2/1.yaml
@@ -54,7 +54,7 @@ spec:
   kubernetes:
     clusters:
       - name: autoscaling-cluster-test-002
-        version: "1.34.0"
+        version: "1.35.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/autoscaling-2/2.yaml
+++ b/manifests/testing-framework/test-sets/autoscaling-2/2.yaml
@@ -56,7 +56,7 @@ spec:
   kubernetes:
     clusters:
       - name: autoscaling-cluster-test-002
-        version: "1.34.0"
+        version: "1.35.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/1.yaml
@@ -44,7 +44,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/2.yaml
@@ -44,7 +44,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "off"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/3.yaml
@@ -44,7 +44,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/4.yaml
@@ -44,7 +44,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/5.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/6.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
+++ b/manifests/testing-framework/test-sets/proxy-with-hetzner/7.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-with-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/1.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/1.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/10.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/10.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/2.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/2.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "off"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/3.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/3.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/4.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/4.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/5.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/5.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "off"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/6.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/6.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "off"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/7.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/7.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/8.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/8.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/proxy-without-hetzner/9.yaml
+++ b/manifests/testing-framework/test-sets/proxy-without-hetzner/9.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: proxy-without-hetzner
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "default"

--- a/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/1.yaml
@@ -98,7 +98,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts-rolling-update-nodepools1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update-2/2.yaml
@@ -49,7 +49,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts-rolling-update-nodepools1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/rolling-update/1.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/1.yaml
@@ -86,7 +86,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts-rolling-update-nodepools1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/rolling-update/2.yaml
+++ b/manifests/testing-framework/test-sets/rolling-update/2.yaml
@@ -86,7 +86,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts-rolling-update-nodepools1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-1/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-1/1.yaml
@@ -26,7 +26,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-1-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-1/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-1/2.yaml
@@ -26,7 +26,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-1-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/1.yaml
@@ -24,7 +24,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-2-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/2.yaml
@@ -42,7 +42,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-2-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-2/3.yaml
@@ -41,7 +41,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-2-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-3/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-3/1.yaml
@@ -32,7 +32,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-3-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-3/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-3/2.yaml
@@ -32,7 +32,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-3-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/1.yaml
@@ -24,7 +24,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-4-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/2.yaml
@@ -41,7 +41,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-4-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
+++ b/manifests/testing-framework/test-sets/succeeds-on-last-4/3.yaml
@@ -40,7 +40,7 @@ spec:
   kubernetes:
     clusters:
       - name: succeeds-on-last-4-cluster-0
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -250,7 +250,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts1-htz-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -259,7 +259,7 @@ spec:
             - htz-cmpt-nodes
             - exo-cmpt-nodes
       - name: ts1-gcp-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -267,7 +267,7 @@ spec:
           compute:
             - gcp-cmpt-nodes
       - name: ts1-oci-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"
@@ -277,7 +277,7 @@ spec:
           compute:
             - oci-cmpt-nodes
       - name: ts1-aws-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -285,7 +285,7 @@ spec:
           compute:
             - aws-cmpt-nodes
       - name: ts1-azr-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -293,7 +293,7 @@ spec:
           compute:
             - azr-cmpt-nodes
       - name: ts1-ovh-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -228,7 +228,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts1-htz-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -236,7 +236,7 @@ spec:
           compute:
             - htz-cmpt-nodes
       - name: ts1-gcp-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -244,7 +244,7 @@ spec:
           compute:
             - gcp-cmpt-nodes
       - name: ts1-oci-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"
@@ -254,7 +254,7 @@ spec:
           compute:
             - oci-cmpt-nodes
       - name: ts1-aws-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -262,7 +262,7 @@ spec:
           compute:
             - aws-cmpt-nodes
       - name: ts1-azr-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -270,7 +270,7 @@ spec:
           compute:
             - azr-cmpt-nodes
       - name: ts1-ovh-cluster-test-set-no1
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set2/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/1.yaml
@@ -142,7 +142,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts2-htz-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -150,7 +150,7 @@ spec:
           compute:
             - htz-kube-nodes
       - name: ts2-oci-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set2/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/2.yaml
@@ -150,7 +150,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts2-htz-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -158,7 +158,7 @@ spec:
           compute:
             - htz-kube-nodes
       - name: ts2-oci-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set2/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set2/3.yaml
@@ -143,7 +143,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts2-htz-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -151,7 +151,7 @@ spec:
           compute:
             - htz-kube-nodes
       - name: ts2-oci-cluster-test-set-no2
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set3/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/1.yaml
@@ -111,7 +111,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts3-c-1-cluster-test-set-no3
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:
@@ -119,7 +119,7 @@ spec:
           compute:
             - htz-cmpt-nodes
       - name: ts3-c-2-cluster-test-set-no3
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set3/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/2.yaml
@@ -43,7 +43,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts3-c-1-cluster-test-set-no3
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set3/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/3.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts3-c-1-cluster-test-set-no3
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set3/4.yaml
+++ b/manifests/testing-framework/test-sets/test-set3/4.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts3-c-1-cluster-test-set-no3
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set4/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/1.yaml
@@ -27,7 +27,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts4-c-1-cluster-test-set-no4
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set4/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/2.yaml
@@ -61,7 +61,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts4-c-1-cluster-test-set-no4
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set4/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set4/3.yaml
@@ -51,7 +51,7 @@ spec:
   kubernetes:
     clusters:
       - name: ts4-c-1-cluster-test-set-no4
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         installationProxy:
           mode: "on"

--- a/manifests/testing-framework/test-sets/test-set5/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/1.yaml
@@ -58,7 +58,7 @@ spec:
   kubernetes:
     clusters:
       - name: hybrid-cluster-test-set-no-5
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set5/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/2.yaml
@@ -58,7 +58,7 @@ spec:
   kubernetes:
     clusters:
       - name: hybrid-cluster-test-set-no-5
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/manifests/testing-framework/test-sets/test-set5/3.yaml
+++ b/manifests/testing-framework/test-sets/test-set5/3.yaml
@@ -54,7 +54,7 @@ spec:
   kubernetes:
     clusters:
       - name: hybrid-cluster-test-set-no-5
-        version: "1.35.0"
+        version: "1.36.0"
         network: 192.168.2.0/24
         pools:
           control:

--- a/services/kube-eleven/Dockerfile
+++ b/services/kube-eleven/Dockerfile
@@ -4,12 +4,12 @@ ARG TARGETARCH
 
 # download and unzip kube-one binary
 RUN apt-get -qq update && apt-get -qq install unzip
-RUN KUBEONE_V=1.13.5 && \
+RUN KUBEONE_V=1.14.1 && \
     wget -q https://github.com/kubermatic/kubeone/releases/download/v${KUBEONE_V}/kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip && \
     unzip -qq kubeone_${KUBEONE_V}_linux_$TARGETARCH.zip -d kubeone_dir
 
 #Install kubectl
-RUN KC_VERSION=v1.34.0 && \
+RUN KC_VERSION=v1.35.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 #Unset the GOPATH

--- a/services/kuber/Dockerfile
+++ b/services/kuber/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.26.3 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.34.0 && \
+RUN KC_VERSION=v1.35.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 #Unset the GOPATH

--- a/services/manager/Dockerfile
+++ b/services/manager/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.26.3 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.34.0 && \
+RUN KC_VERSION=v1.35.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 #Unset the GOPATH

--- a/services/testing-framework/Dockerfile
+++ b/services/testing-framework/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/golang:1.26.3 AS build
 ARG TARGETARCH
 
 #Install kubectl
-RUN KC_VERSION=v1.34.0 && \
+RUN KC_VERSION=v1.35.0 && \
     wget -q https://dl.k8s.io/release/${KC_VERSION}/bin/linux/$TARGETARCH/kubectl
 
 


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Kubernetes examples and configuration guidance for versions 1.34.0–1.36.0.
  - Updated the documented KubeOne version to 1.14.1 and refreshed compatibility links.
  - Added Claudie versions 0.13.0 and 0.16.0 to the supported version matrix.
  - Refined rolling-update examples with user-owned repositories and tagged templates.

- **Compatibility**
  - Kubernetes version validation now supports 1.34.x, 1.35.x, and 1.36.x.
  - Updated deployment and testing configurations for current Kubernetes, kubectl, and service image releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->