### PR TITLE
update tofu to 1.12.5

### DIFF
--- a/docs/contributing/local-testing.md
+++ b/docs/contributing/local-testing.md
@@ -31,7 +31,7 @@ Running Claudie services requires sufficient CPU and memory resources to ensure 
 As Claudie uses number of external tools to build and manage clusters, it is important these tools are installed on your local system.
 
 - `go` - check current version used in `go.mod` file
-- `terraform` - check current version used in Terraformer Dockerfile
+- `tofu` - check current version used in Terraformer Dockerfile
 - `ansible` - check current version used in Ansibler Dockerfile
 - `kubeone` - check current version used in Kube-eleven Dockerfile
 - `kubectl` - check current version used in Kuber Dockerfile

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424
 - name: ghcr.io/berops/claudie/manager
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390
 - name: ghcr.io/berops/claudie/kuber
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390
 - name: ghcr.io/berops/claudie/manager
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: b4c932d-4362
+  newTag: 34aa04c-4390

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ddb1426-4403
+  newTag: 3876bcc-4424

--- a/services/terraformer/Dockerfile
+++ b/services/terraformer/Dockerfile
@@ -2,9 +2,9 @@ FROM docker.io/library/golang:1.26.3 AS build
 
 ARG TARGETARCH
 
-# download and unzip kube-one binary
+# download and unzip opentofu binary
 RUN apt-get -qq update && apt-get -qq install unzip
-RUN VERSION=1.10.7 && \
+RUN VERSION=1.12.5 && \
     wget -q https://github.com/opentofu/opentofu/releases/download/v${VERSION}/tofu_${VERSION}_linux_$TARGETARCH.zip && \
     unzip -qq tofu_${VERSION}_linux_$TARGETARCH.zip -d tofu
 

--- a/services/terraformer/internal/worker/service/internal/templates/backend.tpl
+++ b/services/terraformer/internal/worker/service/internal/templates/backend.tpl
@@ -8,11 +8,13 @@ terraform {
     access_key = "{{ .AccessKey }}"
     secret_key = "{{ .SecretKey }}"
 
-    {{if .BucketURL }}endpoint = "{{ .BucketURL }}"{{ end }}
+    {{if .BucketURL }}endpoints = {
+      s3 = "{{ .BucketURL }}"
+    }{{ end }}
 
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
-    force_path_style            = true
+    use_path_style              = true
   }
 }


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3-compatible backend configuration with custom endpoint handling and path-style access support.
  * Updated infrastructure tooling to use OpenTofu 1.12.5 for more reliable builds.

* **Documentation**
  * Updated local testing requirements to reference OpenTofu and its tooling version.

* **Chores**
  * Updated service and testing framework images to the latest release builds.
  * Refreshed deployment configuration to keep supporting components aligned with current releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->