### PR TITLE
Feat/ssh pings

### DIFF
--- a/docs/environment-settings/environment.md
+++ b/docs/environment-settings/environment.md
@@ -42,9 +42,9 @@ AWS_REGION=local
 # Default is all namespaces
 CLAUDIE_NAMESPACES="dev"
 
-# Defines how many concurrent workers will ping nodes of the currently built cluster. Only applicable to Kuber and Manager services.
-# Default is 20
-PING_CONCURRENT_WORKERS=20
+# Defines how many concurrent workers will ssh ping the loadbalancer nodes during healthchecks. Only applicable to the Manager service.
+# Default is 10
+PING_CONCURRENT_WORKERS=10
 
 # Defines how many clusters ansibler will work on concurrently.
 # Default is 8

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.53.0
-	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -113,6 +112,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect

--- a/internal/clusters/ping4.go
+++ b/internal/clusters/ping4.go
@@ -23,7 +23,7 @@ const (
 
 	// PingRetryCount is the number of times the ping will be retried
 	// to determine if the node is healthy of not.
-	PingRetryCount = 3
+	PingRetryCount = 4
 )
 
 var (
@@ -94,6 +94,7 @@ func SSHPing(logger zerolog.Logger, retries int, dst NodeEndpoint) error {
 
 	var err error
 	for i := range retries {
+		logger.Debug().Msgf("SSH ping %s:%s", dst.Ip, dst.Port)
 		if err = sshPing(PingTimeout, dst); err == nil {
 			break
 		}
@@ -101,7 +102,7 @@ func SSHPing(logger zerolog.Logger, retries int, dst NodeEndpoint) error {
 			break
 		}
 		wait := 1 * time.Second
-		logger.Err(err).Msgf("failed to ssh ping node %q, retrying again in %s", dst.Ip, wait)
+		logger.Warn().Msgf("failed to ssh ping node %q: %v, retrying again in %s", dst.Ip, err, wait)
 		time.Sleep(wait)
 	}
 	if err != nil {

--- a/internal/clusters/ping4.go
+++ b/internal/clusters/ping4.go
@@ -1,290 +1,205 @@
 package clusters
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"maps"
 	"net"
-	"os"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/berops/claudie/internal/envs"
+	"github.com/berops/claudie/internal/nodepools"
 	"github.com/berops/claudie/proto/pb/spec"
 	"github.com/rs/zerolog"
 
-	"golang.org/x/net/icmp"
-	"golang.org/x/net/ipv4"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
 	// How long to wait before considering the ping packet to be lost.
-	PingTimeout = 3 * time.Second
+	PingTimeout = 2 * time.Second
+
 	// PingRetryCount is the number of times the ping will be retried
 	// to determine if the node is healthy of not.
-	PingRetryCount = 5
+	PingRetryCount = 3
 )
 
-// How many goroutines will be used to ping nodes of a cluster.
-var pingConcurrentWorkers = envs.GetOrDefaultInt("PING_CONCURRENT_WORKERS", 20)
+var (
+	// How many goroutines will be used to ping nodes of a cluster.
+	pingConcurrentWorkers = envs.GetOrDefaultInt("PING_CONCURRENT_WORKERS", 10)
 
-// ErrEchoTimeout is returned when the reply is not received within the requested timeout.
-var ErrEchoTimeout = errors.New("icmp request timeout")
+	// ErrUnreachable is returned when a node cannot be reached via an SSH ping.
+	ErrUnreachable = errors.New("failed to reach node")
+)
 
-func ping4(logger zerolog.Logger, conn *icmp.PacketConn, id, seq int, dst *net.UDPAddr, timeout time.Duration) error {
-	m := icmp.Message{
-		Type: ipv4.ICMPTypeEcho,
-		Code: 0,
-		Body: &icmp.Echo{
-			ID:   id,
-			Seq:  seq,
-			Data: []byte("ping"),
-		},
-	}
-
-	b, err := m.Marshal(nil)
-	if err != nil {
-		return fmt.Errorf("failed to marshal icmp seq %v: %w", seq, err)
-	}
-
-	if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
-		return fmt.Errorf("failed to set write deadline for icmp seq: %v: %w", seq, err)
-	}
-
-	w, err := conn.WriteTo(b, dst)
-	if err != nil {
-		return fmt.Errorf("failed to write icmp seq %v: %w", seq, err)
-	}
-
-	if w != len(b) {
-		return fmt.Errorf("not all bytes for icmp seq %v were written", seq)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	for {
-		select {
-		case <-ctx.Done():
-			return ErrEchoTimeout
-		default:
-			if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-				logger.Err(err).Msgf("Failed to set read deadline for icmp connection")
-				continue
-			}
-
-			rcv := make([]byte, 1024)
-			r, peer, err := conn.ReadFrom(rcv)
-			if err != nil {
-				if errors.Is(err, os.ErrDeadlineExceeded) {
-					return ErrEchoTimeout
-				}
-				logger.Err(err).Msgf("Failed to read icmp seq %v reply", seq)
-				continue
-			}
-
-			if peer.String() != dst.String() {
-				continue
-			}
-
-			reply, err := icmp.ParseMessage(1, rcv[:r]) // 1 is icmp ip4 protocol.
-			if err != nil {
-				logger.Err(err).Msgf("failed to parse icmp seq %v reply", seq)
-				continue
-			}
-
-			switch reply.Type {
-			case ipv4.ICMPTypeEchoReply:
-				body, ok := reply.Body.(*icmp.Echo)
-				if !ok {
-					logger.Warn().Msg("Received icmp echo reply does not have expected echo body, skipping")
-					continue
-				}
-
-				// Reply ID seems to be different when executed inside a container
-				// can't really match the request via the reply ID, thus we only
-				// have the seq number to match the reply to the request.
-				// As long as there are no two concurrent ping attempts to the
-				// same peer this should be fine.
-				// if body.ID != id {
-				// 	logger.Debug().Msgf("Received icmp echo reply id: %v does not match echo request id: %v, skipping", body.ID, id)
-				// 	continue
-				// }
-				if body.Seq != seq {
-					logger.Warn().Msgf("Received icmp echo reply seq: %v does not match echo request seq: %v, skipping", body.Seq, seq)
-					continue
-				}
-				return nil
-			default:
-				logger.Debug().Msgf("Received non icmp echo reply packet, skipping")
-			}
-		}
-	}
+type NodeEndpoint struct {
+	Ip       string
+	Port     string
+	Username string
+	SSHKey   string
 }
 
-// Ping pings a single IPv4 address with the requested amount of retries.
-// An error is returned when more then count/2 packets are lost.
-func Ping(logger zerolog.Logger, count int, dst string) error {
-	dstAddr := &net.UDPAddr{IP: net.ParseIP(dst)}
-	if dstAddr.IP == nil {
-		logger.Warn().Msgf("Received invalid IP address to ping %q, considering as unreachable", dst)
-		return fmt.Errorf("unhealthy connection: %w, invalid IP address %q", ErrEchoTimeout, dst)
-	}
+func (n NodeEndpoint) Incomplete() bool {
+	return n.Ip == "" ||
+		n.Port == "" ||
+		n.Username == "" ||
+		n.SSHKey == ""
+}
 
-	conn, err := icmp.ListenPacket("udp4", "0.0.0.0")
+func sshPing(timeout time.Duration, ep NodeEndpoint) error {
+	signer, err := ssh.ParsePrivateKey([]byte(ep.SSHKey))
 	if err != nil {
-		return fmt.Errorf("failed to listen for icmp packets: %w", err)
+		return fmt.Errorf("%s invalid ssh key: %w", ep.Ip, err)
 	}
-	defer conn.Close()
 
-	id := os.Getpid() & 0xffff // 16bit id
-	lost := 0
+	cfg := ssh.ClientConfig{
+		User: ep.Username,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
 
-	logger.Debug().Msgf("verifying if node %s is reachable", dst)
-	for i := range count {
-		time.Sleep(1 * time.Second)
-		seq := i + 1
-		send := time.Now()
-		if err := ping4(logger, conn, id, seq, dstAddr, PingTimeout); err != nil {
-			lost++
-			if errors.Is(err, ErrEchoTimeout) {
-				logger.Warn().Msgf("[%v] node %s icmp seq %v, lost", time.Since(send).String(), dst, seq)
-				continue
-			}
-			logger.Err(err).Msg("failed to ping node")
-			continue
+	endpoint := net.JoinHostPort(ep.Ip, ep.Port)
+
+	//nolint
+	conn, err := net.DialTimeout("tcp", endpoint, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to establish connection: %w", err)
+	}
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		conn.Close()
+		return fmt.Errorf("failed to set connection timeouts: %w", err)
+	}
+
+	c, chans, reqs, err := ssh.NewClientConn(conn, endpoint, &cfg)
+	if err != nil {
+		return fmt.Errorf("failed to establish ssh client connection: %w", err)
+	}
+	return ssh.NewClient(c, chans, reqs).Close()
+}
+
+// SSHPing performs an SSH ping against an [NodeEndpoint] with the requested amount of retries.
+func SSHPing(logger zerolog.Logger, retries int, dst NodeEndpoint) error {
+	if dst.Incomplete() {
+		logger.
+			Warn().
+			Msgf("Received incomplete node endpoint address to ssh ping %q, considering as unreachable", dst.Ip)
+
+		return fmt.Errorf("unhealthy connection: %w, IP address %q", ErrUnreachable, dst.Ip)
+	}
+
+	var err error
+	for i := range retries {
+		if err = sshPing(PingTimeout, dst); err == nil {
+			break
 		}
-		logger.Debug().Msgf("[%v] node %s icmp seq %v, ok", time.Since(send).String(), dst, seq)
+		if i == retries-1 {
+			break
+		}
+		wait := 1 * time.Second
+		logger.Err(err).Msgf("failed to ssh ping node %q, retrying again in %s", dst.Ip, wait)
+		time.Sleep(wait)
 	}
-	if lost > max(count/2, (count+1)/2) {
-		return fmt.Errorf("unhealthy connection: %w, [%v/%v] messages lost", ErrEchoTimeout, lost, count)
+	if err != nil {
+		return fmt.Errorf("unhealthy connection: %w: %w", ErrUnreachable, err)
 	}
 	return nil
 }
 
-// PingNodes pings nodes of the cluster, including loadbalancer nodes, using
-// the public IPv4 Address of the nodes.
-func PingNodes(logger zerolog.Logger, state *spec.Clusters) (map[string][]string, map[string]map[string][]string, error) {
-	type nodemap = map[string]string
-
-	k8sNodes := make(nodemap)
-	for _, np := range state.GetK8S().GetClusterInfo().GetNodePools() {
-		for _, n := range np.Nodes {
-			k8sNodes[n.Public] = np.Name
-		}
-	}
-
-	lbsNodes := make(map[string]nodemap)
-	for _, lb := range state.GetLoadBalancers().GetClusters() {
-		lbsNodes[lb.ClusterInfo.Id()] = make(nodemap)
-		for _, np := range lb.GetClusterInfo().GetNodePools() {
-			for _, n := range np.Nodes {
-				lbsNodes[lb.ClusterInfo.Id()][n.Public] = np.Name
-			}
-		}
-	}
-
-	ips := slices.Collect(maps.Keys(k8sNodes))
-	for _, lbs := range lbsNodes {
-		ips = slices.AppendSeq(ips, maps.Keys(lbs))
-	}
-
-	k8sip := make(map[string][]string)
-	lbsip := make(map[string]map[string][]string)
-
-	unreachable, err := pingAll(logger, pingConcurrentWorkers, ips, Ping)
-	for _, ip := range unreachable {
-		if np, ok := k8sNodes[ip]; ok {
-			k8sip[np] = append(k8sip[np], ip)
-		} else {
-			for lb, nodes := range lbsNodes {
-				if np, ok := nodes[ip]; ok {
-					if lbsip[lb] == nil {
-						lbsip[lb] = make(map[string][]string)
-					}
-					lbsip[lb][np] = append(lbsip[lb][np], ip)
-				}
-			}
-		}
-	}
-
-	return k8sip, lbsip, err
-}
-
+// PingLoadBalancerNodes pings all of the nodes of the LoadBalancer cluster and
+// returns those that are unreachable.
+//
+// The resulting value will be of map[LoadBalancer.Id]map[NodePool.Name][]NodeIPs.
 func PingLoadBalancerNodes(logger zerolog.Logger, state *spec.Clusters) (map[string]map[string][]string, error) {
-	type nodemap = map[string]string
+	type nodemap = map[NodeEndpoint]string  // map[NodeEndpoint]NodePool.Name
+	nodepoolMap := make(map[string]nodemap) // map[LoadBalancer.Id]nodemap
 
-	lbsNodes := make(map[string]nodemap)
 	for _, lb := range state.GetLoadBalancers().GetClusters() {
-		lbsNodes[lb.ClusterInfo.Id()] = make(nodemap)
-		for _, np := range lb.GetClusterInfo().GetNodePools() {
+		nodepoolMap[lb.ClusterInfo.Id()] = make(nodemap)
+
+		for _, np := range lb.ClusterInfo.NodePools {
 			for _, n := range np.Nodes {
-				lbsNodes[lb.ClusterInfo.Id()][n.Public] = np.Name
-			}
-		}
-	}
-
-	var ips []string
-	for _, lbs := range lbsNodes {
-		ips = slices.AppendSeq(ips, maps.Keys(lbs))
-	}
-
-	lbsip := make(map[string]map[string][]string)
-	unreachable, err := pingAll(logger, pingConcurrentWorkers, ips, Ping)
-	for _, ip := range unreachable {
-		for lb, nodes := range lbsNodes {
-			if np, ok := nodes[ip]; ok {
-				if lbsip[lb] == nil {
-					lbsip[lb] = make(map[string][]string)
+				ep := NodeEndpoint{
+					Ip:       n.Public,
+					Port:     fmt.Sprint(nodepools.NodeSSHPort(np, n)),
+					Username: nodepools.NodeSSHUsername(n),
+					SSHKey:   "",
 				}
-				lbsip[lb][np] = append(lbsip[lb][np], ip)
+
+				switch t := np.Type.(type) {
+				case *spec.NodePool_DynamicNodePool:
+					ep.SSHKey = t.DynamicNodePool.PrivateKey
+				case *spec.NodePool_StaticNodePool:
+					ep.SSHKey = t.StaticNodePool.NodeKeys[n.Public]
+				}
+
+				nodepoolMap[lb.ClusterInfo.Id()][ep] = np.Name
 			}
 		}
 	}
 
-	return lbsip, err
+	var eps []NodeEndpoint
+	for _, e := range nodepoolMap {
+		eps = slices.AppendSeq(eps, maps.Keys(e))
+	}
+
+	unreachable, err := pingAll(logger, pingConcurrentWorkers, eps, SSHPing)
+
+	out := make(map[string]map[string][]string) // map[LoadBalancer.Id]map[NodePool.Name][]NodeIP
+	for _, ep := range unreachable {
+		for id, nodepools := range nodepoolMap {
+			if nodepoolName, ok := nodepools[ep]; ok {
+				if out[id] == nil {
+					out[id] = make(map[string][]string)
+				}
+				out[id][nodepoolName] = append(out[id][nodepoolName], ep.Ip)
+			}
+		}
+	}
+	return out, err
 }
 
 func pingAll(
 	logger zerolog.Logger,
 	goroutineCount int,
-	ips []string,
-	f func(logger zerolog.Logger, count int, dst string) error,
-) ([]string, error) {
+	eps []NodeEndpoint,
+	f func(logger zerolog.Logger, count int, ep NodeEndpoint) error,
+) ([]NodeEndpoint, error) {
 	if goroutineCount < 1 {
 		return nil, nil
 	}
 
-	type data struct {
-		ip  string
+	type errResult struct {
+		ep  NodeEndpoint
 		err error
 	}
 
 	var (
 		wg      = new(sync.WaitGroup)
-		errChan = make(chan data)
-		tasks   = make(chan string)
+		errChan = make(chan errResult)
+		tasks   = make(chan NodeEndpoint)
 	)
 
 	for range goroutineCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for ip := range tasks {
-				if err := f(logger, PingRetryCount, ip); err != nil {
-					errChan <- data{
-						ip:  ip,
+		wg.Go(func() {
+			for ep := range tasks {
+				if err := f(logger, PingRetryCount, ep); err != nil {
+					errChan <- errResult{
+						ep:  ep,
 						err: err,
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	go func() {
-		for _, ip := range ips {
-			tasks <- ip
+		for _, ep := range eps {
+			tasks <- ep
 		}
 		close(tasks)
 	}()
@@ -294,11 +209,11 @@ func pingAll(
 		close(errChan)
 	}()
 
-	var unreachable []string
+	var unreachable []NodeEndpoint
 	var errAll error
-	for err := range errChan {
-		unreachable = append(unreachable, err.ip)
-		errAll = errors.Join(errAll, fmt.Errorf("node %s: %w", err.ip, err.err))
+	for result := range errChan {
+		unreachable = append(unreachable, result.ep)
+		errAll = errors.Join(errAll, fmt.Errorf("node %s: %w", result.ep.Ip, result.err))
 	}
 	return unreachable, errAll
 }

--- a/internal/clusters/ping4_test.go
+++ b/internal/clusters/ping4_test.go
@@ -1,18 +1,22 @@
 package clusters
 
 import (
+	"bytes"
+	"crypto/ed25519"
+	crand "crypto/rand"
+	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/rand/v2"
-	"net/netip"
+	"net"
 	"os"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/berops/claudie/internal/spectesting"
-	"github.com/berops/claudie/proto/pb/spec"
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
 )
 
 func FuzzPingAll(f *testing.F) {
@@ -28,273 +32,356 @@ func FuzzPingAll(f *testing.F) {
 	log := zerolog.Logger{}
 
 	f.Fuzz(func(t *testing.T, s string) {
-		ips := strings.Split(s, ",")
+		var eps []NodeEndpoint
+		for ip := range strings.SplitSeq(s, ",") {
+			eps = append(eps, NodeEndpoint{Ip: ip})
+		}
 		gc := rand.IntN(20)
-		u, err := pingAll(log, gc, ips, func(logger zerolog.Logger, count int, dst string) error { return nil })
+		u, err := pingAll(log, gc, eps, func(logger zerolog.Logger, count int, ep NodeEndpoint) error { return nil })
 		if err != nil {
-			t.Errorf("pingAll() goroutines = %v, ips = %v, unreachable = %v, err = %v", gc, ips, u, err)
+			t.Errorf("pingAll() goroutines = %v, eps = %v, unreachable = %v, err = %v", gc, eps, u, err)
 		}
 	})
 }
 
-func TestPingNodes(t *testing.T) {
-	logger := zerolog.New(os.Stdout)
-
-	var (
-		wantK8sIps = make(map[string][]string)
-		wantLbsIps = make(map[string][]string)
-	)
-
-	// re-assign ips so that no two nodes have the same ip.
-	network, err := netip.ParsePrefix("172.0.1.0/16")
-	assert.Nil(t, err)
-	iter := network.Addr()
-
-	k8s := spectesting.GenerateFakeK8SCluster(true)
-	k8s.ClusterInfo.NodePools = k8s.ClusterInfo.NodePools[:2]
-	for _, np := range k8s.ClusterInfo.NodePools {
-		np.Nodes = np.Nodes[:2]
-		np.Nodes[0].Public = iter.String()
-		iter = iter.Next()
-
-		np.Nodes[1].Public = iter.String()
-		iter = iter.Next()
-		wantK8sIps[np.Name] = append(wantK8sIps[np.Name], np.Nodes[0].Public)
-		wantK8sIps[np.Name] = append(wantK8sIps[np.Name], np.Nodes[1].Public)
-	}
-
-	lbs := spectesting.GenerateFakeLBCluster(true, k8s.ClusterInfo)
-	lbs.ClusterInfo.NodePools = lbs.ClusterInfo.NodePools[:2]
-	for _, np := range lbs.ClusterInfo.NodePools {
-		np.Nodes = np.Nodes[:2]
-		np.Nodes[0].Public = iter.String()
-		iter = iter.Next()
-
-		np.Nodes[1].Public = iter.String()
-		iter = iter.Next()
-		wantLbsIps[np.Name] = append(wantLbsIps[np.Name], np.Nodes[0].Public)
-		wantLbsIps[np.Name] = append(wantLbsIps[np.Name], np.Nodes[1].Public)
-	}
-	s := &spec.Clusters{
-		K8S:           k8s,
-		LoadBalancers: &spec.LoadBalancers{Clusters: []*spec.LBcluster{lbs}},
-	}
-
-	gotK8s, gotLbs, err := PingNodes(logger, s)
-	assert.NotNil(t, err)
-
-	assert.Equal(t, 2, len(gotK8s))
-	assert.Equal(t, 1, len(gotLbs))
-
-	assert.Equal(t, 2, len(gotK8s[k8s.ClusterInfo.NodePools[0].Name]))
-	assert.Equal(t, 2, len(gotK8s[k8s.ClusterInfo.NodePools[1].Name]))
-
-	assert.Equal(t, 2, len(gotLbs[lbs.ClusterInfo.Id()][lbs.ClusterInfo.NodePools[0].Name]))
-	assert.Equal(t, 2, len(gotLbs[lbs.ClusterInfo.Id()][lbs.ClusterInfo.NodePools[1].Name]))
-
-	for np, v := range wantK8sIps {
-		for _, ip := range v {
-			assert.True(t, slices.Contains(gotK8s[np], ip))
-		}
-	}
-
-	for np, v := range wantLbsIps {
-		for _, ip := range v {
-			assert.True(t, slices.Contains(gotLbs[lbs.ClusterInfo.Id()][np], ip))
-		}
-	}
-}
-
 func TestPingAll(t *testing.T) {
 	logger := zerolog.Logger{}
-	type args struct {
-		goroutineCount int
-		ips            []string
-		f              func(logger zerolog.Logger, count int, dst string) error
+
+	eps := func(ips ...string) []NodeEndpoint {
+		out := make([]NodeEndpoint, 0, len(ips))
+		for _, ip := range ips {
+			out = append(out, NodeEndpoint{Ip: ip})
+		}
+		return out
+	}
+
+	ok := func(logger zerolog.Logger, count int, ep NodeEndpoint) error { return nil }
+	fail := func(ips ...string) func(logger zerolog.Logger, count int, ep NodeEndpoint) error {
+		return func(logger zerolog.Logger, count int, ep NodeEndpoint) error {
+			if slices.Contains(ips, ep.Ip) {
+				return errors.New("not reachable")
+			}
+			return nil
+		}
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
+		name           string
+		goroutineCount int
+		eps            []NodeEndpoint
+		f              func(logger zerolog.Logger, count int, ep NodeEndpoint) error
+		want           []string
+		wantErr        bool
 	}{
 		{
-			args: args{
-				goroutineCount: 0,
-				ips:            []string{},
-				f:              func(logger zerolog.Logger, count int, dst string) error { return nil },
-			},
+			goroutineCount: 0,
+			eps:            eps(),
+			f:              ok,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
-				f:              func(logger zerolog.Logger, count int, dst string) error { return nil },
-			},
-			want:    nil,
-			wantErr: false,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+			f:              ok,
+			want:           nil,
+			wantErr:        false,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "3":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "3"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+			f:              fail("1", "2", "3"),
+			want:           []string{"1", "2", "3"},
+			wantErr:        true,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "6", "10":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "6", "10"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"),
+			f:              fail("1", "2", "6", "10"),
+			want:           []string{"1", "2", "6", "10"},
+			wantErr:        true,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "6", "10":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "6", "10"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+			f:              fail("1", "2", "6", "10"),
+			want:           []string{"1", "2", "6", "10"},
+			wantErr:        true,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "6", "10":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "6", "10"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"),
+			f:              fail("1", "2", "6", "10"),
+			want:           []string{"1", "2", "6", "10"},
+			wantErr:        true,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "6", "10":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "6", "10"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"),
+			f:              fail("1", "2", "6", "10"),
+			want:           []string{"1", "2", "6", "10"},
+			wantErr:        true,
 		},
 		{
-			args: args{
-				goroutineCount: 3,
-				ips:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28"},
-				f: func(logger zerolog.Logger, count int, dst string) error {
-					switch dst {
-					case "1", "2", "6", "10":
-						return errors.New("not reachable")
-					}
-					return nil
-				},
-			},
-			want:    []string{"1", "2", "6", "10"},
-			wantErr: true,
+			goroutineCount: 3,
+			eps:            eps("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28"),
+			f:              fail("1", "2", "6", "10"),
+			want:           []string{"1", "2", "6", "10"},
+			wantErr:        true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotErr := pingAll(logger, tt.args.goroutineCount, tt.args.ips, tt.args.f)
+			got, gotErr := pingAll(logger, tt.goroutineCount, tt.eps, tt.f)
 			if (gotErr != nil) != tt.wantErr {
 				t.Fatalf("pingAll() got %v, want %v", gotErr, tt.wantErr)
-				return
 			}
 
-			for _, got := range got {
-				found := slices.Contains(tt.want, got)
-				if !found {
-					t.Fatalf("pingAll() got %v missing in want %v", got, tt.want)
+			if len(got) != len(tt.want) {
+				t.Fatalf("pingAll() returned %v unreachable endpoints %v, want %v", len(got), got, tt.want)
+			}
+
+			for _, ep := range got {
+				if !slices.Contains(tt.want, ep.Ip) {
+					t.Fatalf("pingAll() got %v missing in want %v", ep.Ip, tt.want)
 				}
 			}
 		})
 	}
 }
 
-func TestPing(t *testing.T) {
+// The joined error of pingAll must satisfy errors.Is(err, ErrUnreachable) when
+// the ping function reports unreachable nodes, as callers rely on it to
+// distinguish unreachable nodes from failures of the pinging itself.
+func TestPingAllErrorIsUnreachable(t *testing.T) {
+	logger := zerolog.Logger{}
+
+	f := func(logger zerolog.Logger, count int, ep NodeEndpoint) error {
+		return fmt.Errorf("unhealthy connection: %w", ErrUnreachable)
+	}
+
+	_, err := pingAll(logger, 3, []NodeEndpoint{{Ip: "1"}, {Ip: "2"}}, f)
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("pingAll() = %v, want ErrUnreachable", err)
+	}
+}
+
+// Generates a fresh ed25519 keypair, returning the private key PEM encoded as
+// stored in [NodeEndpoint.SSHKey] and the corresponding public key.
+func newTestClientKey(t *testing.T) (string, ssh.PublicKey) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(crand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("failed to marshal client key: %v", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to convert client public key: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(block)), sshPub
+}
+
+// Starts an in-process SSH server on a random localhost port that accepts
+// public key auth for the passed in key only. Returns the listen address.
+func newTestSSHServer(t *testing.T, authorized ssh.PublicKey) string {
+	t.Helper()
+
+	_, hostPriv, err := ed25519.GenerateKey(crand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate host key: %v", err)
+	}
+
+	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
+	if err != nil {
+		t.Fatalf("failed to create host signer: %v", err)
+	}
+
+	cfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), authorized.Marshal()) {
+				return nil, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	//nolint
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				sconn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
+				if err != nil {
+					conn.Close()
+					return
+				}
+				go ssh.DiscardRequests(reqs)
+				go func() {
+					for ch := range chans {
+						_ = ch.Reject(ssh.UnknownChannelType, "unsupported")
+					}
+				}()
+				_ = sconn.Wait()
+				_ = sconn.Close()
+			}()
+		}
+	}()
+
+	return l.Addr().String()
+}
+
+// Starts a server on a random localhost port that completes the TCP handshake
+// but never sends a byte, mimicking a node whose kernel is alive but whose
+// sshd is wedged. Returns the listen address.
+func newSilentServer(t *testing.T) string {
+	t.Helper()
+
+	//nolint
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		// Hold on to the connections so they stay open, but never
+		// respond on them.
+		var conns []net.Conn
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				for _, c := range conns {
+					c.Close()
+				}
+				return
+			}
+			conns = append(conns, conn)
+		}
+	}()
+
+	return l.Addr().String()
+}
+
+func endpoint(t *testing.T, addr, sshKey string) NodeEndpoint {
+	t.Helper()
+
+	ip, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("failed to split address %q: %v", addr, err)
+	}
+
+	return NodeEndpoint{
+		Ip:       ip,
+		Port:     port,
+		Username: "claudie",
+		SSHKey:   sshKey,
+	}
+}
+
+func TestSSHPing(t *testing.T) {
 	if testing.Short() {
-		t.Skipf("skipping ping tests")
+		t.Skipf("skipping ssh ping tests")
 	}
 
 	logger := zerolog.New(os.Stdout)
-	type args struct {
-		count int
-		dst   string
-	}
 
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "ok-empty",
-			args: args{
-				count: 5,
-				dst:   "",
-			},
-			wantErr: false,
-		},
-		{
-			name: "ok-localhost",
-			args: args{
-				count: 5,
-				dst:   "127.0.0.1",
-			},
-			wantErr: false,
-		},
-		{
-			name: "fail-invalid",
-			args: args{
-				count: 5,
-				dst:   "0.0.0.0",
-			},
-			wantErr: true,
-		},
-	}
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		key, pub := newTestClientKey(t)
+		addr := newTestSSHServer(t, pub)
 
-			err := Ping(logger, tt.args.count, tt.args.dst)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Ping() = %v want %v", err, tt.wantErr)
+		if err := SSHPing(logger, PingRetryCount, endpoint(t, addr, key)); err != nil {
+			t.Fatalf("SSHPing() = %v, want nil", err)
+		}
+	})
+
+	t.Run("incomplete-endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		err := SSHPing(logger, 1, NodeEndpoint{Ip: "127.0.0.1"})
+		if !errors.Is(err, ErrUnreachable) {
+			t.Fatalf("SSHPing() = %v, want ErrUnreachable", err)
+		}
+	})
+
+	t.Run("closed-port", func(t *testing.T) {
+		t.Parallel()
+
+		key, _ := newTestClientKey(t)
+
+		// Reserve a port and close it again so that nothing listens on it.
+		//nolint
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to listen: %v", err)
+		}
+		addr := l.Addr().String()
+		l.Close()
+
+		if err := SSHPing(logger, 1, endpoint(t, addr, key)); !errors.Is(err, ErrUnreachable) {
+			t.Fatalf("SSHPing() = %v, want ErrUnreachable", err)
+		}
+	})
+
+	// A node that is alive but refuses the presented key counts as
+	// unreachable, an SSH ping verifies the node is manageable by
+	// claudie, not just that the machine is up.
+	t.Run("auth-rejected", func(t *testing.T) {
+		t.Parallel()
+
+		key, _ := newTestClientKey(t)
+		_, otherPub := newTestClientKey(t)
+		addr := newTestSSHServer(t, otherPub)
+
+		if err := SSHPing(logger, 1, endpoint(t, addr, key)); !errors.Is(err, ErrUnreachable) {
+			t.Fatalf("SSHPing() = %v, want ErrUnreachable", err)
+		}
+	})
+
+	// A host that accepts the TCP connection but never responds must fail
+	// within the handshake deadline instead of blocking forever, see the
+	// SetDeadline call in sshPing.
+	t.Run("silent-server-bounded", func(t *testing.T) {
+		t.Parallel()
+
+		key, _ := newTestClientKey(t)
+		addr := newSilentServer(t)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- SSHPing(logger, 1, endpoint(t, addr, key))
+		}()
+
+		// One attempt costs at most the TCP dial + the handshake
+		// deadline + the retry sleep, anything above that means the
+		// handshake is not bounded.
+		watchdog := 3*PingTimeout + 2*time.Second
+
+		select {
+		case err := <-done:
+			if !errors.Is(err, ErrUnreachable) {
+				t.Fatalf("SSHPing() = %v, want ErrUnreachable", err)
 			}
-		})
-	}
+		case <-time.After(watchdog):
+			t.Fatalf("SSHPing() against a silent server did not return within %v, handshake deadline not enforced", watchdog)
+		}
+	})
 }

--- a/internal/nodepools/nodepools.go
+++ b/internal/nodepools/nodepools.go
@@ -21,11 +21,11 @@ const (
 	DefaultSSHPort = int32(22)
 )
 
-// SSHPort returns the effective SSH port for a nodepool and normalizes the
-// stored value in-place, replacing 0 with DefaultSSHPort.
+// SSHPort returns the effective SSH port for a nodepool, if the SSH
+// port is not set, the [DefaultSSHPort] value is returned as a default.
 func SSHPort(np *spec.NodePool) int32 {
 	if np.SshPort == 0 {
-		np.SshPort = DefaultSSHPort
+		return DefaultSSHPort
 	}
 	return np.SshPort
 }
@@ -38,6 +38,16 @@ func NodeSSHPort(np *spec.NodePool, n *spec.Node) int32 {
 		return n.SshPort
 	}
 	return SSHPort(np)
+}
+
+// NodeSSHUsername returns the Username to be used when establishing an SSH
+// connection to the node. Defaults to 'root' is not set.
+func NodeSSHUsername(n *spec.Node) string {
+	u := "root"
+	if n.Username != "" {
+		u = n.Username
+	}
+	return u
 }
 
 type RegionNetwork struct {
@@ -229,6 +239,7 @@ func PartialCopyWithReplacedNodes(np *spec.NodePool, nodes []*spec.Node, nodeKey
 		Labels:      np.Labels,
 		Taints:      np.Taints,
 		Annotations: np.Annotations,
+		SshPort:     np.SshPort,
 	}
 
 	// To avoid issues with possible node counts, deep clone the node type itself.
@@ -560,11 +571,7 @@ func RandomNodePublicEndpoint(nps []*spec.NodePool) (username, endpoint, key, ss
 	node := np.Nodes[idx]
 
 	endpoint = node.Public
-	username = "root"
-	if node.Username != "" && node.Username != username {
-		username = node.Username
-	}
-
+	username = NodeSSHUsername(node)
 	port := fmt.Sprint(NodeSSHPort(np, node))
 
 	switch t := np.Type.(type) {

--- a/internal/nodepools/nodepools.go
+++ b/internal/nodepools/nodepools.go
@@ -41,7 +41,7 @@ func NodeSSHPort(np *spec.NodePool, n *spec.Node) int32 {
 }
 
 // NodeSSHUsername returns the Username to be used when establishing an SSH
-// connection to the node. Defaults to 'root' is not set.
+// connection to the node. Defaults to 'root', if not set.
 func NodeSSHUsername(n *spec.Node) string {
 	u := "root"
 	if n.Username != "" {

--- a/manifests/claudie/kuber.yaml
+++ b/manifests/claudie/kuber.yaml
@@ -44,9 +44,6 @@ spec:
             capabilities:
               drop:
                 - all
-              add:
-                # needed to access raw sockets for ping.
-                - NET_RAW
           resources:
             requests:
               cpu: 100m

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417
 - name: ghcr.io/berops/claudie/manager
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ddb1426-4403
+  newTag: 407b676-4415
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ddb1426-4403
+  newTag: 407b676-4415
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ddb1426-4403
+  newTag: 407b676-4415
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ddb1426-4403
+  newTag: 407b676-4415
 - name: ghcr.io/berops/claudie/manager
-  newTag: ddb1426-4403
+  newTag: 407b676-4415
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ddb1426-4403
+  newTag: 407b676-4415

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 166b447-4432
+  newTag: 1c26092-4436
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 166b447-4432
+  newTag: 1c26092-4436
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 166b447-4432
+  newTag: 1c26092-4436
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 166b447-4432
+  newTag: 1c26092-4436
 - name: ghcr.io/berops/claudie/manager
-  newTag: 166b447-4432
+  newTag: 1c26092-4436
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 166b447-4432
+  newTag: 1c26092-4436

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430
 - name: ghcr.io/berops/claudie/manager
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430

--- a/manifests/claudie/manager.yaml
+++ b/manifests/claudie/manager.yaml
@@ -44,9 +44,6 @@ spec:
             capabilities:
               drop:
                 - all
-              add:
-                # needed to access raw sockets for ping.
-                - NET_RAW
           resources:
             requests:
               cpu: 80m

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 407b676-4415
+  newTag: ac24f6b-4417

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 6314238-4427
+  newTag: 2281c4d-4430

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ddb1426-4403
+  newTag: 407b676-4415

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 166b447-4432
+  newTag: 1c26092-4436

--- a/services/kuber/internal/worker/service/internal/nodes/delete.go
+++ b/services/kuber/internal/worker/service/internal/nodes/delete.go
@@ -19,11 +19,10 @@ import (
 
 const (
 	longhornNamespace = "longhorn-system"
+	drainTimeout      = 30 * time.Minute
 
-	UnreachableNodesPingCount = clusters.PingRetryCount + 3
-
-	drainTimeout = 30 * time.Minute
-
+	// Label used to prevent deletion of a node
+	// until the label itself is removed from the node.
 	upgradeLockLabelKey = "claudie.io/upgrade-lock"
 )
 
@@ -31,70 +30,47 @@ const (
 // drain because they have the claudie.io/upgrade-lock label set by the operator.
 var ErrUpgradeLocked = errors.New("nodes with claudie.io/upgrade-lock label skipped, waiting for operator to remove label")
 
-// etcdMemberList wraps parsed structures that are
-// needed from the output of the `etcdctl member list`
-// command, ignoring others.
-type etcdMemberList struct {
-	Members []struct {
-		// Hex encoded id of the member within etcd.
-		Id string
+type (
+	// etcdMemberList wraps parsed structures that are
+	// needed from the output of the `etcdctl member list`
+	// command, ignoring others.
+	etcdMemberList struct {
+		Members []struct {
+			// Hex encoded id of the member within etcd.
+			Id string
 
-		// Name of the node within the cluster.
-		Name string
+			// Name of the node within the cluster.
+			Name string
+		}
 	}
-}
 
-type nodeInfo struct {
-	fullname       string
-	k8sName        string
-	publicEndpoint string
-}
+	NodeInfo struct {
+		Fullname string
+		K8sName  string
+		Ep       clusters.NodeEndpoint
+	}
 
-type Deleter struct {
-	masterNodes   []nodeInfo
-	workerNodes   []nodeInfo
-	kubeconfig    string
-	clusterPrefix string
-	controlNode   string
-}
+	Deleter struct {
+		masterNodes   []NodeInfo
+		workerNodes   []NodeInfo
+		kubeconfig    string
+		clusterPrefix string
+		controlNode   string
+	}
+)
 
 // New returns new [Deleter] struct, used for node deletion from a k8s cluster
 // The passed in [spec.K8Scluster] is not modified in any way by any of the
 // functions of the deleter. The passed in deleteMaster and deleteWorker nodes
 // are being worked with to delete them from the kubernetes cluster via the
 // kubeconfig of the [spec.K8Scluster].
-func NewDeleter(
-	deleteMaster, deleteWorker []*spec.Node,
-	cluster *spec.K8Scluster,
-) (*Deleter, error) {
-	var (
-		clusterID = cluster.ClusterInfo.Id()
-		mn, wn    []nodeInfo
-	)
-
-	for i := range deleteMaster {
-		mn = append(mn, nodeInfo{
-			fullname:       deleteMaster[i].Name,
-			k8sName:        strings.TrimPrefix(deleteMaster[i].Name, fmt.Sprintf("%s-", clusterID)),
-			publicEndpoint: deleteMaster[i].Public,
-		})
-	}
-
-	for i := range deleteWorker {
-		wn = append(wn, nodeInfo{
-			fullname:       deleteWorker[i].Name,
-			k8sName:        strings.TrimPrefix(deleteWorker[i].Name, fmt.Sprintf("%s-", clusterID)),
-			publicEndpoint: deleteWorker[i].Public,
-		})
-	}
-
-	// find a control node that will not be deleted.
+func NewDeleter(deleteMaster, deleteWorker []NodeInfo, cluster *spec.K8Scluster) (*Deleter, error) {
 	var notDeleted string
 	for cn := range nodepools.Control(cluster.ClusterInfo.NodePools) {
 		for _, n := range cn.Nodes {
-			if !slices.ContainsFunc(deleteMaster, func(o *spec.Node) bool { return o.Name == n.Name }) {
-				// pick the first control node as the ones
-				// deleted are no longer in the cluster's state.
+			if !slices.ContainsFunc(deleteMaster, func(o NodeInfo) bool { return o.Fullname == n.Name }) {
+				// No need to check whether we are picking a deleted
+				// node, since they are not longer part of the [spec.K8Scluster].
 				notDeleted = n.Name
 				break
 			}
@@ -106,11 +82,11 @@ func NewDeleter(
 	}
 
 	return &Deleter{
-		masterNodes:   mn,
-		workerNodes:   wn,
+		masterNodes:   deleteMaster,
+		workerNodes:   deleteWorker,
 		kubeconfig:    cluster.Kubeconfig,
-		clusterPrefix: clusterID,
-		controlNode:   strings.TrimPrefix(notDeleted, fmt.Sprintf("%s-", clusterID)),
+		clusterPrefix: cluster.ClusterInfo.Id(),
+		controlNode:   strings.TrimPrefix(notDeleted, fmt.Sprintf("%s-", cluster.ClusterInfo.Id())),
 	}, nil
 }
 
@@ -141,78 +117,69 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 
 	// Remove master nodes sequentially to minimise risk of faults in etcd
 	for _, master := range d.masterNodes {
-		if !slices.Contains(k8snodes, master.k8sName) {
+		if !slices.Contains(k8snodes, master.K8sName) {
 			logger.
 				Warn().
-				Msgf("Node with name %s not found in cluster", master.k8sName)
+				Msgf("Node with name %s not found in cluster", master.K8sName)
 			continue
 		}
 
-		hasLock, err := kubectl.KubectlNodeHasLabel(master.k8sName, upgradeLockLabelKey)
+		hasLock, err := kubectl.KubectlNodeHasLabel(master.K8sName, upgradeLockLabelKey)
 		if err != nil {
 			// Fail closed: treat the node as locked so the task is retried
 			// instead of draining on a transient kubectl failure.
-			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", master.k8sName)
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", master.K8sName)
 			locked = true
 			continue
 		}
 		if hasLock {
-			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", master.k8sName)
+			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", master.K8sName)
 			locked = true
 			continue
 		}
 
 		logger.
 			Info().
-			Msgf("verifying if node %s is reachable", master.k8sName)
+			Msgf("verifying if node %s is reachable", master.K8sName)
 
-		if err := clusters.Ping(logger, UnreachableNodesPingCount, master.publicEndpoint); err != nil {
-			if errors.Is(err, clusters.ErrEchoTimeout) {
-				logger.
-					Info().
-					Msgf(
-						"Node %s is unreachable, marking node with `out-of-service` taint "+
-							"before deleting it from the cluster", master.k8sName,
-					)
+		if err := clusters.SSHPing(logger, clusters.PingRetryCount, master.Ep); errors.Is(err, clusters.ErrUnreachable) {
+			logger.
+				Info().
+				Msgf(
+					"Node %s is unreachable, marking node with `out-of-service` taint "+
+						"before deleting it from the cluster", master.K8sName,
+				)
 
-				if err := kubectl.KubectlTaintNodeShutdown(master.k8sName); err != nil {
-					logger.
-						Err(err).
-						Msgf(
-							"Failed to taint node %s with 'out-of-service' taint, proceeding with default deletion",
-							master.k8sName,
-						)
-				}
-			} else {
+			if err := kubectl.KubectlTaintNodeShutdown(master.K8sName); err != nil {
 				logger.
 					Err(err).
 					Msgf(
-						"Failed to determine if node %s is reachable or not, proceeding with default deletion",
-						master.k8sName,
+						"Failed to taint node %s with 'out-of-service' taint, proceeding with default deletion",
+						master.K8sName,
 					)
 			}
 		}
 
 		// IMPORTANT: first you have to cordon and drain, and only after that you can remove from etcd
 		// kubectl cordon <node-name> <args>
-		if err := kubectl.KubectlCordon(master.k8sName); err != nil {
-			errDel = errors.Join(errDel, fmt.Errorf("error while cordon master node %s from cluster: %w", master.k8sName, err))
+		if err := kubectl.KubectlCordon(master.K8sName); err != nil {
+			errDel = errors.Join(errDel, fmt.Errorf("error while cordon master node %s from cluster: %w", master.K8sName, err))
 			continue
 		}
 
 		// kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
-		if err := kubectl.KubectlDrainWithTimeout(drainTimeout, master.k8sName); err != nil {
+		if err := kubectl.KubectlDrainWithTimeout(drainTimeout, master.K8sName); err != nil {
 			if !errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while draining node %s from cluster: %w", master.k8sName, err)
+				return fmt.Errorf("error while draining node %s from cluster: %w", master.K8sName, err)
 			}
 
 			logger.
 				Info().
-				Msgf("timeout for draining node %q reached, continuing with deletion", master.k8sName)
+				Msgf("timeout for draining node %q reached, continuing with deletion", master.K8sName)
 		}
 
 		// delete master nodes from etcd
-		if err := d.deleteFromEtcd(logger, kubectl, master.k8sName); err != nil {
+		if err := d.deleteFromEtcd(logger, kubectl, master.K8sName); err != nil {
 			return fmt.Errorf("error while deleting nodes from etcd: %w", err)
 		}
 
@@ -224,94 +191,85 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 
 	// Remove worker nodes sequentially to minimise risk of fault when replicating PVC
 	for _, worker := range d.workerNodes {
-		if !slices.Contains(k8snodes, worker.k8sName) {
+		if !slices.Contains(k8snodes, worker.K8sName) {
 			logger.
 				Warn().
-				Msgf("Node with name %s not found in cluster", worker.k8sName)
+				Msgf("Node with name %s not found in cluster", worker.K8sName)
 			continue
 		}
 
-		hasLock, err := kubectl.KubectlNodeHasLabel(worker.k8sName, upgradeLockLabelKey)
+		hasLock, err := kubectl.KubectlNodeHasLabel(worker.K8sName, upgradeLockLabelKey)
 		if err != nil {
 			// Fail closed: treat the node as locked so the task is retried
 			// instead of draining on a transient kubectl failure.
-			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", worker.k8sName)
+			logger.Warn().Err(err).Msgf("failed to check upgrade-lock label on node %s, deferring drain", worker.K8sName)
 			locked = true
 			continue
 		}
 		if hasLock {
-			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", worker.k8sName)
+			logger.Info().Msgf("node %s has upgrade-lock label, skipping drain", worker.K8sName)
 			locked = true
 			continue
 		}
 
 		logger.
 			Info().
-			Msgf("verifying if node %s is reachable", worker.k8sName)
+			Msgf("verifying if node %s is reachable", worker.K8sName)
 
-		if err := clusters.Ping(logger, UnreachableNodesPingCount, worker.publicEndpoint); err != nil {
-			if errors.Is(err, clusters.ErrEchoTimeout) {
-				logger.
-					Info().
-					Msgf(
-						"Node %s is unreachable, marking node with `out-of-service` taint "+
-							"before deleting it from the cluster", worker.k8sName,
-					)
+		if err := clusters.SSHPing(logger, clusters.PingRetryCount, worker.Ep); errors.Is(err, clusters.ErrUnreachable) {
+			logger.
+				Info().
+				Msgf(
+					"Node %s is unreachable, marking node with `out-of-service` taint "+
+						"before deleting it from the cluster", worker.K8sName,
+				)
 
-				if err := kubectl.KubectlTaintNodeShutdown(worker.k8sName); err != nil {
-					logger.
-						Err(err).
-						Msgf(
-							"Failed to taint node %s with 'out-of-service' taint, proceeding with default deletion",
-							worker.k8sName,
-						)
-				}
-			} else {
+			if err := kubectl.KubectlTaintNodeShutdown(worker.K8sName); err != nil {
 				logger.
 					Err(err).
 					Msgf(
-						"Failed to determine if node %s is reachable or not, proceeding with default deletion",
-						worker.k8sName,
+						"Failed to taint node %s with 'out-of-service' taint, proceeding with default deletion",
+						worker.K8sName,
 					)
 			}
 		}
 
-		if err := disableDiskScheduling(kubectl, worker.k8sName); err != nil {
+		if err := disableDiskScheduling(kubectl, worker.K8sName); err != nil {
 			// not a fatal error.
 			logger.
 				Warn().
-				Msgf("failed to disable longhorn disk scheduling for node %q: %s", worker.k8sName, err)
+				Msgf("failed to disable longhorn disk scheduling for node %q: %s", worker.K8sName, err)
 		}
 
 		// kubectl cordon <node-name> <args>
-		if err := kubectl.KubectlCordon(worker.k8sName); err != nil {
-			errDel = errors.Join(errDel, fmt.Errorf("error while cordon worker node %s from cluster: %w", worker.k8sName, err))
+		if err := kubectl.KubectlCordon(worker.K8sName); err != nil {
+			errDel = errors.Join(errDel, fmt.Errorf("error while cordon worker node %s from cluster: %w", worker.K8sName, err))
 			continue
 		}
 
 		// kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
-		if err := kubectl.KubectlDrainWithTimeout(drainTimeout, worker.k8sName); err != nil {
+		if err := kubectl.KubectlDrainWithTimeout(drainTimeout, worker.K8sName); err != nil {
 			if !errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while draining node %s from cluster: %w", worker.k8sName, err)
+				return fmt.Errorf("error while draining node %s from cluster: %w", worker.K8sName, err)
 			}
 
 			logger.
 				Info().
-				Msgf("timeout for draining node %q reached, continuing with deletion", worker.k8sName)
+				Msgf("timeout for draining node %q reached, continuing with deletion", worker.K8sName)
 		}
 
 		if err := d.deleteNodesByName(logger, kubectl, worker, k8snodes); err != nil {
-			errDel = errors.Join(errDel, fmt.Errorf("error while deleting node %s from cluster: %w", worker.k8sName, err))
+			errDel = errors.Join(errDel, fmt.Errorf("error while deleting node %s from cluster: %w", worker.K8sName, err))
 			continue
 		}
 
-		if err := removeReplicasOnDeletedNode(kubectl, worker.k8sName); err != nil {
+		if err := removeReplicasOnDeletedNode(kubectl, worker.K8sName); err != nil {
 			// not a fatal error.
 			logger.
 				Warn().
 				Msgf(
 					"failed to delete unused replicas from replicas.longhorn.io, after node %s deletion: %s",
-					worker.k8sName,
+					worker.K8sName,
 					err,
 				)
 		}
@@ -324,17 +282,17 @@ func (d *Deleter) DeleteNodes(logger zerolog.Logger) error {
 }
 
 // deleteNodesByName deletes node from the k8s cluster.
-func (d *Deleter) deleteNodesByName(logger zerolog.Logger, kc kubectl.Kubectl, node nodeInfo, realNodeNames []string) error {
-	if !slices.Contains(realNodeNames, node.k8sName) {
-		logger.Warn().Msgf("Node with name %s not found in cluster", node.k8sName)
+func (d *Deleter) deleteNodesByName(logger zerolog.Logger, kc kubectl.Kubectl, node NodeInfo, realNodeNames []string) error {
+	if !slices.Contains(realNodeNames, node.K8sName) {
+		logger.Warn().Msgf("Node with name %s not found in cluster", node.K8sName)
 		return nil
 	}
 
-	logger.Info().Msgf("Deleting node %s from k8s cluster", node.k8sName)
+	logger.Info().Msgf("Deleting node %s from k8s cluster", node.K8sName)
 
 	//kubectl delete node <node-name>
-	if err := kc.KubectlDeleteResource("nodes", node.k8sName); err != nil {
-		return fmt.Errorf("error while deleting node %s from cluster: %w", node.k8sName, err)
+	if err := kc.KubectlDeleteResource("nodes", node.K8sName); err != nil {
+		return fmt.Errorf("error while deleting node %s from cluster: %w", node.K8sName, err)
 	}
 
 	return nil

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/berops/claudie/internal/clusters"
 	"github.com/berops/claudie/internal/kubectl"
 	"github.com/berops/claudie/internal/nodepools"
 	"github.com/berops/claudie/proto/pb/spec"
@@ -36,6 +37,197 @@ func DeleteNodes(logger zerolog.Logger, tracker Tracker) {
 	}
 }
 
+func deleteFromState(
+	logger zerolog.Logger,
+	a *spec.Update_KDeleteNodes,
+	k8s *spec.K8Scluster,
+	tracker Tracker,
+) {
+	if a.KDeleteNodes.WithNodePool {
+		k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, a.KDeleteNodes.Nodepool)
+	} else {
+		np := nodepools.FindByName(a.KDeleteNodes.Nodepool, k8s.ClusterInfo.NodePools)
+		if np == nil {
+			// The scheduled deletion of the node from the nodepool is not present
+			// in the clusters state. As to why this code is place in this function
+			// and also in the [deleteNodesFromCluster] function, the reason is that
+			// since these nodes are not in the tracked state when the message is submited
+			// back into the manager service it will refuse the update.
+			//
+			// However since this function is part of a node deletion process we need
+			// to handle drifts in the state at this point. For example it may happen
+			// that a VM was shutdown and removed from the cluster, but the VM itself
+			// may not have been destroyed and came back online at a future point in time
+			//
+			// which causes a drift in the state and the VM is no longer in the tracked
+			// state but claudie schedules a deletion to fix the drift in which case
+			// the code in this function handles it.
+			logger.
+				Warn().
+				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
+					"to be deleted is missing from the provided state, interpreting this as a drift and "+
+					"scheduling a deletion of one of the nodes", a.KDeleteNodes.Nodepool)
+
+			if len(a.KDeleteNodes.Nodes) < 1 {
+				return
+			}
+
+			fullname := a.KDeleteNodes.Nodes[0]
+			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
+
+			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
+			if err != nil {
+				logger.
+					Warn().
+					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
+						"assuming node is no longer part of the cluster", fullname)
+				return
+			}
+
+			if err := deleteUntrackedNodes(logger, k8s, isControl, []*spec.Node{{Name: fullname}}); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+
+			// Do not propagate an update in this case as the nodepool is not tracked
+			// and the manager service wil refuse the update. This will also cause
+			// for the manager to not consume the update and therefore other stages
+			// of the scheduled pipeline, if any, will be skipped with a no-op.
+			return
+		}
+		nodepools.DeleteNodes(np, a.KDeleteNodes.Nodes)
+	}
+
+	update := tracker.Result.Update()
+	update.Kubernetes(k8s)
+	update.Commit()
+
+	logger.
+		Info().
+		Msgf("Nodes %v Removed from tracked state", a.KDeleteNodes.Nodes)
+}
+
+func deleteNodesFromCluster(
+	logger zerolog.Logger,
+	a *spec.Update_DeletedK8SNodes_,
+	k8s *spec.K8Scluster,
+	tracker Tracker,
+) {
+	switch typ := a.DeletedK8SNodes.Kind.(type) {
+	case *spec.Update_DeletedK8SNodes_Partial_:
+		if len(typ.Partial.Nodes) < 1 {
+			logger.Info().Msg("Received task with no nodes to remove")
+			return
+		}
+
+		np := nodepools.FindByName(typ.Partial.Nodepool, k8s.ClusterInfo.NodePools)
+		if np == nil {
+			logger.
+				Warn().
+				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
+					"to be deleted is missing from the provided state, interpreting this as a drift and "+
+					"scheduling a deletion of one of the nodes", typ.Partial.Nodepool)
+
+			if len(typ.Partial.Nodes) < 1 {
+				return
+			}
+
+			node := typ.Partial.Nodes[0]
+			fullname := node.Name
+			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
+
+			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
+			if err != nil {
+				logger.
+					Warn().
+					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
+						"assuming node is no longer part of the cluster", fullname)
+				return
+			}
+
+			if err := deleteUntrackedNodes(logger, k8s, isControl, []*spec.Node{node}); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+
+			// Do not propagate an update in this case as the nodepool is not tracked
+			// and the manager service wil refuse the update
+			return
+		}
+
+		switch t := np.Type.(type) {
+		case *spec.NodePool_DynamicNodePool:
+			logger.
+				Info().
+				Msgf("Deleting %v dynamic node/s from nodepool %q", len(typ.Partial.Nodes), np.Name)
+
+			if err := deleteDynamicNodes(logger, k8s, np, typ.Partial.Nodes); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+		case *spec.NodePool_StaticNodePool:
+			logger.
+				Info().
+				Msgf("Deleting %v static node/s from nodepool %q", len(typ.Partial.Nodes), np.Name)
+
+			if err := deleteStaticNodes(logger, k8s, np, typ.Partial.Nodes, typ.Partial.StaticNodeKeys); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+		default:
+			logger.Info().Msgf("Unknown nodepool type %T", t)
+			return
+		}
+
+		logger.Info().Msg("Nodes successfully deleted")
+		return
+	case *spec.Update_DeletedK8SNodes_Whole:
+		if len(typ.Whole.Nodepool.Nodes) < 1 {
+			logger.Info().Msg("Received task with no nodes to remove")
+			return
+		}
+
+		np := typ.Whole.Nodepool
+		switch t := np.Type.(type) {
+		case *spec.NodePool_DynamicNodePool:
+			logger.
+				Info().
+				Msgf("Deleting %v dynamic node/s from nodepool %q", len(np.Nodes), np.Name)
+
+			if err := deleteDynamicNodes(logger, k8s, np, np.Nodes); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+		case *spec.NodePool_StaticNodePool:
+			logger.
+				Info().
+				Msgf("Deleting %v static node/s from nodepool %q", len(np.Nodes), np.Name)
+
+			if err := deleteStaticNodes(logger, k8s, np, np.Nodes, np.GetStaticNodePool().NodeKeys); err != nil {
+				logger.Err(err).Msg("Failed to delete nodes")
+				tracker.Diagnostics.Push(err)
+				return
+			}
+		default:
+			logger.Info().Msgf("Unknown nodepool type %T", t)
+			return
+		}
+
+		logger.Info().Msg("Nodes successfully deleted")
+		return
+	default:
+		logger.
+			Info().
+			Msgf("Received unknown task %T for node deletion, skipping", typ)
+		return
+	}
+}
+
 func isControlNode(name string, kubeconfig string) (bool, error) {
 	kc := kubectl.Kubectl{
 		Kubeconfig:        kubeconfig,
@@ -63,160 +255,99 @@ func isControlNode(name string, kubeconfig string) (bool, error) {
 	return ok, nil
 }
 
-func deleteNodes(logger zerolog.Logger, master, worker []*spec.Node, k8s *spec.K8Scluster) error {
+func deleteUntrackedNodes(logger zerolog.Logger, k8s *spec.K8Scluster, isControl bool, n []*spec.Node) error {
+	var master, worker []nodes.NodeInfo
+	var ni []nodes.NodeInfo
+
+	for i := range n {
+		ni = append(ni, nodes.NodeInfo{
+			Fullname: n[i].Name,
+			K8sName:  strings.TrimPrefix(n[i].Name, fmt.Sprintf("%s-", k8s.ClusterInfo.Id())),
+			// Zero value, treat as unreachable by default.
+			Ep: clusters.NodeEndpoint{},
+		})
+	}
+
+	if isControl {
+		master = append(master, ni...)
+	} else {
+		worker = append(worker, ni...)
+	}
+
 	deleter, err := nodes.NewDeleter(master, worker, k8s)
 	if err != nil {
 		return err
 	}
-
 	return deleter.DeleteNodes(logger)
 }
 
-func deleteFromState(
+func deleteStaticNodes(
 	logger zerolog.Logger,
-	a *spec.Update_KDeleteNodes,
 	k8s *spec.K8Scluster,
-	tracker Tracker,
-) {
-	if a.KDeleteNodes.WithNodePool {
-		k8s.ClusterInfo.NodePools = nodepools.DeleteByName(k8s.ClusterInfo.NodePools, a.KDeleteNodes.Nodepool)
-	} else {
-		np := nodepools.FindByName(a.KDeleteNodes.Nodepool, k8s.ClusterInfo.NodePools)
-		if np == nil {
-			logger.
-				Warn().
-				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
-					"to be deleted is missing from the provided state, interpreting this as a drift and "+
-					"scheduling a deletion of one of the nodes", a.KDeleteNodes.Nodepool)
+	np *spec.NodePool,
+	n []*spec.Node,
+	nodeKeys map[string]string,
+) error {
+	var master, worker []nodes.NodeInfo
+	var ni []nodes.NodeInfo
 
-			if len(a.KDeleteNodes.Nodes) < 1 {
-				return
-			}
-
-			fullname := a.KDeleteNodes.Nodes[0]
-			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
-
-			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
-			if err != nil {
-				logger.
-					Warn().
-					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
-						"assuming node is no longer part of the cluster", fullname)
-				return
-			}
-
-			var master, worker []*spec.Node
-
-			if isControl {
-				logger.Info().Msgf("Deleting control node %q", fullname)
-				master = append(master, &spec.Node{Name: fullname})
-			} else {
-				logger.Info().Msgf("Deleting worker node %q", fullname)
-				worker = append(worker, &spec.Node{Name: fullname})
-			}
-
-			if err := deleteNodes(logger, master, worker, k8s); err != nil {
-				logger.Err(err).Msg("Failed to delete nodes")
-				tracker.Diagnostics.Push(err)
-				return
-			}
-			// Do not propagate an update in this case as the nodepool is not tracked
-			// and the manager service wil refuse the update.
-			return
-		}
-		nodepools.DeleteNodes(np, a.KDeleteNodes.Nodes)
+	for i := range n {
+		ni = append(ni, nodes.NodeInfo{
+			Fullname: n[i].Name,
+			K8sName:  strings.TrimPrefix(n[i].Name, fmt.Sprintf("%s-", k8s.ClusterInfo.Id())),
+			Ep: clusters.NodeEndpoint{
+				Ip:       n[i].Public,
+				Port:     fmt.Sprint(nodepools.NodeSSHPort(np, n[i])),
+				Username: nodepools.NodeSSHUsername(n[i]),
+				SSHKey:   nodeKeys[n[i].Public],
+			},
+		})
 	}
 
-	update := tracker.Result.Update()
-	update.Kubernetes(k8s)
-	update.Commit()
+	if np.IsControl {
+		master = append(master, ni...)
+	} else {
+		worker = append(worker, ni...)
+	}
 
-	logger.
-		Info().
-		Msgf("Nodes %v Removed from tracked state", a.KDeleteNodes.Nodes)
+	deleter, err := nodes.NewDeleter(master, worker, k8s)
+	if err != nil {
+		return err
+	}
+	return deleter.DeleteNodes(logger)
 }
 
-func deleteNodesFromCluster(
+func deleteDynamicNodes(
 	logger zerolog.Logger,
-	a *spec.Update_DeletedK8SNodes_,
 	k8s *spec.K8Scluster,
-	tracker Tracker,
-) {
-	var master, worker []*spec.Node
+	np *spec.NodePool,
+	n []*spec.Node,
+) error {
+	var master, worker []nodes.NodeInfo
+	var ni []nodes.NodeInfo
 
-	switch typ := a.DeletedK8SNodes.Kind.(type) {
-	case *spec.Update_DeletedK8SNodes_Partial_:
-		np := nodepools.FindByName(typ.Partial.Nodepool, k8s.ClusterInfo.NodePools)
-		if np == nil {
-			logger.
-				Warn().
-				Msgf("Received valid task for deleting nodes, but the nodepool %q from which nodes are "+
-					"to be deleted is missing from the provided state, interpreting this as a drift and "+
-					"scheduling a deletion of one of the nodes", typ.Partial.Nodepool)
-
-			if len(typ.Partial.Nodes) < 1 {
-				return
-			}
-
-			node := typ.Partial.Nodes[0]
-			fullname := node.Name
-			strippedName := strings.TrimPrefix(fullname, fmt.Sprintf("%s-", k8s.ClusterInfo.Id()))
-
-			isControl, err := isControlNode(strippedName, k8s.Kubeconfig)
-			if err != nil {
-				logger.
-					Warn().
-					Msgf("Failed to determine role for node %q within kubernetes cluster, "+
-						"assuming node is no longer part of the cluster", fullname)
-				return
-			}
-
-			if isControl {
-				logger.Info().Msgf("Deleting control node %q", fullname)
-				master = append(master, node)
-			} else {
-				logger.Info().Msgf("Deleting worker node %q", fullname)
-				worker = append(worker, node)
-			}
-
-			if err := deleteNodes(logger, master, worker, k8s); err != nil {
-				logger.Err(err).Msg("Failed to delete nodes")
-				tracker.Diagnostics.Push(err)
-				return
-			}
-
-			// Do not propagate an update in this case as the nodepool is not tracked
-			// and the manager service wil refuse the update
-			return
-		}
-
-		if np.IsControl {
-			master = append(master, typ.Partial.Nodes...)
-		} else {
-			worker = append(worker, typ.Partial.Nodes...)
-		}
-	case *spec.Update_DeletedK8SNodes_Whole:
-		if typ.Whole.Nodepool.IsControl {
-			master = append(master, typ.Whole.Nodepool.Nodes...)
-		} else {
-			worker = append(worker, typ.Whole.Nodepool.Nodes...)
-		}
+	for i := range n {
+		ni = append(ni, nodes.NodeInfo{
+			Fullname: n[i].Name,
+			K8sName:  strings.TrimPrefix(n[i].Name, fmt.Sprintf("%s-", k8s.ClusterInfo.Id())),
+			Ep: clusters.NodeEndpoint{
+				Ip:       n[i].Public,
+				Port:     fmt.Sprint(nodepools.NodeSSHPort(np, n[i])),
+				Username: nodepools.NodeSSHUsername(n[i]),
+				SSHKey:   np.GetDynamicNodePool().PrivateKey,
+			},
+		})
 	}
 
-	if len(master) == 0 && len(worker) == 0 {
-		logger.Info().Msg("Received task with no nodes to remove")
-		return
+	if np.IsControl {
+		master = append(master, ni...)
+	} else {
+		worker = append(worker, ni...)
 	}
 
-	logger.
-		Info().
-		Msgf("Deleting %v control nodes %v worker nodes", len(master), len(worker))
-
-	if err := deleteNodes(logger, master, worker, k8s); err != nil {
-		logger.Err(err).Msg("Failed to delete nodes")
-		tracker.Diagnostics.Push(err)
-		return
+	deleter, err := nodes.NewDeleter(master, worker, k8s)
+	if err != nil {
+		return err
 	}
-
-	logger.Info().Msg("Nodes successfully deleted")
+	return deleter.DeleteNodes(logger)
 }

--- a/services/kuber/internal/worker/service/task_delete_nodes.go
+++ b/services/kuber/internal/worker/service/task_delete_nodes.go
@@ -92,8 +92,8 @@ func deleteFromState(
 
 			// Do not propagate an update in this case as the nodepool is not tracked
 			// and the manager service wil refuse the update. This will also cause
-			// for the manager to not consume the update and therefore other stages
-			// of the scheduled pipeline, if any, will be skipped with a no-op.
+			// for the manager to not consume the update and therefore continue with
+			// other stages, if any.
 			return
 		}
 		nodepools.DeleteNodes(np, a.KDeleteNodes.Nodes)

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -49,8 +49,7 @@ type NodeDescription struct {
 	LastTransitionTime *metav1.Time
 }
 
-// UnreachableNodesMap holds the nodepools and all of the nodes within
-// that nodepool that are unreachable via a Ping on the IPv4 public endpoint.
+// UnreachableNodesMap unreachable nodepools to their unreachable nodes IPs.
 type UnreachableIPv4Map = map[string][]string
 
 type UnknownNodeStatus struct {
@@ -191,7 +190,7 @@ func CheckNodesStatus(logger zerolog.Logger, state *spec.Clusters, hc HealthChec
 
 	result.UnknownLoadBalancersNodes, err = clusters.PingLoadBalancerNodes(logger, state)
 	if err != nil {
-		if !errors.Is(err, clusters.ErrEchoTimeout) {
+		if !errors.Is(err, clusters.ErrUnreachable) {
 			logger.
 				Err(err).
 				Msg("Failed to determine if any nodes were unreachable")
@@ -200,9 +199,8 @@ func CheckNodesStatus(logger zerolog.Logger, state *spec.Clusters, hc HealthChec
 			// in which case the healthcheck cannot be interpreted properly.
 			return result, err
 		}
-
-		// If there is a [clusters.ErrEchoTimeout], fallthrough as the
-		// returned k, lb values will have unreachable nodes.
+		// If there is a [clusters.ErrUnreachable], fallthrough as the
+		// returned value will contain unreachable nodes.
 	}
 
 	return result, nil

--- a/services/manager/internal/service/healthcheck.go
+++ b/services/manager/internal/service/healthcheck.go
@@ -49,7 +49,7 @@ type NodeDescription struct {
 	LastTransitionTime *metav1.Time
 }
 
-// UnreachableNodesMap unreachable nodepools to their unreachable nodes IPs.
+// UnreachableIPv4Map unreachable nodepools to their unreachable nodes IPs.
 type UnreachableIPv4Map = map[string][]string
 
 type UnknownNodeStatus struct {

--- a/services/testing-framework/utils.go
+++ b/services/testing-framework/utils.go
@@ -298,10 +298,7 @@ func validateWireguardSetup(nps []*spec.NodePool, expectedPeerList []Peer) error
 
 			var sshKey string
 			port := nodepools.NodeSSHPort(np, n)
-			username := n.Username
-			if username == "" {
-				username = "root"
-			}
+			username := nodepools.NodeSSHUsername(n)
 
 			switch typ := np.Type.(type) {
 			case *spec.NodePool_DynamicNodePool:


### PR DESCRIPTION
Closes https://github.com/berops/claudie/issues/2181

Changes in this Pull Requests drops all previous usage of raw ICMP packets for pinging (only used for LoadBalancer nodes) and replaces them with SSH pings that timed-out after ~4 seconds if the node is unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node reachability checks now use SSH with retries and endpoint-specific diagnostics.
  * Node deletion supports static, dynamic, and untracked nodes.
  * SSH username and port defaults are applied consistently.

* **Bug Fixes**
  * Improved handling of unreachable nodes and partial health-check results.

* **Documentation**
  * Updated concurrent health-check settings and reduced the default worker count from 20 to 10.

* **Security**
  * Removed unnecessary raw-network access from service containers.

* **Chores**
  * Updated container image versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->