### PR TITLE
fix unreachable node deletion pipeline

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426
 - name: ghcr.io/berops/claudie/manager
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 6314238-4427
+  newTag: 166b447-4432
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 6314238-4427
+  newTag: 166b447-4432
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 6314238-4427
+  newTag: 166b447-4432
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 6314238-4427
+  newTag: 166b447-4432
 - name: ghcr.io/berops/claudie/manager
-  newTag: 6314238-4427
+  newTag: 166b447-4432
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 6314238-4427
+  newTag: 166b447-4432

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: ddb1426-4403
+  newTag: b296c06-4422
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: ddb1426-4403
+  newTag: b296c06-4422
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: ddb1426-4403
+  newTag: b296c06-4422
 - name: ghcr.io/berops/claudie/kuber
-  newTag: ddb1426-4403
+  newTag: b296c06-4422
 - name: ghcr.io/berops/claudie/manager
-  newTag: ddb1426-4403
+  newTag: b296c06-4422
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: ddb1426-4403
+  newTag: b296c06-4422

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 6314238-4427
+  newTag: 166b447-4432

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: ddb1426-4403
+  newTag: b296c06-4422

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 3876bcc-4424
+  newTag: 9ae531d-4426

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -1326,35 +1326,35 @@ func ScheduleDeletionsInNodePools(
 	}
 
 	for np, nodes := range diff.Deleted {
+		// Nodepools deleted as a whole are always part of the claudie tracked
+		// state. [NodePoolsDiff] fills [NodePoolsDiffResult.Deleted] from the
+		// current state and the reconciliate_unreachable_nodes drift logic only
+		// ever fills [NodePoolsDiffResult.PartiallyDeleted], thus the lookup
+		// cannot return nil.
 		currentStateNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools)
-		if currentStateNodePool != nil {
-			// If the ApiServer is on the kubernetes cluster on deletion of the
-			// control plane nodes the Kubeadm config map needs to be updated which
-			// is used during the join operation of new nodes.
-			if opts.HasApiServer && currentStateNodePool.IsControl {
-				kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
-					{
-						Kind: spec.StageKuber_PATCH_KUBEADM,
-						Description: &spec.StageDescription{
-							About:      "Updating Kubeadm certSANs",
-							ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
-						},
-					},
-					{
-						Kind: spec.StageKuber_CILIUM_RESTART,
-						Description: &spec.StageDescription{
-							About: "Rollout restart of cilium pods",
-							// Rollout restart failing is not a fatal error.
-							ErrorLevel: spec.ErrorLevel_ERROR_WARN,
-						},
-					},
-				}...)
-			}
-		}
 
-		// Contrary to addition, when deleting we do not skip if the nodepool is not found.
-		// As deleting from a not found nodepool should be handled gracefully by the existing
-		// services.
+		// If the ApiServer is on the kubernetes cluster on deletion of the
+		// control plane nodes the Kubeadm config map needs to be updated which
+		// is used during the join operation of new nodes.
+		if opts.HasApiServer && currentStateNodePool.IsControl {
+			kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
+				{
+					Kind: spec.StageKuber_PATCH_KUBEADM,
+					Description: &spec.StageDescription{
+						About:      "Updating Kubeadm certSANs",
+						ErrorLevel: spec.ErrorLevel_ERROR_FATAL,
+					},
+				},
+				{
+					Kind: spec.StageKuber_CILIUM_RESTART,
+					Description: &spec.StageDescription{
+						About: "Rollout restart of cilium pods",
+						// Rollout restart failing is not a fatal error.
+						ErrorLevel: spec.ErrorLevel_ERROR_WARN,
+					},
+				},
+			}...)
+		}
 
 		// If the deletion of the last autoscaled nodepools is to be scheduled. Also remove
 		// the CA requirement for the cluster.
@@ -1428,30 +1428,16 @@ func ScheduleDeletionsInNodePools(
 		pipeline := []*spec.Stage{
 			removeFromTrackedStage,
 		}
-
-		// If the nodepool is missing from the current state
-		// and this function was called it means that the
-		// reconciliate_unreachable_nodes logic was involved.
-		//
-		// Scheduling a node/nodepool deletion that is not part
-		// of the tracked state is a valid operation, as the node
-		// may have been unreachable, claudie decided to delete it
-		// but it may have come back online and re-connected to the
-		// cluster. Therefore the following stages are only to be
-		// considered when the node/nodepool is part of the claudie
-		// tracked state.
-		if currentStateNodePool != nil {
-			if removeFromLBStage != nil {
-				pipeline = append(pipeline, removeFromLBStage)
-			}
-			pipeline = append(pipeline, removeFromClusterStage)
-			if len(ans.Ansibler.SubPasses) > 0 {
-				cleanUpStage = &spec.Stage{StageKind: &ans}
-				pipeline = append(pipeline, cleanUpStage)
-			}
-			if infraRemovalStage != nil {
-				pipeline = append(pipeline, infraRemovalStage)
-			}
+		if removeFromLBStage != nil {
+			pipeline = append(pipeline, removeFromLBStage)
+		}
+		pipeline = append(pipeline, removeFromClusterStage)
+		if len(ans.Ansibler.SubPasses) > 0 {
+			cleanUpStage = &spec.Stage{StageKind: &ans}
+			pipeline = append(pipeline, cleanUpStage)
+		}
+		if infraRemovalStage != nil {
+			pipeline = append(pipeline, infraRemovalStage)
 		}
 
 		return &spec.TaskEvent{

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -1029,10 +1029,17 @@ func ScheduleAdditionsInNodePools(
 	return nil
 }
 
+// K8sNodeDeletionOptions are options to be passed into the [ScheduleDeletionsInNodePools]
+// function to configure aspects of the pipeline for the deletion.
 type K8sNodeDeletionOptions struct {
-	UseProxy     bool
+	// UseProxy switch for scheduling proxy related tasks within the workflow.
+	UseProxy bool
+
+	// Whether the kubernetes cluster has one of its control nodes as the API server.
 	HasApiServer bool
-	IsStatic     bool
+
+	// Whether the nodes are from a static nodepool or not.
+	IsStatic bool
 
 	// Optional unreachable infrastructure that will
 	// be passed along the scheduled deletion [spec.TaskEvent]
@@ -1162,8 +1169,7 @@ func ScheduleDeletionsInNodePools(
 		}...)
 	}
 
-	// Only send the data through the terraformer stage if deletion is
-	// for dynamic nodes.
+	// Only send the data through the terraformer stage if deletion is for dynamic nodes.
 	if !opts.IsStatic {
 		infraRemovalStage = &spec.Stage{
 			StageKind: &spec.Stage_Terraformer{
@@ -1187,11 +1193,12 @@ func ScheduleDeletionsInNodePools(
 	}
 
 	for np, nodes := range diff.PartiallyDeleted {
-		// If the ApiServer is on the kubernetes cluster on deletion of the
-		// control plane nodes the Kubeadm config map needs to be updated which
-		// is used during the join operation of new nodes.
-		if matchedNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); matchedNodePool != nil {
-			if opts.HasApiServer && matchedNodePool.IsControl {
+		currentStateNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools)
+		if currentStateNodePool != nil {
+			// If the ApiServer is on the kubernetes cluster on deletion of the
+			// control plane nodes the Kubeadm config map needs to be updated which
+			// is used during the join operation of new nodes.
+			if opts.HasApiServer && currentStateNodePool.IsControl {
 				kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
 					{
 						Kind: spec.StageKuber_PATCH_KUBEADM,
@@ -1262,23 +1269,33 @@ func ScheduleDeletionsInNodePools(
 			}
 		}
 
-		var pipeline []*spec.Stage
-
-		pipeline = append(pipeline, removeFromTrackedStage)
-
-		if removeFromLBStage != nil {
-			pipeline = append(pipeline, removeFromLBStage)
+		pipeline := []*spec.Stage{
+			removeFromTrackedStage,
 		}
 
-		pipeline = append(pipeline, removeFromClusterStage)
-
-		if len(ans.Ansibler.SubPasses) > 0 {
-			cleanUpStage = &spec.Stage{StageKind: &ans}
-			pipeline = append(pipeline, cleanUpStage)
-		}
-
-		if infraRemovalStage != nil {
-			pipeline = append(pipeline, infraRemovalStage)
+		// If the nodepool is missing from the current state
+		// and this function was called it means that the
+		// reconciliate_unreachable_nodes logic was involved.
+		//
+		// Scheduling a node/nodepool deletion that is not part
+		// of the tracked state is a valid operation, as the node
+		// may have been unreachable, claudie decided to delete it
+		// but it may have come back online and re-connected to the
+		// cluster. Therefore the following stages are only to be
+		// considered when the node/nodepool is part of the claudie
+		// tracked state.
+		if currentStateNodePool != nil {
+			if removeFromLBStage != nil {
+				pipeline = append(pipeline, removeFromLBStage)
+			}
+			pipeline = append(pipeline, removeFromClusterStage)
+			if len(ans.Ansibler.SubPasses) > 0 {
+				cleanUpStage = &spec.Stage{StageKind: &ans}
+				pipeline = append(pipeline, cleanUpStage)
+			}
+			if infraRemovalStage != nil {
+				pipeline = append(pipeline, infraRemovalStage)
+			}
 		}
 
 		return &spec.TaskEvent{
@@ -1309,11 +1326,12 @@ func ScheduleDeletionsInNodePools(
 	}
 
 	for np, nodes := range diff.Deleted {
-		// If the ApiServer is on the kubernetes cluster on deletion of the
-		// control plane nodes the Kubeadm config map needs to be updated which
-		// is used during the join operation of new nodes.
-		if matchedNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools); matchedNodePool != nil {
-			if opts.HasApiServer && matchedNodePool.IsControl {
+		currentStateNodePool := nodepools.FindByName(np, current.K8S.ClusterInfo.NodePools)
+		if currentStateNodePool != nil {
+			// If the ApiServer is on the kubernetes cluster on deletion of the
+			// control plane nodes the Kubeadm config map needs to be updated which
+			// is used during the join operation of new nodes.
+			if opts.HasApiServer && currentStateNodePool.IsControl {
 				kuber.Kuber.SubPasses = append(kuber.Kuber.SubPasses, []*spec.StageKuber_SubPass{
 					{
 						Kind: spec.StageKuber_PATCH_KUBEADM,
@@ -1407,21 +1425,33 @@ func ScheduleDeletionsInNodePools(
 			}
 		}
 
-		var pipeline []*spec.Stage
-
-		pipeline = append(pipeline, removeFromTrackedStage)
-
-		if removeFromLBStage != nil {
-			pipeline = append(pipeline, removeFromLBStage)
+		pipeline := []*spec.Stage{
+			removeFromTrackedStage,
 		}
 
-		pipeline = append(pipeline, removeFromClusterStage)
-		if len(ans.Ansibler.SubPasses) > 0 {
-			cleanUpStage = &spec.Stage{StageKind: &ans}
-			pipeline = append(pipeline, cleanUpStage)
-		}
-		if infraRemovalStage != nil {
-			pipeline = append(pipeline, infraRemovalStage)
+		// If the nodepool is missing from the current state
+		// and this function was called it means that the
+		// reconciliate_unreachable_nodes logic was involved.
+		//
+		// Scheduling a node/nodepool deletion that is not part
+		// of the tracked state is a valid operation, as the node
+		// may have been unreachable, claudie decided to delete it
+		// but it may have come back online and re-connected to the
+		// cluster. Therefore the following stages are only to be
+		// considered when the node/nodepool is part of the claudie
+		// tracked state.
+		if currentStateNodePool != nil {
+			if removeFromLBStage != nil {
+				pipeline = append(pipeline, removeFromLBStage)
+			}
+			pipeline = append(pipeline, removeFromClusterStage)
+			if len(ans.Ansibler.SubPasses) > 0 {
+				cleanUpStage = &spec.Stage{StageKind: &ans}
+				pipeline = append(pipeline, cleanUpStage)
+			}
+			if infraRemovalStage != nil {
+				pipeline = append(pipeline, infraRemovalStage)
+			}
 		}
 
 		return &spec.TaskEvent{

--- a/services/manager/internal/service/reconciliate_kubernetes_test.go
+++ b/services/manager/internal/service/reconciliate_kubernetes_test.go
@@ -51,8 +51,11 @@ func namedDynamicNodePool(name string) *spec.NodePool {
 }
 
 // expectedStage describes a single pipeline stage of a scheduled deletion,
-// exactly one of the subpass slices is set, matching the stage kind.
+// exactly one of the subpass slices is set, matching the stage kind. The
+// about field pins the stage description, as stages of the same kind with
+// the same subpass kinds trigger different code paths in the services.
 type expectedStage struct {
+	about       string
 	kuber       []spec.StageKuber_SubPassKind
 	ansibler    []spec.StageAnsibler_SubPassKind
 	terraformer []spec.StageTerraformer_SubPassKind
@@ -67,6 +70,9 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 		if stage == nil {
 			t.Fatalf("pipeline stage %d = %T, want kuber", i, got.StageKind)
 		}
+		if stage.Description.About != want.about {
+			t.Errorf("pipeline stage %d description = %q, want %q", i, stage.Description.About, want.about)
+		}
 		var kinds []spec.StageKuber_SubPassKind
 		for _, sp := range stage.SubPasses {
 			kinds = append(kinds, sp.Kind)
@@ -78,6 +84,9 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 		stage := got.GetAnsibler()
 		if stage == nil {
 			t.Fatalf("pipeline stage %d = %T, want ansibler", i, got.StageKind)
+		}
+		if stage.Description.About != want.about {
+			t.Errorf("pipeline stage %d description = %q, want %q", i, stage.Description.About, want.about)
 		}
 		var kinds []spec.StageAnsibler_SubPassKind
 		for _, sp := range stage.SubPasses {
@@ -91,6 +100,9 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 		if stage == nil {
 			t.Fatalf("pipeline stage %d = %T, want terraformer", i, got.StageKind)
 		}
+		if stage.Description.About != want.about {
+			t.Errorf("pipeline stage %d description = %q, want %q", i, stage.Description.About, want.about)
+		}
 		var kinds []spec.StageTerraformer_SubPassKind
 		for _, sp := range stage.SubPasses {
 			kinds = append(kinds, sp.Kind)
@@ -98,6 +110,8 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 		if !slices.Equal(kinds, want.terraformer) {
 			t.Errorf("pipeline stage %d terraformer subpasses = %v, want %v", i, kinds, want.terraformer)
 		}
+	default:
+		t.Fatalf("pipeline stage %d expectation has no stage kind set", i)
 	}
 }
 
@@ -112,6 +126,9 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 // This holds even when a loadbalancer still lists the absent nodepool among its
 // targets: the envoy reconciliation stage commits an update as well, so it has
 // to stay out of the pipeline too.
+//
+// Only partial deletions can carry an untracked nodepool, whole nodepool
+// deletions always reference the current state, see [NodePoolsDiff].
 func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 	const (
 		p1 = "pool-1"
@@ -119,10 +136,16 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 	)
 
 	var (
-		kuberDelete = expectedStage{
+		kuberTrackedDelete = expectedStage{
+			about: "Removing Nodes from tracked state",
 			kuber: []spec.StageKuber_SubPassKind{spec.StageKuber_DELETE_NODES},
 		}
-		kuberDeleteWholeNodePool = expectedStage{
+		kuberClusterDelete = expectedStage{
+			about: "Reconciling cluster",
+			kuber: []spec.StageKuber_SubPassKind{spec.StageKuber_DELETE_NODES},
+		}
+		kuberClusterDeleteWholeNodePool = expectedStage{
+			about: "Reconciling cluster",
 			kuber: []spec.StageKuber_SubPassKind{
 				spec.StageKuber_DELETE_NODES,
 				spec.StageKuber_RECONCILE_LONGHORN_STORAGE_CLASSES,
@@ -152,12 +175,15 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p1: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline: []expectedStage{
-				kuberDelete,
-				kuberDelete,
-				{ansibler: append(
-					[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
-					proxyPasses...,
-				)},
+				kuberTrackedDelete,
+				kuberClusterDelete,
+				{
+					about: "Configuring nodes of the cluster and its loadbalancers",
+					ansibler: append(
+						[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
+						proxyPasses...,
+					),
+				},
 			},
 			wantNodepool: p1,
 			wantNodes:    []string{"node-1"},
@@ -168,9 +194,12 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p2: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true},
 			wantPipeline: []expectedStage{
-				kuberDelete,
-				kuberDelete,
-				{ansibler: []spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES}},
+				kuberTrackedDelete,
+				kuberClusterDelete,
+				{
+					about:    "Configuring nodes of the cluster and its loadbalancers",
+					ansibler: []spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
+				},
 			},
 			wantNodepool: p2,
 			wantNodes:    []string{"node-1"},
@@ -181,10 +210,16 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p1: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{UseProxy: true},
 			wantPipeline: []expectedStage{
-				kuberDelete,
-				kuberDelete,
-				{ansibler: proxyPasses},
-				{terraformer: []spec.StageTerraformer_SubPassKind{spec.StageTerraformer_UPDATE_INFRASTRUCTURE}},
+				kuberTrackedDelete,
+				kuberClusterDelete,
+				{
+					about:    "Configuring nodes of the cluster and its loadbalancers",
+					ansibler: proxyPasses,
+				},
+				{
+					about:       "Reconciling infrastructure for kubernetes cluster",
+					terraformer: []spec.StageTerraformer_SubPassKind{spec.StageTerraformer_UPDATE_INFRASTRUCTURE},
+				},
 			},
 			wantNodepool: p1,
 			wantNodes:    []string{"node-1"},
@@ -194,7 +229,7 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			nodepool:     namedStaticNodePool(p1),
 			diff:         NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{"": {"node-1"}}},
 			opts:         K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
-			wantPipeline: []expectedStage{kuberDelete},
+			wantPipeline: []expectedStage{kuberTrackedDelete},
 			wantNodepool: "",
 			wantNodes:    []string{"node-1"},
 		},
@@ -204,7 +239,7 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			lbs:          []*spec.LBcluster{lbTargeting("ghost")},
 			diff:         NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{"ghost": {"node-1"}}},
 			opts:         K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
-			wantPipeline: []expectedStage{kuberDelete},
+			wantPipeline: []expectedStage{kuberTrackedDelete},
 			wantNodepool: "ghost",
 			wantNodes:    []string{"node-1"},
 		},
@@ -214,37 +249,19 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			diff:     NodePoolsDiffResult{Deleted: NodePoolsViewType{p2: {"node-1", "node-2"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline: []expectedStage{
-				kuberDelete,
-				kuberDeleteWholeNodePool,
-				{ansibler: append(
-					[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
-					proxyPasses...,
-				)},
+				kuberTrackedDelete,
+				kuberClusterDeleteWholeNodePool,
+				{
+					about: "Configuring nodes of the cluster and its loadbalancers",
+					ansibler: append(
+						[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
+						proxyPasses...,
+					),
+				},
 			},
 			wantWithNodePool: true,
 			wantNodepool:     p2,
 			wantNodes:        []string{"node-1", "node-2"},
-		},
-		{
-			name:             "untracked whole nodepool deletion schedules only the tracked state removal stage",
-			nodepool:         namedStaticNodePool(p2),
-			diff:             NodePoolsDiffResult{Deleted: NodePoolsViewType{"ghost": {"node-1"}}},
-			opts:             K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
-			wantPipeline:     []expectedStage{kuberDelete},
-			wantWithNodePool: true,
-			wantNodepool:     "ghost",
-			wantNodes:        []string{"node-1"},
-		},
-		{
-			name:             "untracked whole nodepool still referenced by a loadbalancer omits the envoy stage",
-			nodepool:         namedStaticNodePool(p2),
-			lbs:              []*spec.LBcluster{lbTargeting("ghost")},
-			diff:             NodePoolsDiffResult{Deleted: NodePoolsViewType{"ghost": {"node-1"}}},
-			opts:             K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
-			wantPipeline:     []expectedStage{kuberDelete},
-			wantWithNodePool: true,
-			wantNodepool:     "ghost",
-			wantNodes:        []string{"node-1"},
 		},
 	}
 

--- a/services/manager/internal/service/reconciliate_kubernetes_test.go
+++ b/services/manager/internal/service/reconciliate_kubernetes_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/berops/claudie/proto/pb/spec"
 )
 
-func deletionClusters(nps ...*spec.NodePool) *spec.Clusters {
+func deletionClusters(lbs []*spec.LBcluster, nps ...*spec.NodePool) *spec.Clusters {
 	return &spec.Clusters{
 		K8S: &spec.K8Scluster{
 			ClusterInfo: &spec.ClusterInfo{
@@ -16,7 +16,25 @@ func deletionClusters(nps ...*spec.NodePool) *spec.Clusters {
 				NodePools: nps,
 			},
 		},
-		LoadBalancers: &spec.LoadBalancers{},
+		LoadBalancers: &spec.LoadBalancers{Clusters: lbs},
+	}
+}
+
+// lbTargeting returns a loadbalancer cluster with a single role targeting the
+// given nodepools, which is all that the target pool matching in
+// ScheduleDeletionsInNodePools reads.
+func lbTargeting(targets ...string) *spec.LBcluster {
+	return &spec.LBcluster{
+		ClusterInfo: &spec.ClusterInfo{
+			Name: "test-lb",
+			Hash: "hash",
+		},
+		Roles: []*spec.Role{
+			{
+				Name:        "api",
+				TargetPools: targets,
+			},
+		},
 	}
 }
 
@@ -90,6 +108,10 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 // from the cluster without committing an update, and since the task delta is
 // then never consumed, any update committed by a later stage would be refused
 // by the manager, re-running that stage indefinitely.
+//
+// This holds even when a loadbalancer still lists the absent nodepool among its
+// targets: the envoy reconciliation stage commits an update as well, so it has
+// to stay out of the pipeline too.
 func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 	const (
 		p1 = "pool-1"
@@ -116,6 +138,7 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 	tests := []struct {
 		name             string
 		nodepool         *spec.NodePool
+		lbs              []*spec.LBcluster
 		diff             NodePoolsDiffResult
 		opts             K8sNodeDeletionOptions
 		wantPipeline     []expectedStage
@@ -176,6 +199,16 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			wantNodes:    []string{"node-1"},
 		},
 		{
+			name:         "untracked nodepool still referenced by a loadbalancer omits the envoy stage",
+			nodepool:     namedStaticNodePool(p1),
+			lbs:          []*spec.LBcluster{lbTargeting("ghost")},
+			diff:         NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{"ghost": {"node-1"}}},
+			opts:         K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline: []expectedStage{kuberDelete},
+			wantNodepool: "ghost",
+			wantNodes:    []string{"node-1"},
+		},
+		{
 			name:     "tracked whole nodepool deletion schedules the full pipeline",
 			nodepool: namedStaticNodePool(p2),
 			diff:     NodePoolsDiffResult{Deleted: NodePoolsViewType{p2: {"node-1", "node-2"}}},
@@ -202,11 +235,22 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 			wantNodepool:     "ghost",
 			wantNodes:        []string{"node-1"},
 		},
+		{
+			name:             "untracked whole nodepool still referenced by a loadbalancer omits the envoy stage",
+			nodepool:         namedStaticNodePool(p2),
+			lbs:              []*spec.LBcluster{lbTargeting("ghost")},
+			diff:             NodePoolsDiffResult{Deleted: NodePoolsViewType{"ghost": {"node-1"}}},
+			opts:             K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline:     []expectedStage{kuberDelete},
+			wantWithNodePool: true,
+			wantNodepool:     "ghost",
+			wantNodes:        []string{"node-1"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			te := ScheduleDeletionsInNodePools(deletionClusters(tt.nodepool), &tt.diff, tt.opts)
+			te := ScheduleDeletionsInNodePools(deletionClusters(tt.lbs, tt.nodepool), &tt.diff, tt.opts)
 			if te == nil {
 				t.Fatal("ScheduleDeletionsInNodePools() = nil, want a task event")
 			}

--- a/services/manager/internal/service/reconciliate_kubernetes_test.go
+++ b/services/manager/internal/service/reconciliate_kubernetes_test.go
@@ -91,7 +91,10 @@ func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
 // then never consumed, any update committed by a later stage would be refused
 // by the manager, re-running that stage indefinitely.
 func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
-	const tracked = "pool-1"
+	const (
+		p1 = "pool-1"
+		p2 = "pool-2"
+	)
 
 	var (
 		kuberDelete = expectedStage{
@@ -122,8 +125,8 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 	}{
 		{
 			name:     "tracked static nodepool with proxy schedules the full pipeline",
-			nodepool: namedStaticNodePool(tracked),
-			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			nodepool: namedStaticNodePool(p1),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p1: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline: []expectedStage{
 				kuberDelete,
@@ -133,26 +136,26 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 					proxyPasses...,
 				)},
 			},
-			wantNodepool: tracked,
+			wantNodepool: p1,
 			wantNodes:    []string{"node-1"},
 		},
 		{
 			name:     "tracked static nodepool without proxy schedules only the utilities cleanup",
-			nodepool: namedStaticNodePool(tracked),
-			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			nodepool: namedStaticNodePool(p2),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p2: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true},
 			wantPipeline: []expectedStage{
 				kuberDelete,
 				kuberDelete,
 				{ansibler: []spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES}},
 			},
-			wantNodepool: tracked,
+			wantNodepool: p2,
 			wantNodes:    []string{"node-1"},
 		},
 		{
 			name:     "tracked dynamic nodepool with proxy also schedules the terraformer stage",
-			nodepool: namedDynamicNodePool(tracked),
-			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			nodepool: namedDynamicNodePool(p1),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{p1: {"node-1"}}},
 			opts:     K8sNodeDeletionOptions{UseProxy: true},
 			wantPipeline: []expectedStage{
 				kuberDelete,
@@ -160,12 +163,12 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 				{ansibler: proxyPasses},
 				{terraformer: []spec.StageTerraformer_SubPassKind{spec.StageTerraformer_UPDATE_INFRASTRUCTURE}},
 			},
-			wantNodepool: tracked,
+			wantNodepool: p1,
 			wantNodes:    []string{"node-1"},
 		},
 		{
 			name:         "untracked nodepool schedules only the tracked state removal stage",
-			nodepool:     namedStaticNodePool(tracked),
+			nodepool:     namedStaticNodePool(p1),
 			diff:         NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{"": {"node-1"}}},
 			opts:         K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline: []expectedStage{kuberDelete},
@@ -174,8 +177,8 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 		},
 		{
 			name:     "tracked whole nodepool deletion schedules the full pipeline",
-			nodepool: namedStaticNodePool(tracked),
-			diff:     NodePoolsDiffResult{Deleted: NodePoolsViewType{tracked: {"node-1", "node-2"}}},
+			nodepool: namedStaticNodePool(p2),
+			diff:     NodePoolsDiffResult{Deleted: NodePoolsViewType{p2: {"node-1", "node-2"}}},
 			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline: []expectedStage{
 				kuberDelete,
@@ -186,12 +189,12 @@ func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
 				)},
 			},
 			wantWithNodePool: true,
-			wantNodepool:     tracked,
+			wantNodepool:     p2,
 			wantNodes:        []string{"node-1", "node-2"},
 		},
 		{
 			name:             "untracked whole nodepool deletion schedules only the tracked state removal stage",
-			nodepool:         namedStaticNodePool(tracked),
+			nodepool:         namedStaticNodePool(p2),
 			diff:             NodePoolsDiffResult{Deleted: NodePoolsViewType{"ghost": {"node-1"}}},
 			opts:             K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
 			wantPipeline:     []expectedStage{kuberDelete},

--- a/services/manager/internal/service/reconciliate_kubernetes_test.go
+++ b/services/manager/internal/service/reconciliate_kubernetes_test.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/berops/claudie/proto/pb/spec"
+)
+
+func deletionClusters(nps ...*spec.NodePool) *spec.Clusters {
+	return &spec.Clusters{
+		K8S: &spec.K8Scluster{
+			ClusterInfo: &spec.ClusterInfo{
+				Name:      "test-cluster",
+				Hash:      "hash",
+				NodePools: nps,
+			},
+		},
+		LoadBalancers: &spec.LoadBalancers{},
+	}
+}
+
+func namedStaticNodePool(name string) *spec.NodePool {
+	np := staticNodePool(nil)
+	np.Name = name
+	return np
+}
+
+func namedDynamicNodePool(name string) *spec.NodePool {
+	np := dynamicNodePool(awsProvider("key", "secret"))
+	np.Name = name
+	return np
+}
+
+// expectedStage describes a single pipeline stage of a scheduled deletion,
+// exactly one of the subpass slices is set, matching the stage kind.
+type expectedStage struct {
+	kuber       []spec.StageKuber_SubPassKind
+	ansibler    []spec.StageAnsibler_SubPassKind
+	terraformer []spec.StageTerraformer_SubPassKind
+}
+
+func assertStage(t *testing.T, i int, got *spec.Stage, want expectedStage) {
+	t.Helper()
+
+	switch {
+	case want.kuber != nil:
+		stage := got.GetKuber()
+		if stage == nil {
+			t.Fatalf("pipeline stage %d = %T, want kuber", i, got.StageKind)
+		}
+		var kinds []spec.StageKuber_SubPassKind
+		for _, sp := range stage.SubPasses {
+			kinds = append(kinds, sp.Kind)
+		}
+		if !slices.Equal(kinds, want.kuber) {
+			t.Errorf("pipeline stage %d kuber subpasses = %v, want %v", i, kinds, want.kuber)
+		}
+	case want.ansibler != nil:
+		stage := got.GetAnsibler()
+		if stage == nil {
+			t.Fatalf("pipeline stage %d = %T, want ansibler", i, got.StageKind)
+		}
+		var kinds []spec.StageAnsibler_SubPassKind
+		for _, sp := range stage.SubPasses {
+			kinds = append(kinds, sp.Kind)
+		}
+		if !slices.Equal(kinds, want.ansibler) {
+			t.Errorf("pipeline stage %d ansibler subpasses = %v, want %v", i, kinds, want.ansibler)
+		}
+	case want.terraformer != nil:
+		stage := got.GetTerraformer()
+		if stage == nil {
+			t.Fatalf("pipeline stage %d = %T, want terraformer", i, got.StageKind)
+		}
+		var kinds []spec.StageTerraformer_SubPassKind
+		for _, sp := range stage.SubPasses {
+			kinds = append(kinds, sp.Kind)
+		}
+		if !slices.Equal(kinds, want.terraformer) {
+			t.Errorf("pipeline stage %d terraformer subpasses = %v, want %v", i, kinds, want.terraformer)
+		}
+	}
+}
+
+// The pipeline shape decides which services participate in a node/nodepool
+// deletion. For nodepools missing from the current state (drift, e.g. a node
+// re-joined the cluster after being removed from the state and the input
+// manifest) only the first kuber stage may be scheduled: it deletes the nodes
+// from the cluster without committing an update, and since the task delta is
+// then never consumed, any update committed by a later stage would be refused
+// by the manager, re-running that stage indefinitely.
+func TestScheduleDeletionsInNodePoolsPipelineShape(t *testing.T) {
+	const tracked = "pool-1"
+
+	var (
+		kuberDelete = expectedStage{
+			kuber: []spec.StageKuber_SubPassKind{spec.StageKuber_DELETE_NODES},
+		}
+		kuberDeleteWholeNodePool = expectedStage{
+			kuber: []spec.StageKuber_SubPassKind{
+				spec.StageKuber_DELETE_NODES,
+				spec.StageKuber_RECONCILE_LONGHORN_STORAGE_CLASSES,
+			},
+		}
+		proxyPasses = []spec.StageAnsibler_SubPassKind{
+			spec.StageAnsibler_INSTALL_VPN,
+			spec.StageAnsibler_UPDATE_PROXY_ENVS_ON_NODES,
+			spec.StageAnsibler_COMMIT_PROXY_ENVS,
+		}
+	)
+
+	tests := []struct {
+		name             string
+		nodepool         *spec.NodePool
+		diff             NodePoolsDiffResult
+		opts             K8sNodeDeletionOptions
+		wantPipeline     []expectedStage
+		wantWithNodePool bool
+		wantNodepool     string
+		wantNodes        []string
+	}{
+		{
+			name:     "tracked static nodepool with proxy schedules the full pipeline",
+			nodepool: namedStaticNodePool(tracked),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline: []expectedStage{
+				kuberDelete,
+				kuberDelete,
+				{ansibler: append(
+					[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
+					proxyPasses...,
+				)},
+			},
+			wantNodepool: tracked,
+			wantNodes:    []string{"node-1"},
+		},
+		{
+			name:     "tracked static nodepool without proxy schedules only the utilities cleanup",
+			nodepool: namedStaticNodePool(tracked),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			opts:     K8sNodeDeletionOptions{IsStatic: true},
+			wantPipeline: []expectedStage{
+				kuberDelete,
+				kuberDelete,
+				{ansibler: []spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES}},
+			},
+			wantNodepool: tracked,
+			wantNodes:    []string{"node-1"},
+		},
+		{
+			name:     "tracked dynamic nodepool with proxy also schedules the terraformer stage",
+			nodepool: namedDynamicNodePool(tracked),
+			diff:     NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{tracked: {"node-1"}}},
+			opts:     K8sNodeDeletionOptions{UseProxy: true},
+			wantPipeline: []expectedStage{
+				kuberDelete,
+				kuberDelete,
+				{ansibler: proxyPasses},
+				{terraformer: []spec.StageTerraformer_SubPassKind{spec.StageTerraformer_UPDATE_INFRASTRUCTURE}},
+			},
+			wantNodepool: tracked,
+			wantNodes:    []string{"node-1"},
+		},
+		{
+			name:         "untracked nodepool schedules only the tracked state removal stage",
+			nodepool:     namedStaticNodePool(tracked),
+			diff:         NodePoolsDiffResult{PartiallyDeleted: NodePoolsViewType{"": {"node-1"}}},
+			opts:         K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline: []expectedStage{kuberDelete},
+			wantNodepool: "",
+			wantNodes:    []string{"node-1"},
+		},
+		{
+			name:     "tracked whole nodepool deletion schedules the full pipeline",
+			nodepool: namedStaticNodePool(tracked),
+			diff:     NodePoolsDiffResult{Deleted: NodePoolsViewType{tracked: {"node-1", "node-2"}}},
+			opts:     K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline: []expectedStage{
+				kuberDelete,
+				kuberDeleteWholeNodePool,
+				{ansibler: append(
+					[]spec.StageAnsibler_SubPassKind{spec.StageAnsibler_REMOVE_CLAUDIE_UTILITIES},
+					proxyPasses...,
+				)},
+			},
+			wantWithNodePool: true,
+			wantNodepool:     tracked,
+			wantNodes:        []string{"node-1", "node-2"},
+		},
+		{
+			name:             "untracked whole nodepool deletion schedules only the tracked state removal stage",
+			nodepool:         namedStaticNodePool(tracked),
+			diff:             NodePoolsDiffResult{Deleted: NodePoolsViewType{"ghost": {"node-1"}}},
+			opts:             K8sNodeDeletionOptions{IsStatic: true, UseProxy: true},
+			wantPipeline:     []expectedStage{kuberDelete},
+			wantWithNodePool: true,
+			wantNodepool:     "ghost",
+			wantNodes:        []string{"node-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := ScheduleDeletionsInNodePools(deletionClusters(tt.nodepool), &tt.diff, tt.opts)
+			if te == nil {
+				t.Fatal("ScheduleDeletionsInNodePools() = nil, want a task event")
+			}
+
+			if len(te.Pipeline) != len(tt.wantPipeline) {
+				t.Fatalf("pipeline has %d stages, want %d", len(te.Pipeline), len(tt.wantPipeline))
+			}
+			for i, want := range tt.wantPipeline {
+				assertStage(t, i, te.Pipeline[i], want)
+			}
+
+			update, ok := te.Task.Do.(*spec.Task_Update)
+			if !ok {
+				t.Fatalf("task action = %T, want update", te.Task.Do)
+			}
+			delta, ok := update.Update.Delta.(*spec.Update_KDeleteNodes)
+			if !ok {
+				t.Fatalf("task delta = %T, want KDeleteNodes", update.Update.Delta)
+			}
+
+			if delta.KDeleteNodes.WithNodePool != tt.wantWithNodePool {
+				t.Errorf("delta WithNodePool = %v, want %v", delta.KDeleteNodes.WithNodePool, tt.wantWithNodePool)
+			}
+			if delta.KDeleteNodes.Nodepool != tt.wantNodepool {
+				t.Errorf("delta Nodepool = %q, want %q", delta.KDeleteNodes.Nodepool, tt.wantNodepool)
+			}
+			if !slices.Equal(delta.KDeleteNodes.Nodes, tt.wantNodes) {
+				t.Errorf("delta Nodes = %v, want %v", delta.KDeleteNodes.Nodes, tt.wantNodes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For scheduling deletion of unreachable nodes if the node is no longer tracked by the Claudie state, irrelevant pipeline stages
are scheduled for the task which end up in an endless loop (due to the node/nodepool not being in the state)

A node/nodepool may not be in the state if it was removed due to being unreachable but the VM (if it was a static one) came back online and re-joined the cluster. Claudie then  scheduled deletion of the node again but as its no longer tracked in the state we need to only schedule one stage for the pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kubernetes node and node pool deletion handling when tracked infrastructure information is incomplete.
  - Prevented unnecessary cleanup actions for node pools that are no longer tracked.
  - Ensured complete node pool deletions consistently perform all required cleanup and control-plane checks.
  - Improved handling of unreachable infrastructure details during deletion workflows.

- **Tests**
  - Added comprehensive coverage for partial and complete deletions across static and dynamic node pools, proxy configurations, and load balancer scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->