### PR TITLE
fix/leaked-containerd-task

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,7 +56,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: b57536f-4452
+  newTag: 7fff0f5-4475
 - name: ghcr.io/berops/claudie/claudie-operator
   newTag: b57536f-4452
 - name: ghcr.io/berops/claudie/kube-eleven

--- a/services/ansibler/ansible-playbooks/apiEndpointChange.yml
+++ b/services/ansibler/ansible-playbooks/apiEndpointChange.yml
@@ -84,10 +84,10 @@
         - "containerd"
 
     - name: restart controller
-      shell: "crictl pods | grep kube-controller-manager | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && crictl rmp {}'"
+      shell: "crictl pods | grep kube-controller-manager | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && { crictl rmp {} || true; }'"
 
     - name: restart scheduler
-      shell: "crictl pods | grep kube-scheduler | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && crictl rmp {}'"
+      shell: "crictl pods | grep kube-scheduler | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && { crictl rmp {} || true; }'"
 
 - hosts: compute
   gather_facts: true

--- a/services/ansibler/ansible-playbooks/proxy/commit-proxy-envs-changes.yml
+++ b/services/ansibler/ansible-playbooks/proxy/commit-proxy-envs-changes.yml
@@ -31,12 +31,6 @@
     - name: Update NO_PROXY and no_proxy in static pods /etc/kubernetes/manifests
       ansible.builtin.shell: |
         kubeadm init phase control-plane all --config {{file}}
-    - name: restart controller
-      ansible.builtin.shell: |
-        crictl pods | grep kube-controller-manager | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && crictl rmp {}'
-    - name: restart scheduler
-      ansible.builtin.shell: |
-        crictl pods | grep kube-scheduler | awk '{print $1}' | xargs -I {} sh -c 'crictl stopp {} && crictl rmp {}'
 
 - hosts: all
   gather_facts: false


### PR DESCRIPTION
Issue #2196

In `commit-proxy-envs-changes.yml`, the Ansible tasks `restart controller` and `restart controller` were removed. There is no need to manually restart the pods, as there is a task that updates the `/etc/kubernetes/manifests` files, and these changes trigger pod restarts automatically.

In `apiEndpointChange.yml`, the command `crictl rmp` was replaced with `{ crictl rmp {} || true; }`. In this scenario, pod restarts have to be done manually. If `crictl rmp` fails, it will still exit with exit code 0 and therefore will not cause any issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control-plane update reliability by allowing pod cleanup to continue when removal encounters an error.
  * Prevented redundant control-plane component restarts after proxy environment updates, reducing unnecessary disruption.

* **Maintenance**
  * Updated the deployment image used for control-plane management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->