### PR TITLE
feat/0-sized-nodepools

### DIFF
--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497
 - name: ghcr.io/berops/claudie/kuber
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497
 - name: ghcr.io/berops/claudie/manager
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497

--- a/manifests/claudie/kustomization.yaml
+++ b/manifests/claudie/kustomization.yaml
@@ -56,14 +56,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/berops/claudie/ansibler
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495
 - name: ghcr.io/berops/claudie/claudie-operator
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495
 - name: ghcr.io/berops/claudie/kube-eleven
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495
 - name: ghcr.io/berops/claudie/kuber
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495
 - name: ghcr.io/berops/claudie/manager
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495
 - name: ghcr.io/berops/claudie/terraformer
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: d8c26bc-4495
+  newTag: 63a7324-4497

--- a/manifests/testing-framework/kustomization.yaml
+++ b/manifests/testing-framework/kustomization.yaml
@@ -92,4 +92,4 @@ secretGenerator:
 
 images:
 - name: ghcr.io/berops/claudie/testing-framework
-  newTag: 2f15a60-4479
+  newTag: d8c26bc-4495

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -867,14 +867,14 @@ func ScheduleAdditionsInNodePools(
 			pipeline = append(pipeline, terraformerStage)
 		}
 
-		if !opts.IsStatic && len(toAdd.Nodes) != 0 {
+		if len(toAdd.Nodes) != 0 {
 			pipeline = append(pipeline, ansiblerStage)
 			pipeline = append(pipeline, kubeElevenStage)
 			pipeline = append(pipeline, kuberStage)
-		}
 
-		if updateLoadBalancersStage != nil {
-			pipeline = append(pipeline, updateLoadBalancersStage)
+			if updateLoadBalancersStage != nil {
+				pipeline = append(pipeline, updateLoadBalancersStage)
+			}
 		}
 
 		return &spec.TaskEvent{

--- a/services/manager/internal/service/reconciliate_kubernetes.go
+++ b/services/manager/internal/service/reconciliate_kubernetes.go
@@ -867,9 +867,11 @@ func ScheduleAdditionsInNodePools(
 			pipeline = append(pipeline, terraformerStage)
 		}
 
-		pipeline = append(pipeline, ansiblerStage)
-		pipeline = append(pipeline, kubeElevenStage)
-		pipeline = append(pipeline, kuberStage)
+		if !opts.IsStatic && len(toAdd.Nodes) != 0 {
+			pipeline = append(pipeline, ansiblerStage)
+			pipeline = append(pipeline, kubeElevenStage)
+			pipeline = append(pipeline, kuberStage)
+		}
 
 		if updateLoadBalancersStage != nil {
 			pipeline = append(pipeline, updateLoadBalancersStage)


### PR DESCRIPTION
Issue #2180 

This change prevents running `ansibler`, `kube-eleven`, and `kuber` when the autoscaler creates a node pool with 0 nodes.

This is irrelevant to static node pools and creation of dynamic node pools with fixed size 0 is not allowed. Only the autoscaler scenario applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Node pool provisioning now runs for both static and dynamic node pools when nodes are added.
  - Empty node pool additions no longer trigger provisioning or load balancer updates.

- **Maintenance**
  - Updated platform and testing framework components to newer versions, including improvements to node management, cluster operations, and infrastructure provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->