### PR TITLE
fix: reject unusable AutoscalerConfig min/max in nodepool validation

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -254,9 +254,9 @@ type DynamicNodePool struct {
 // Autoscaler configuration on per nodepool basis. Defines the number of nodes, autoscaler will scale up or down specific nodepool.
 type AutoscalerConfig struct {
 	// Minimum number of nodes in nodepool.
-	Min int32 `yaml:"min" json:"min,omitempty"`
+	Min int32 `validate:"gte=0" yaml:"min" json:"min,omitempty"`
 	// Maximum number of nodes in nodepool.
-	Max int32 `validate:"max=255" yaml:"max" json:"max,omitempty"`
+	Max int32 `validate:"gte=0,max=255,gtefield=Min" yaml:"max" json:"max,omitempty"`
 }
 
 // Provider spec is further specification build on top of the data from any of the provider instance.

--- a/api/manifest/validate_test.go
+++ b/api/manifest/validate_test.go
@@ -20,7 +20,13 @@ var (
 	testNodepoolAutoScalerSuccAC = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Min: 1, Max: 3}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
 	testNodepoolAutoScalerSucc   = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), Count: 1, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
 	testNodepoolAutoScalerFail   = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), Count: 1, AutoscalerConfig: AutoscalerConfig{Min: 1, Max: 3}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
-	testDomainFail               = &Manifest{
+
+	testNodepoolAutoScalerFailNoMax    = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Min: 3}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
+	testNodepoolAutoScalerFailNegMin   = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Min: -1, Max: 5}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
+	testNodepoolAutoScalerFailNegMax   = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Max: -3}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
+	testNodepoolAutoScalerFailMinGtMax = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Min: 5, Max: 2}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
+	testNodepoolAutoScalerSuccMinZero  = &DynamicNodePool{Name: "Test", ServerType: "s1", Image: "ubuntu", StorageDiskSize: new(int32(50)), AutoscalerConfig: AutoscalerConfig{Min: 0, Max: 3}, ProviderSpec: ProviderSpec{Name: "p1", Region: "a", Zone: "1"}}
+	testDomainFail                     = &Manifest{
 		Kubernetes: Kubernetes{
 			Clusters: []Cluster{
 				{Name: "VERY-LONG-NAME-FOR-CLUSTER", Pools: Pool{
@@ -311,6 +317,16 @@ func TestNodepool(t *testing.T) {
 	require.NoError(t, err)
 	err = testNodepoolAutoScalerFail.Validate(&Manifest{})
 	require.Error(t, err)
+	err = testNodepoolAutoScalerFailNoMax.Validate(&Manifest{})
+	require.Error(t, err)
+	err = testNodepoolAutoScalerFailNegMin.Validate(&Manifest{})
+	require.Error(t, err)
+	err = testNodepoolAutoScalerFailNegMax.Validate(&Manifest{})
+	require.Error(t, err)
+	err = testNodepoolAutoScalerFailMinGtMax.Validate(&Manifest{})
+	require.Error(t, err)
+	err = testNodepoolAutoScalerSuccMinZero.Validate(&Manifest{})
+	require.NoError(t, err)
 }
 
 // TestNodepool tests the nodepool spec validation for dynamic and static node pools.


### PR DESCRIPTION
Motivation:
DynamicNodePool.AutoscalerConfig is meant to be optional and mutually
exclusive with Count, but the struct validation tags did not actually
constrain Min/Max to a usable range. A non-zero but unusable autoscaler
block (e.g. {min: 3} with max omitted, {min: -1, max: 5}, {max: -3}, or
{min: 5, max: 2}) satisfied "required_without=Count" and passed struct
validation, since the runtime isDefined() check (Min >= 0 && Max > 0)
does not catch min > max or a max that defaults to 0. Such a nodepool
is then silently created with count: 0 and no autoscaler, with no
validation error anywhere.

Approach:
Add validate tags to AutoscalerConfig.Min ("gte=0") and Max
("gte=0,max=255,gtefield=Min") so a non-zero autoscaler block must be
usable: 0 <= min <= max <= 255. Omitting the block still requires
Count via the existing required_without=Count tag. min: 0 stays valid
for scale-from-zero, since Max's gtefield=Min still allows max >= 0.
No other logic changes.

Validation:
- go build ./... passes for the whole repo.
- go test -short ./... passes for the whole repo.
- Added unit tests to api/manifest/validate_test.go covering the
  accepted-today-but-unusable cases from the issue (min without max,
  negative min, negative max, min > max) as errors, and confirmed
  min: 0 with a valid max still passes.
- Confirmed the new no-max test case fails before the fix ("An error
  is expected but got nil") and passes after, by temporarily reverting
  only the two struct tags and re-running
  `go test ./api/manifest/... -run TestNodepool -v`.
- golangci-lint (v2.13.2, matching the version pinned in
  .github/workflows/CI-pipeline.yml) run against ./api/manifest/...
  reports 0 issues.

Report: https://github.com/berops/claudie/issues/2218
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #2218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autoscaler settings now reject negative minimum or maximum values.
  * Maximum values can no longer be lower than the configured minimum.
  * A minimum value of zero is now accepted when valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->