### PR TITLE
fix: require externalNetworkName by OpenStack provider type

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -270,7 +270,7 @@ type ProviderSpec struct {
 	Zone string `yaml:"zone" json:"zone"`
 	// Name of the external provider network to which the nodes will be connected to. Currently only required for OpenStack.
 	// +optional
-	ExternalNetworkName string `validate:"external_net" yaml:"externalNetworkName" json:"externalNetworkName"`
+	ExternalNetworkName string `yaml:"externalNetworkName" json:"externalNetworkName"`
 }
 
 // StaticNodePool List of static nodepools of already existing machines, not created by Claudie, used for Kubernetes or loadbalancer clusters.

--- a/api/manifest/validate.go
+++ b/api/manifest/validate.go
@@ -92,8 +92,6 @@ func prettyPrintValidationError(err error) error {
 			nerr = fmt.Errorf("field '%s' is required to follow semantic version 2.0, ref: https://semver.org/", err.StructField())
 		case "required_without":
 			nerr = fmt.Errorf("'%s' needs to be set if '%s' is not specified", err.Field(), err.Param())
-		case "external_net":
-			nerr = fmt.Errorf("field '%s' is required to be defined when using Openstack provider", err.StructField())
 		default:
 			nerr = err
 		}

--- a/api/manifest/validate_node_pool.go
+++ b/api/manifest/validate_node_pool.go
@@ -133,13 +133,12 @@ func (d *DynamicNodePool) Validate(m *Manifest) error {
 		return err
 	}
 
-	validate := validator.New()
-
-	if err := validate.RegisterValidation("external_net", validateExternalNet); err != nil {
+	// Validate OpenStack external network requirement
+	if err := d.validateExternalNet(m); err != nil {
 		return err
 	}
 
-	if err := validate.Struct(d); err != nil {
+	if err := validator.New().Struct(d); err != nil {
 		return prettyPrintValidationError(err)
 	}
 	return nil
@@ -269,10 +268,22 @@ func checkAnnotations(annotations map[string]string) error {
 	return nil
 }
 
-func validateExternalNet(fl validator.FieldLevel) bool {
-	providerSpec := fl.Parent().Interface().(ProviderSpec)
-	if providerSpec.Name == "openstack" {
-		return providerSpec.ExternalNetworkName != ""
+// validateExternalNet requires externalNetworkName when the referenced provider type is openstack.
+func (d *DynamicNodePool) validateExternalNet(m *Manifest) error {
+	providerType, err := m.GetProviderType(d.ProviderSpec.Name)
+	if err != nil {
+		// Provider existence is validated in [NodePool.Validate] before
+		// calling [DynamicNodePool.Validate].
+		return nil
 	}
-	return true
+
+	if providerType != "openstack" {
+		return nil
+	}
+
+	if d.ProviderSpec.ExternalNetworkName == "" {
+		return fmt.Errorf("externalNetworkName is required for OpenStack provider")
+	}
+
+	return nil
 }

--- a/api/manifest/validate_node_pool_test.go
+++ b/api/manifest/validate_node_pool_test.go
@@ -299,3 +299,125 @@ func TestValidateSpot(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateExternalNet verifies externalNetworkName is required based on
+// provider type (openstack), not the provider instance name.
+func TestValidateExternalNet(t *testing.T) {
+	openstackManifest := &Manifest{
+		Providers: Provider{
+			Openstack: []Openstack{{
+				Name:                        "openstack-1",
+				AuthURL:                     "https://openstack.example.com:5000",
+				DomainId:                    "default",
+				ProjectId:                   "fake-project-id",
+				ApplicationCredentialId:     "fake-app-cred-id",
+				ApplicationCredentialSecret: "fake-app-cred-secret",
+			}},
+		},
+		Kubernetes: Kubernetes{
+			Clusters: []Cluster{
+				{
+					Name:    "cluster-1",
+					Network: "10.0.0.0/8",
+					Version: "v1.34.0",
+					Pools:   Pool{Compute: []string{"worker-np"}},
+				},
+			},
+		},
+	}
+
+	// Non-OpenStack provider whose instance name is literally "openstack".
+	hetznerNamedOpenstack := &Manifest{
+		Providers: Provider{
+			Hetzner: []Hetzner{{
+				Name:        "openstack",
+				Credentials: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}},
+		},
+		Kubernetes: Kubernetes{
+			Clusters: []Cluster{
+				{
+					Name:    "cluster-1",
+					Network: "10.0.0.0/8",
+					Version: "v1.34.0",
+					Pools:   Pool{Compute: []string{"worker-np"}},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name            string
+		nodepool        *DynamicNodePool
+		manifest        *Manifest
+		wantError       bool
+		wantErrContains string
+	}{
+		{
+			name: "openstack provider with non-openstack instance name missing ExternalNetworkName fails",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "m1.medium",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				ProviderSpec: ProviderSpec{
+					Name:   "openstack-1",
+					Region: "RegionOne",
+					Zone:   "nova",
+				},
+			},
+			manifest:        openstackManifest,
+			wantError:       true,
+			wantErrContains: "externalNetworkName is required for OpenStack",
+		},
+		{
+			name: "non-openstack provider named openstack does not require ExternalNetworkName",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "cx21",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				ProviderSpec: ProviderSpec{
+					Name:   "openstack",
+					Region: "fsn1",
+					Zone:   "fsn1-dc14",
+				},
+			},
+			manifest:  hetznerNamedOpenstack,
+			wantError: false,
+		},
+		{
+			name: "openstack provider with ExternalNetworkName set passes",
+			nodepool: &DynamicNodePool{
+				Name:       "worker-np",
+				ServerType: "m1.medium",
+				Image:      "ubuntu-22.04",
+				Count:      1,
+				ProviderSpec: ProviderSpec{
+					Name:                "openstack-1",
+					Region:              "RegionOne",
+					Zone:                "nova",
+					ExternalNetworkName: "ext-net",
+				},
+			},
+			manifest:  openstackManifest,
+			wantError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Call Validate (not validateExternalNet directly) so the test also
+			// catches regressions if Validate stops invoking validateExternalNet.
+			err := tc.nodepool.Validate(tc.manifest)
+			if tc.wantError {
+				require.Error(t, err, "expected error but got nil")
+				if tc.wantErrContains != "" {
+					require.ErrorContains(t, err, tc.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err, "expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/manifests/testing-framework/test-sets/test-set1/1.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/1.yaml
@@ -219,7 +219,6 @@ spec:
           name: ovh-1
           region: DE1
           zone: nova
-          externalNetworkName: Ext-Net
         count: 1
         serverType: c3-4-flex
         image: "Ubuntu 24.04"
@@ -237,7 +236,6 @@ spec:
           name: ovh-1
           region: RBX-A
           zone: nova
-          externalNetworkName: Ext-Net
         count: 1
         serverType: c3-8-flex
         image: "Ubuntu 24.04"

--- a/manifests/testing-framework/test-sets/test-set1/2.yaml
+++ b/manifests/testing-framework/test-sets/test-set1/2.yaml
@@ -197,7 +197,6 @@ spec:
           name: ovh-1
           region: DE1
           zone: nova
-          externalNetworkName: Ext-Net
         count: 2
         serverType: c3-4-flex
         image: "Ubuntu 24.04"
@@ -215,7 +214,6 @@ spec:
           name: ovh-1
           region: RBX-A
           zone: nova
-          externalNetworkName: Ext-Net
         count: 2
         serverType: c3-8-flex
         image: "Ubuntu 24.04"


### PR DESCRIPTION
## Summary
`validateExternalNet` compared `ProviderSpec.Name` (instance name) to the literal `"openstack"`, so OpenStack providers with other names skipped the check and non-OpenStack providers named `openstack` were wrongly required to set `externalNetworkName`.

- Validate via `Manifest.GetProviderType` (same pattern as spot/GPU checks)
- Drop the `external_net` tag, callback, and pretty-print case
- Remove `externalNetworkName` from OVH nodepools in `test-set1`
- Add focused unit tests

Fixes #2217

## Test plan
- [x] `go test ./api/manifest/ -run TestValidateExternalNet -v`
- [x] `go test ./api/manifest/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenStack node pool validation now determines requirements by provider type rather than provider instance name.
  * OpenStack configurations still require an external network name, with clearer validation behavior.
  * Non-OpenStack providers are no longer incorrectly subject to the OpenStack external network requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->